### PR TITLE
web-transport-proto: Fix clippy warnings

### DIFF
--- a/web-transport-proto/src/huffman.rs
+++ b/web-transport-proto/src/huffman.rs
@@ -351,11 +351,11 @@ impl Iterator for DecodeIter<'_> {
 }
 
 pub trait HpackStringDecode {
-    fn hpack_decode(&self) -> DecodeIter;
+    fn hpack_decode(&self) -> DecodeIter<'_>;
 }
 
 impl HpackStringDecode for Vec<u8> {
-    fn hpack_decode(&self) -> DecodeIter {
+    fn hpack_decode(&self) -> DecodeIter<'_> {
         DecodeIter {
             bit_pos: BitWindow::new(),
             content: self,

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -33,7 +33,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-native-certs = "0.8"
 thiserror = "2"
 
-tokio = { version = "1", default-features = false, features = ["macros"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "macros"] }
 url = "2"
 web-transport-proto = { path = "../web-transport-proto", version = "0.2" }
 


### PR DESCRIPTION
* web-transport-quinn: Fix missing "io-util" feature for tokio