### PR TITLE
Rename the repo.

### DIFF
--- a/web-transport-proto/CHANGELOG.md
+++ b/web-transport-proto/CHANGELOG.md
@@ -6,32 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6](https://github.com/kixelated/web-transport-rs/compare/web-transport-proto-v0.2.5...web-transport-proto-v0.2.6) - 2025-05-15
+## [0.2.6](https://github.com/kixelated/web-transport/compare/web-transport-proto-v0.2.5...web-transport-proto-v0.2.6) - 2025-05-15
 
 ### Other
 
-- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport-rs/pull/73))
-- Add url query to CONNECT :path request ([#70](https://github.com/kixelated/web-transport-rs/pull/70))
+- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport/pull/73))
+- Add url query to CONNECT :path request ([#70](https://github.com/kixelated/web-transport/pull/70))
 
-## [0.2.5](https://github.com/kixelated/web-transport-rs/compare/web-transport-proto-v0.2.4...web-transport-proto-v0.2.5) - 2025-03-26
-
-### Other
-
-- Added Ring feature flag ([#68](https://github.com/kixelated/web-transport-rs/pull/68))
-
-## [0.2.4](https://github.com/kixelated/web-transport-rs/compare/web-transport-proto-v0.2.3...web-transport-proto-v0.2.4) - 2025-01-15
+## [0.2.5](https://github.com/kixelated/web-transport/compare/web-transport-proto-v0.2.4...web-transport-proto-v0.2.5) - 2025-03-26
 
 ### Other
 
-- Bump some deps. ([#55](https://github.com/kixelated/web-transport-rs/pull/55))
-- Clippy fixes. ([#53](https://github.com/kixelated/web-transport-rs/pull/53))
+- Added Ring feature flag ([#68](https://github.com/kixelated/web-transport/pull/68))
 
-## [0.2.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-proto-v0.2.2...web-transport-proto-v0.2.3) - 2024-09-02
-
-### Other
-- Don't set the N bit for literals. ([#41](https://github.com/kixelated/web-transport-rs/pull/41))
-
-## [0.2.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-proto-v0.2.1...web-transport-proto-v0.2.2) - 2024-08-15
+## [0.2.4](https://github.com/kixelated/web-transport/compare/web-transport-proto-v0.2.3...web-transport-proto-v0.2.4) - 2025-01-15
 
 ### Other
-- Some more documentation. ([#34](https://github.com/kixelated/web-transport-rs/pull/34))
+
+- Bump some deps. ([#55](https://github.com/kixelated/web-transport/pull/55))
+- Clippy fixes. ([#53](https://github.com/kixelated/web-transport/pull/53))
+
+## [0.2.3](https://github.com/kixelated/web-transport/compare/web-transport-proto-v0.2.2...web-transport-proto-v0.2.3) - 2024-09-02
+
+### Other
+- Don't set the N bit for literals. ([#41](https://github.com/kixelated/web-transport/pull/41))
+
+## [0.2.2](https://github.com/kixelated/web-transport/compare/web-transport-proto-v0.2.1...web-transport-proto-v0.2.2) - 2024-08-15
+
+### Other
+- Some more documentation. ([#34](https://github.com/kixelated/web-transport/pull/34))

--- a/web-transport-proto/Cargo.toml
+++ b/web-transport-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport-proto"
 description = "WebTransport core protocol"
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.2.6"

--- a/web-transport-quinn/CHANGELOG.md
+++ b/web-transport-quinn/CHANGELOG.md
@@ -6,79 +6,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.7.2...web-transport-quinn-v0.7.3) - 2025-07-20
+## [0.7.3](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.7.2...web-transport-quinn-v0.7.3) - 2025-07-20
 
 ### Other
 
 - Re-export the http crate.
 
-## [0.7.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.7.1...web-transport-quinn-v0.7.2) - 2025-06-02
+## [0.7.2](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.7.1...web-transport-quinn-v0.7.2) - 2025-06-02
 
 ### Fixed
 
-- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport-rs/pull/82))
+- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport/pull/82))
 
-## [0.7.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.7.0...web-transport-quinn-v0.7.1) - 2025-05-21
-
-### Other
-
-- Fully take ownership of the Url, not a ref. ([#80](https://github.com/kixelated/web-transport-rs/pull/80))
-
-## [0.6.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.6.0...web-transport-quinn-v0.6.1) - 2025-05-21
+## [0.7.1](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.7.0...web-transport-quinn-v0.7.1) - 2025-05-21
 
 ### Other
 
-- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport-rs/pull/75))
+- Fully take ownership of the Url, not a ref. ([#80](https://github.com/kixelated/web-transport/pull/80))
 
-## [0.6.0](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.5.1...web-transport-quinn-v0.6.0) - 2025-05-15
+## [0.6.1](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.6.0...web-transport-quinn-v0.6.1) - 2025-05-21
 
 ### Other
 
-- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport-rs/pull/73))
+- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport/pull/75))
 
-## [0.5.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.5.0...web-transport-quinn-v0.5.1) - 2025-03-26
+## [0.6.0](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.5.1...web-transport-quinn-v0.6.0) - 2025-05-15
+
+### Other
+
+- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport/pull/73))
+
+## [0.5.1](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.5.0...web-transport-quinn-v0.5.1) - 2025-03-26
 
 ### Fixed
 
-- completely remove aws-lc when feature is off ([#69](https://github.com/kixelated/web-transport-rs/pull/69))
+- completely remove aws-lc when feature is off ([#69](https://github.com/kixelated/web-transport/pull/69))
 
 ### Other
 
-- Added Ring feature flag ([#68](https://github.com/kixelated/web-transport-rs/pull/68))
-- Adding with_unreliable shim functions to wasm/quinn ClientBuilders for easier generic use ([#64](https://github.com/kixelated/web-transport-rs/pull/64))
+- Added Ring feature flag ([#68](https://github.com/kixelated/web-transport/pull/68))
+- Adding with_unreliable shim functions to wasm/quinn ClientBuilders for easier generic use ([#64](https://github.com/kixelated/web-transport/pull/64))
 
-## [0.5.0](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.4.1...web-transport-quinn-v0.5.0) - 2025-01-26
-
-### Other
-
-- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport-rs/pull/60))
-
-## [0.4.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.4.0...web-transport-quinn-v0.4.1) - 2025-01-15
+## [0.5.0](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.4.1...web-transport-quinn-v0.5.0) - 2025-01-26
 
 ### Other
 
-- Switch to aws_lc_rs ([#58](https://github.com/kixelated/web-transport-rs/pull/58))
-- Bump some deps. ([#55](https://github.com/kixelated/web-transport-rs/pull/55))
-- Clippy fixes. ([#53](https://github.com/kixelated/web-transport-rs/pull/53))
+- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport/pull/60))
 
-## [0.4.0](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.3.4...web-transport-quinn-v0.4.0) - 2024-12-03
+## [0.4.1](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.4.0...web-transport-quinn-v0.4.1) - 2025-01-15
 
 ### Other
 
-- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport-rs/pull/50))
+- Switch to aws_lc_rs ([#58](https://github.com/kixelated/web-transport/pull/58))
+- Bump some deps. ([#55](https://github.com/kixelated/web-transport/pull/55))
+- Clippy fixes. ([#53](https://github.com/kixelated/web-transport/pull/53))
 
-## [0.3.4](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.3.3...web-transport-quinn-v0.3.4) - 2024-10-26
+## [0.4.0](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.3.4...web-transport-quinn-v0.4.0) - 2024-12-03
+
+### Other
+
+- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport/pull/50))
+
+## [0.3.4](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.3.3...web-transport-quinn-v0.3.4) - 2024-10-26
 
 ### Other
 
-- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport-rs/pull/45))
+- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport/pull/45))
 
-## [0.3.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.3.2...web-transport-quinn-v0.3.3) - 2024-09-03
-
-### Other
-- Some more documentation. ([#42](https://github.com/kixelated/web-transport-rs/pull/42))
-
-## [0.3.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-quinn-v0.3.1...web-transport-quinn-v0.3.2) - 2024-08-15
+## [0.3.3](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.3.2...web-transport-quinn-v0.3.3) - 2024-09-03
 
 ### Other
-- Some more documentation. ([#34](https://github.com/kixelated/web-transport-rs/pull/34))
+- Some more documentation. ([#42](https://github.com/kixelated/web-transport/pull/42))
+
+## [0.3.2](https://github.com/kixelated/web-transport/compare/web-transport-quinn-v0.3.1...web-transport-quinn-v0.3.2) - 2024-08-15
+
+### Other
+- Some more documentation. ([#34](https://github.com/kixelated/web-transport/pull/34))

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport-quinn"
 description = "WebTransport library for Quinn"
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.7.3"
@@ -39,7 +39,7 @@ thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["io-util", "macros"] }
 url = "2"
 web-transport-proto = { path = "../web-transport-proto", version = "0.2" }
-web-transport-trait = { path = "../web-transport-trait" }
+web-transport-trait = { path = "../web-transport-trait", version = "0.1" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/web-transport-trait/Cargo.toml
+++ b/web-transport-trait/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport-trait"
 description = "An async WebTransport trait."
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.1.0"

--- a/web-transport-wasm/CHANGELOG.md
+++ b/web-transport-wasm/CHANGELOG.md
@@ -6,62 +6,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.5.0...web-transport-wasm-v0.5.1) - 2025-06-02
+## [0.5.1](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.5.0...web-transport-wasm-v0.5.1) - 2025-06-02
 
 ### Fixed
 
-- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport-rs/pull/82))
+- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport/pull/82))
 
-## [0.4.7](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.6...web-transport-wasm-v0.4.7) - 2025-05-21
-
-### Other
-
-- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport-rs/pull/75))
-
-## [0.4.6](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.5...web-transport-wasm-v0.4.6) - 2025-05-15
+## [0.4.7](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.6...web-transport-wasm-v0.4.7) - 2025-05-21
 
 ### Other
 
-- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport-rs/pull/73))
+- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport/pull/75))
 
-## [0.4.5](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.4...web-transport-wasm-v0.4.5) - 2025-03-26
-
-### Other
-
-- Fix typo in build.rs ([#62](https://github.com/kixelated/web-transport-rs/pull/62))
-
-## [0.4.4](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.3...web-transport-wasm-v0.4.4) - 2025-01-26
+## [0.4.6](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.5...web-transport-wasm-v0.4.6) - 2025-05-15
 
 ### Other
 
-- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport-rs/pull/60))
+- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport/pull/73))
 
-## [0.4.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.2...web-transport-wasm-v0.4.3) - 2025-01-15
-
-### Other
-
-- Bump some deps. ([#55](https://github.com/kixelated/web-transport-rs/pull/55))
-- Clippy fixes. ([#53](https://github.com/kixelated/web-transport-rs/pull/53))
-- Move the ReadableStreams stuff to a new crate. ([#52](https://github.com/kixelated/web-transport-rs/pull/52))
-
-## [0.4.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.1...web-transport-wasm-v0.4.2) - 2024-12-03
+## [0.4.5](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.4...web-transport-wasm-v0.4.5) - 2025-03-26
 
 ### Other
 
-- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport-rs/pull/50))
+- Fix typo in build.rs ([#62](https://github.com/kixelated/web-transport/pull/62))
 
-## [0.4.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.4.0...web-transport-wasm-v0.4.1) - 2024-10-26
+## [0.4.4](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.3...web-transport-wasm-v0.4.4) - 2025-01-26
+
+### Other
+
+- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport/pull/60))
+
+## [0.4.3](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.2...web-transport-wasm-v0.4.3) - 2025-01-15
 
 ### Other
 
-- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport-rs/pull/45))
+- Bump some deps. ([#55](https://github.com/kixelated/web-transport/pull/55))
+- Clippy fixes. ([#53](https://github.com/kixelated/web-transport/pull/53))
+- Move the ReadableStreams stuff to a new crate. ([#52](https://github.com/kixelated/web-transport/pull/52))
 
-## [0.3.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.3.1...web-transport-wasm-v0.3.2) - 2024-08-15
-
-### Other
-- Fix the WASM docs maybe? ([#36](https://github.com/kixelated/web-transport-rs/pull/36))
-
-## [0.3.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-wasm-v0.3.0...web-transport-wasm-v0.3.1) - 2024-08-15
+## [0.4.2](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.1...web-transport-wasm-v0.4.2) - 2024-12-03
 
 ### Other
-- Some more documentation. ([#34](https://github.com/kixelated/web-transport-rs/pull/34))
+
+- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport/pull/50))
+
+## [0.4.1](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.4.0...web-transport-wasm-v0.4.1) - 2024-10-26
+
+### Other
+
+- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport/pull/45))
+
+## [0.3.2](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.3.1...web-transport-wasm-v0.3.2) - 2024-08-15
+
+### Other
+- Fix the WASM docs maybe? ([#36](https://github.com/kixelated/web-transport/pull/36))
+
+## [0.3.1](https://github.com/kixelated/web-transport/compare/web-transport-wasm-v0.3.0...web-transport-wasm-v0.3.1) - 2024-08-15
+
+### Other
+- Some more documentation. ([#34](https://github.com/kixelated/web-transport/pull/34))

--- a/web-transport-wasm/Cargo.toml
+++ b/web-transport-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport-wasm"
 description = "WebTransport WASM bindings"
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.5.1"

--- a/web-transport-ws/Cargo.toml
+++ b/web-transport-ws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport-ws"
 description = "WebTransport polyfill using WebSockets"
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.1.0"
@@ -18,7 +18,6 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 tokio-tungstenite = "0.24"
 web-transport-proto = { path = "../web-transport-proto", version = "0.2" }
-
 web-transport-trait = { path = "../web-transport-trait", version = "0.1" }
 
 [dev-dependencies]

--- a/web-transport/CHANGELOG.md
+++ b/web-transport/CHANGELOG.md
@@ -6,81 +6,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.4](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.9.3...web-transport-v0.9.4) - 2025-07-20
+## [0.9.4](https://github.com/kixelated/web-transport/compare/web-transport-v0.9.3...web-transport-v0.9.4) - 2025-07-20
 
 ### Other
 
 - updated the following local packages: web-transport-quinn
 
-## [0.9.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.9.2...web-transport-v0.9.3) - 2025-06-02
+## [0.9.3](https://github.com/kixelated/web-transport/compare/web-transport-v0.9.2...web-transport-v0.9.3) - 2025-06-02
 
 ### Fixed
 
-- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport-rs/pull/82))
+- fix connecting to ipv6 using quinn backend ([#82](https://github.com/kixelated/web-transport/pull/82))
 
-## [0.9.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.9.1...web-transport-v0.9.2) - 2025-05-21
-
-### Other
-
-- Fully take ownership of the Url, not a ref. ([#80](https://github.com/kixelated/web-transport-rs/pull/80))
-
-## [0.9.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.9.0...web-transport-v0.9.1) - 2025-05-21
+## [0.9.2](https://github.com/kixelated/web-transport/compare/web-transport-v0.9.1...web-transport-v0.9.2) - 2025-05-21
 
 ### Other
 
-- Again. ([#78](https://github.com/kixelated/web-transport-rs/pull/78))
+- Fully take ownership of the Url, not a ref. ([#80](https://github.com/kixelated/web-transport/pull/80))
 
-## [0.8.3](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.8.2...web-transport-v0.8.3) - 2025-05-21
-
-### Other
-
-- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport-rs/pull/75))
-
-## [0.8.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.8.1...web-transport-v0.8.2) - 2025-05-15
+## [0.9.1](https://github.com/kixelated/web-transport/compare/web-transport-v0.9.0...web-transport-v0.9.1) - 2025-05-21
 
 ### Other
 
-- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport-rs/pull/73))
+- Again. ([#78](https://github.com/kixelated/web-transport/pull/78))
 
-## [0.8.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.8.0...web-transport-v0.8.1) - 2025-03-26
-
-### Other
-
-- Adding with_unreliable shim functions to wasm/quinn ClientBuilders for easier generic use ([#64](https://github.com/kixelated/web-transport-rs/pull/64))
-
-## [0.8.0](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.7.1...web-transport-v0.8.0) - 2025-01-26
+## [0.8.3](https://github.com/kixelated/web-transport/compare/web-transport-v0.8.2...web-transport-v0.8.3) - 2025-05-21
 
 ### Other
 
-- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport-rs/pull/60))
+- Add a required `url` to Session ([#75](https://github.com/kixelated/web-transport/pull/75))
 
-## [0.7.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.7.0...web-transport-v0.7.1) - 2025-01-15
-
-### Other
-
-- Bump some deps. ([#55](https://github.com/kixelated/web-transport-rs/pull/55))
-- Clippy fixes. ([#53](https://github.com/kixelated/web-transport-rs/pull/53))
-
-## [0.7.0](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.6.2...web-transport-v0.7.0) - 2024-12-03
+## [0.8.2](https://github.com/kixelated/web-transport/compare/web-transport-v0.8.1...web-transport-v0.8.2) - 2025-05-15
 
 ### Other
 
-- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport-rs/pull/50))
+- Add (generic) support for learning when a stream is closed. ([#73](https://github.com/kixelated/web-transport/pull/73))
 
-## [0.6.2](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.6.1...web-transport-v0.6.2) - 2024-10-27
+## [0.8.1](https://github.com/kixelated/web-transport/compare/web-transport-v0.8.0...web-transport-v0.8.1) - 2025-03-26
 
 ### Other
 
-- Gotta bump deps too. ([#48](https://github.com/kixelated/web-transport-rs/pull/48))
+- Adding with_unreliable shim functions to wasm/quinn ClientBuilders for easier generic use ([#64](https://github.com/kixelated/web-transport/pull/64))
+
+## [0.8.0](https://github.com/kixelated/web-transport/compare/web-transport-v0.7.1...web-transport-v0.8.0) - 2025-01-26
+
+### Other
+
+- Revamp client/server building. ([#60](https://github.com/kixelated/web-transport/pull/60))
+
+## [0.7.1](https://github.com/kixelated/web-transport/compare/web-transport-v0.7.0...web-transport-v0.7.1) - 2025-01-15
+
+### Other
+
+- Bump some deps. ([#55](https://github.com/kixelated/web-transport/pull/55))
+- Clippy fixes. ([#53](https://github.com/kixelated/web-transport/pull/53))
+
+## [0.7.0](https://github.com/kixelated/web-transport/compare/web-transport-v0.6.2...web-transport-v0.7.0) - 2024-12-03
+
+### Other
+
+- Make a `Client` class to make configuration easier. ([#50](https://github.com/kixelated/web-transport/pull/50))
+
+## [0.6.2](https://github.com/kixelated/web-transport/compare/web-transport-v0.6.1...web-transport-v0.6.2) - 2024-10-27
+
+### Other
+
+- Gotta bump deps too. ([#48](https://github.com/kixelated/web-transport/pull/48))
 - Update crate description
 
-## [0.6.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.6.0...web-transport-v0.6.1) - 2024-10-26
+## [0.6.1](https://github.com/kixelated/web-transport/compare/web-transport-v0.6.0...web-transport-v0.6.1) - 2024-10-26
 
 ### Other
 
-- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport-rs/pull/45))
+- Derive PartialEq for Session. ([#45](https://github.com/kixelated/web-transport/pull/45))
 
-## [0.5.1](https://github.com/kixelated/web-transport-rs/compare/web-transport-v0.5.0...web-transport-v0.5.1) - 2024-08-15
+## [0.5.1](https://github.com/kixelated/web-transport/compare/web-transport-v0.5.0...web-transport-v0.5.1) - 2024-08-15
 
 ### Other
-- Some more documentation. ([#34](https://github.com/kixelated/web-transport-rs/pull/34))
+- Some more documentation. ([#34](https://github.com/kixelated/web-transport/pull/34))

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -2,7 +2,7 @@
 name = "web-transport"
 description = "Generic WebTransport API with native (web-transport-quinn) and WASM (web-transport-wasm) support."
 authors = ["Luke Curley"]
-repository = "https://github.com/kixelated/web-transport-rs"
+repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
 version = "0.9.4"


### PR DESCRIPTION
`-rs` isn't really needed plus there's a NPM module now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated CHANGELOG links to point to the new repository across packages; no content changes.
* Chores
  * Updated repository URL in package metadata across crates.
  * Added an explicit version to an internal dependency for consistency.
* Style
  * Minor formatting cleanup in a manifest.

No functional, API, or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->