### PR TITLE
Use Uint8Array.fromHex() for hex to TypedArray fingerprint

### DIFF
--- a/web-transport-quinn/web/client.js
+++ b/web-transport-quinn/web/client.js
@@ -2,10 +2,7 @@
 import fingerprintHex from 'bundle-text:../cert/localhost.hex';
 
 // Convert the hex to binary.
-let fingerprint = [];
-for (let c = 0; c < fingerprintHex.length - 1; c += 2) {
-    fingerprint.push(parseInt(fingerprintHex.substring(c, c + 2), 16));
-}
+const fingerprint = Uint8Arra.fromHex(fingerprint);
 
 const params = new URLSearchParams(window.location.search)
 
@@ -24,7 +21,7 @@ async function run() {
     const transport = new WebTransport(url, {
         serverCertificateHashes: [{
             "algorithm": "sha-256",
-            "value": new Uint8Array(fingerprint),
+            "value": fingerprint
         }],
     });
     await transport.ready;


### PR DESCRIPTION
Should work in modern browsers - including Safari https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromHex#browser_compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.
- Refactor
  - Streamlined certificate fingerprint handling by using a direct binary representation, removing per-byte parsing and temporary arrays.
- Performance
  - Slightly faster connection setup and reduced memory overhead due to fewer allocations during fingerprint processing.
- Reliability
  - More robust handling of certificate fingerprints by avoiding manual conversion steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->