### PR TITLE
Fix default read_chunk() implementation

### DIFF
--- a/web-transport-trait/src/lib.rs
+++ b/web-transport-trait/src/lib.rs
@@ -186,7 +186,7 @@ pub trait RecvStream: Send {
     ) -> impl Future<Output = Result<Option<Bytes>, Self::Error>> + Send {
         async move {
             // Don't allocate too much. Write your own if you want to increase this buffer.
-            let mut buf = BytesMut::with_capacity(max.max(8 * 1024));
+            let mut buf = BytesMut::with_capacity(max.min(8 * 1024));
 
             // TODO Test this, I think it will work?
             Ok(self.read_buf(&mut buf).await?.map(|_| buf.freeze()))


### PR DESCRIPTION
When implementing `web_transport_trait::RecvStream` for a new backend, the default read_chunk() implementation caused a `WrongSize` error when reading a frame from a group.

This bug was never triggered when using `web-transport-quinn` because it overrides the default implementation.

_EDIT: the following auto-generated summary by AI is crap, it totally misses the point._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced peak memory usage when receiving data by capping the temporary read buffer to 8KB or the requested maximum, whichever is smaller.
  * Prevents unnecessary large allocations during large reads, lowering the risk of memory spikes and improving stability and responsiveness, especially on memory-constrained systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->