### PR TITLE
Set max line length to 72 for commit messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ trim_trailing_whitespace = false
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[COMMIT_EDITMSG]
+max_line_length = 72


### PR DESCRIPTION
The default user value was overridden by the setting applied to all files:

    max_line_length = 100

This sets a specific setting for commit messages.

---

This drove me crazy when editing my commit message. I couldn't understand why neovim wasn't respecting my configuration, until I realized there was a `.editorconfig` at the root of the project.

An alternative fix could be:

```
max_line_length = unset
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a commit message formatting rule enforcing a 72-character maximum per line to improve readability and consistency in project history.
  * Standardizes contributor workflow and supports clearer auto-generated change logs and release notes; existing file-specific formatting rules remain unchanged.
  * Improves maintainer review efficiency and traceability.
  * No user-facing changes or impact on application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->