### PR TITLE
Don't force users to unsafe.

### DIFF
--- a/web-transport-quinn/examples/echo-client.rs
+++ b/web-transport-quinn/examples/echo-client.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
         log::warn!("disabling TLS certificate verification; a MITM attack is possible");
 
         // Accept any certificate.
-        unsafe { client.with_no_certificate_verification()? }
+        client.dangerous().with_no_certificate_verification()?
     } else if let Some(path) = &args.tls_cert {
         // Read the PEM certificate chain
         let chain = fs::File::open(path).context("failed to open cert file")?;


### PR DESCRIPTION
Fixes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the API for configuring certificate verification bypass. Certificate verification can now be disabled via `client.dangerous().with_no_certificate_verification()` instead of the previous direct method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->