### PR TITLE
Remove the trait support for WASM so it compiles without WASM.

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,8 +21,8 @@ setup-tools:
 
 # Run the CI checks
 check:
-	cargo check --workspace --exclude web-transport-wasm --all-targets --all-features
-	cargo clippy --workspace --exclude web-transport-wasm --all-targets --all-features -- -D warnings
+	cargo check --workspace --all-targets --all-features
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 	# Do the same but explicitly use the WASM target.
 	cargo check --target wasm32-unknown-unknown -p web-transport --all-targets --all-features
@@ -34,7 +34,7 @@ check:
 	cargo fmt --all --check
 
 	# requires: cargo install cargo-hack
-	cargo hack check --feature-powerset --workspace --exclude web-transport-wasm --keep-going
+	cargo hack check --feature-powerset --workspace --keep-going
 	cargo hack check --feature-powerset --target wasm32-unknown-unknown -p web-transport --keep-going
 	cargo hack check --feature-powerset --target wasm32-unknown-unknown -p web-transport-wasm --keep-going
 
@@ -46,14 +46,14 @@ check:
 
 # Run any CI tests
 test:
-	cargo test --workspace --exclude web-transport-wasm --all-targets --all-features
+	cargo test --workspace --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport-wasm --all-targets --all-features
 
 # Automatically fix some issues.
 fix:
-	cargo fix --allow-staged --allow-dirty --workspace --exclude web-transport-wasm --all-targets --all-features
-	cargo clippy --fix --allow-staged --allow-dirty --workspace --exclude web-transport-wasm --all-targets --all-features
+	cargo fix --allow-staged --allow-dirty --workspace --all-targets --all-features
+	cargo clippy --fix --allow-staged --allow-dirty --workspace --all-targets --all-features
 
 	# Do the same but explicitly use the WASM target.
 	cargo fix --allow-staged --allow-dirty --target wasm32-unknown-unknown -p web-transport --all-targets --all-features

--- a/web-transport-wasm/Cargo.toml
+++ b/web-transport-wasm/Cargo.toml
@@ -24,7 +24,6 @@ url = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-streams = "0.1.2"
-web-transport-trait = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3.76"

--- a/web-transport-wasm/src/error.rs
+++ b/web-transport-wasm/src/error.rs
@@ -16,8 +16,6 @@ pub enum Error {
     Unknown(JsValue),
 }
 
-impl web_transport_trait::Error for Error {}
-
 impl Error {
     /// The error code used when closing the stream or session.
     pub fn code(&self) -> Option<u8> {

--- a/web-transport-wasm/src/recv.rs
+++ b/web-transport-wasm/src/recv.rs
@@ -93,24 +93,3 @@ impl Drop for RecvStream {
         self.reader.abort("dropped");
     }
 }
-
-impl web_transport_trait::RecvStream for RecvStream {
-    type Error = Error;
-
-    fn stop(&mut self, code: u32) {
-        Self::stop(self, &format!("code = {code}"));
-    }
-
-    async fn read(&mut self, mut dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-        Self::read_buf(self, &mut dst).await
-    }
-
-    async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Self::Error> {
-        Self::read(self, max).await
-    }
-
-    async fn closed(&mut self) -> Result<(), Self::Error> {
-        Self::closed(self).await?;
-        Ok(())
-    }
-}

--- a/web-transport-wasm/src/send.rs
+++ b/web-transport-wasm/src/send.rs
@@ -79,33 +79,3 @@ impl Drop for SendStream {
         self.writer.close();
     }
 }
-
-impl web_transport_trait::SendStream for SendStream {
-    type Error = Error;
-
-    fn set_priority(&mut self, order: i32) {
-        Self::set_priority(self, order)
-    }
-
-    fn reset(&mut self, code: u32) {
-        Self::reset(self, &format!("code = {code}"));
-    }
-
-    async fn finish(&mut self) -> Result<(), Self::Error> {
-        Self::finish(self)
-    }
-
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        Self::write(self, buf).await?;
-        Ok(buf.len())
-    }
-
-    async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<usize, Self::Error> {
-        Self::write_buf(self, buf).await
-    }
-
-    async fn closed(&mut self) -> Result<(), Self::Error> {
-        Self::closed(self).await?;
-        Ok(())
-    }
-}

--- a/web-transport-wasm/src/session.rs
+++ b/web-transport-wasm/src/session.rs
@@ -1,8 +1,3 @@
-#[cfg(not(target_family = "wasm"))]
-compile_error!(
-    "web-transport-wasm requires a WASM platform. Compile with --target=wasm32-unknown-unknown"
-);
-
 use bytes::Bytes;
 use js_sys::Uint8Array;
 use url::Url;
@@ -136,45 +131,3 @@ impl PartialEq for Session {
 }
 
 impl Eq for Session {}
-
-impl web_transport_trait::Session for Session {
-    type SendStream = SendStream;
-    type RecvStream = RecvStream;
-    type Error = Error;
-
-    async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-        Self::accept_uni(self).await
-    }
-
-    async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-        Self::accept_bi(self).await
-    }
-
-    async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-        Self::open_bi(self).await
-    }
-
-    async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-        Self::open_uni(self).await
-    }
-
-    fn close(&self, code: u32, reason: &str) {
-        Self::close(self, code, reason);
-    }
-
-    async fn closed(&self) -> Result<(), Self::Error> {
-        self.closed_inner().await
-    }
-
-    fn send_datagram(&self, _data: Bytes) -> Result<(), Self::Error> {
-        unimplemented!()
-    }
-
-    async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-        unimplemented!()
-    }
-
-    fn max_datagram_size(&self) -> usize {
-        unimplemented!()
-    }
-}


### PR DESCRIPTION
Nobody is (currently) using the trait, and supporting it breaks rust-analyzer and release-plz.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined WASM transport module by simplifying internal architecture while maintaining all existing functionality.

* **Chores**
  * Updated build verification to consistently include all packages in standard checks.
  * Cleaned up unused internal workspace dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->