### PR TITLE
Update the minimum web-transport-proto version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-web-transport-proto = { path = "web-transport-proto", version = "0.2" }
+web-transport-proto = { path = "web-transport-proto", version = "0.2.8" }
 web-transport-trait = { path = "web-transport-trait", version = "0.2" }


### PR DESCRIPTION
A capsule used by web-transport-quinn was added in 0.2.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version to improve system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->