### PR TITLE
Fix a rare race when accepting a stream.

### DIFF
--- a/web-transport-quiche/src/connection.rs
+++ b/web-transport-quiche/src/connection.rs
@@ -425,7 +425,12 @@ impl SessionAccept {
 
             // Poll the list of pending streams.
             let (typ, recv) = match ready!(self.pending_uni.poll_next_unpin(cx)) {
-                Some(res) => res?,
+                Some(Ok(res)) => res,
+                Some(Err(err)) => {
+                    // Ignore the error, the stream was probably reset early.
+                    tracing::warn!(?err, "failed to decode unidirectional stream");
+                    continue;
+                }
                 None => return Poll::Pending,
             };
 
@@ -491,7 +496,12 @@ impl SessionAccept {
 
             // Poll the list of pending streams.
             let res = match ready!(self.pending_bi.poll_next_unpin(cx)) {
-                Some(res) => res?,
+                Some(Ok(res)) => res,
+                Some(Err(err)) => {
+                    // Ignore the error, the stream was probably reset early.
+                    tracing::warn!(?err, "failed to decode bidirectional stream");
+                    continue;
+                }
                 None => return Poll::Pending,
             };
 

--- a/web-transport-quinn/src/session.rs
+++ b/web-transport-quinn/src/session.rs
@@ -389,7 +389,12 @@ impl SessionAccept {
 
             // Poll the list of pending streams.
             let (typ, recv) = match ready!(self.pending_uni.poll_next_unpin(cx)) {
-                Some(res) => res?,
+                Some(Ok(res)) => res,
+                Some(Err(err)) => {
+                    // Ignore the error, the stream was probably reset early.
+                    log::warn!("failed to decode unidirectional stream: {err:?}");
+                    continue;
+                }
                 None => return Poll::Pending,
             };
 
@@ -455,7 +460,12 @@ impl SessionAccept {
 
             // Poll the list of pending streams.
             let res = match ready!(self.pending_bi.poll_next_unpin(cx)) {
-                Some(res) => res?,
+                Some(Ok(res)) => res,
+                Some(Err(err)) => {
+                    // Ignore the error, the stream was probably reset early.
+                    log::warn!("failed to decode bidirectional stream: {err:?}");
+                    continue;
+                }
                 None => return Poll::Pending,
             };
 


### PR DESCRIPTION
If the stream is reset before the WebTransport header can be written, then web-transport-quinn was incorrectly returning an error. This can happen naturally under packet loss scenarios or potentially even when an empty stream is reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of WebTransport stream processing by gracefully handling stream decode errors instead of terminating operations, allowing the system to skip problematic streams and continue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->