### PR TITLE
We should bump the web-transport-trait crates.

### DIFF
--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/web-transport-ws/Cargo.toml
+++ b/web-transport-ws/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "websocket", "polyfill"]

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "2"
 url = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-web-transport-quinn = { version = "0.9.1", path = "../web-transport-quinn" }
+web-transport-quinn = { version = "0.10.0", path = "../web-transport-quinn" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-transport-wasm = { version = "0.5.3", path = "../web-transport-wasm" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped web-transport-quinn package to version 0.10.0.
  * Bumped web-transport-ws package to version 0.2.0.
  * Updated package dependencies to maintain consistency across the web-transport ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->