### PR TITLE
Fix buffer capacity check in varint encode to account for byteOffset

### DIFF
--- a/web-transport-ws/src/varint.ts
+++ b/web-transport-ws/src/varint.ts
@@ -28,7 +28,7 @@ export class VarInt {
 		const x = this.value;
 
 		const size = this.size();
-		if (dst.buffer.byteLength < dst.byteLength + size) {
+		if (dst.byteOffset + dst.byteLength + size > dst.buffer.byteLength) {
 			throw new Error("destination buffer too small");
 		}
 


### PR DESCRIPTION
The capacity check was comparing against the buffer's total byteLength without accounting for byteOffset. For Uint8Array views over a larger buffer, this could incorrectly allow writes that exceed the available space.

Use dst.byteOffset + dst.byteLength + size > dst.buffer.byteLength to properly check the actual end position of the appended data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buffer boundary validation to properly account for typed array offsets, preventing write operations from exceeding allocated memory boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->