### PR TITLE
Remove with_unreliable for non-WASM.

### DIFF
--- a/web-transport-quinn/src/client.rs
+++ b/web-transport-quinn/src/client.rs
@@ -44,15 +44,6 @@ impl ClientBuilder {
         }
     }
 
-    /// For compatibility with WASM. Panics if `val` is false, but does nothing else.
-    pub fn with_unreliable(self, val: bool) -> Self {
-        if !val {
-            panic!("with_unreliable must be true for quic transport");
-        }
-
-        self
-    }
-
     /// Enable the specified congestion controller.
     pub fn with_congestion_control(mut self, algorithm: CongestionControl) -> Self {
         self.congestion_controller = match algorithm {

--- a/web-transport/src/quinn.rs
+++ b/web-transport/src/quinn.rs
@@ -17,13 +17,6 @@ impl ClientBuilder {
         Self::default()
     }
 
-    /// For compatibility with WASM. Panics if `val` is false, but does nothing else.
-    pub fn with_unreliable(self, val: bool) -> Self {
-        Self {
-            inner: self.inner.with_unreliable(val),
-        }
-    }
-
     /// Allow a lower latency congestion controller.
     pub fn with_congestion_control(self, cc: CongestionControl) -> Self {
         Self {

--- a/web-transport/src/wasm.rs
+++ b/web-transport/src/wasm.rs
@@ -23,12 +23,6 @@ impl ClientBuilder {
         }
     }
 
-    pub fn with_unreliable(self, val: bool) -> Self {
-        Self {
-            inner: self.inner.with_unreliable(val),
-        }
-    }
-
     pub fn with_congestion_control(self, cc: CongestionControl) -> Self {
         Self {
             inner: self.inner.with_congestion_control(cc),


### PR DESCRIPTION
If it's not implemented... don't implement it...

#135 