### PR TITLE
Fix stream capacity tracking panic

### DIFF
--- a/web-transport-quiche/src/ez/send.rs
+++ b/web-transport-quiche/src/ez/send.rs
@@ -149,8 +149,6 @@ impl SendState {
                 "sent STREAM",
             );
 
-            self.capacity -= n;
-
             if n < chunk.len() {
                 // NOTE: This logic should rarely be executed because we gate based on stream capacity.
 


### PR DESCRIPTION
## Summary
Remove duplicate capacity decrement that caused panics when sending data on streams.

## Details
The line `self.capacity -= n;` was being called after successfully writing to the stream, but the capacity is already managed elsewhere in the stream send logic. This duplicate decrement caused an underflow panic.

## Impact
Fixes panics that occurred during normal stream send operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)