### PR TITLE
Add Incoming struct to inspect connections before accepting

### DIFF
--- a/web-transport-quiche/src/server.rs
+++ b/web-transport-quiche/src/server.rs
@@ -157,7 +157,10 @@ impl<M: ez::Metrics> Server<M> {
     pub async fn accept(&mut self) -> Option<h3::Request> {
         loop {
             tokio::select! {
-                Some(conn) = self.inner.accept() => self.accept.push(Box::pin(h3::Request::accept(conn))),
+                Some(incoming) = self.inner.accept() => {
+                    let conn = incoming.accept();
+                    self.accept.push(Box::pin(h3::Request::accept(conn)));
+                }
                 Some(res) = self.accept.next() => {
                     match res {
                         Ok(session) => return Some(session),


### PR DESCRIPTION
## Summary
- Adds an `Incoming` struct that wraps a QUIC connection before it's fully accepted
- Allows inspecting the peer address before starting the post-handshake driver

## Changes
- Added `ez::Incoming` struct with `peer_addr()` and `accept()` methods
- Changed `ez::Server::accept()` to return `Incoming` instead of `Connection`
- Updated WebTransport server to call `incoming.accept()` to get the connection

## Use Case
This enables servers to inspect the peer address (and potentially other connection metadata in the future) before accepting the connection and starting the driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)