### PR TITLE
Remove FrameTooLarge error variants

### DIFF
--- a/web-transport-proto/src/settings.rs
+++ b/web-transport-proto/src/settings.rs
@@ -99,9 +99,6 @@ pub enum SettingsError {
     #[error("invalid size")]
     InvalidSize,
 
-    #[error("frame too large")]
-    FrameTooLarge,
-
     #[error("io error: {0}")]
     Io(Arc<std::io::Error>),
 }
@@ -165,7 +162,7 @@ impl Settings {
 
             let size = size.into_inner();
             if size > MAX_FRAME_SIZE {
-                return Err(SettingsError::FrameTooLarge);
+                return Err(std::io::Error::other("frame too large"))?;
             }
 
             let mut payload = stream.take(size);
@@ -380,8 +377,8 @@ mod tests {
         let mut cursor = Cursor::new(wire);
         let err = Settings::read(&mut cursor).await.unwrap_err();
         assert!(
-            matches!(err, SettingsError::FrameTooLarge),
-            "expected FrameTooLarge, got {err:?}"
+            matches!(err, SettingsError::Io(_)),
+            "expected Io, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Removes `ConnectError::FrameTooLarge` and `SettingsError::FrameTooLarge` variants added in #168, which are semver-breaking (new variants on exhaustive enums)
- Maps the frame-too-large condition to `Io` errors instead, preserving the validation logic
- Allows a patch release so downstream crates auto-update

## Follow-up
Add `#[non_exhaustive]` to error enums and re-add `FrameTooLarge` as a minor version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)