### PR TITLE
Update iroh to 0.98.1 and migrate to preset-based endpoint builders

### DIFF
--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -10,10 +10,19 @@ edition = "2024"
 keywords = ["quic", "http3", "webtransport", "iroh"]
 categories = ["network-programming", "web-programming"]
 
+[features]
+default = ["ring"]
+ring = ["iroh/tls-ring"]
+aws-lc-rs = ["iroh/tls-aws-lc-rs"]
+
 [dependencies]
 bytes = "1"
 http = "1"
-iroh = "0.97.0"
+iroh = { version = "0.98.1", default-features = false, features = [
+    "metrics",
+    "fast-apple-datapath",
+    "portmapper",
+] }
 n0-error = "0.1.2"
 n0-future = "0.3.1"
 tokio = { version = "1", default-features = false, features = [

--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["quic", "http3", "webtransport", "iroh"]
 categories = ["network-programming", "web-programming"]
 
 [features]
-default = ["ring"]
-ring = ["iroh/tls-ring"]
-aws-lc-rs = ["iroh/tls-aws-lc-rs"]
+default = ["tls-ring"]
+tls-ring = ["iroh/tls-ring"]
+tls-aws-lc-rs = ["iroh/tls-aws-lc-rs"]
 
 [dependencies]
 bytes = "1"

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use iroh::{Endpoint, endpoint::ConnectionError};
+use iroh::{Endpoint, endpoint::ConnectionError, endpoint::presets};
 use n0_tracing_test::traced_test;
 use tokio::time::timeout;
 use tracing::Instrument;
@@ -11,7 +11,7 @@ use crate::{ALPN_H3, Client, H3Request, QuicRequest, SessionError};
 #[tokio::test]
 #[traced_test]
 async fn h3_smoke() -> n0_error::Result<()> {
-    let client = Endpoint::empty_builder()
+    let client = Endpoint::builder(presets::Empty)
         .bind()
         .instrument(tracing::error_span!("client-ep"))
         .await
@@ -19,7 +19,7 @@ async fn h3_smoke() -> n0_error::Result<()> {
     let client_id = client.id();
     let client = Client::new(client);
 
-    let server = Endpoint::empty_builder()
+    let server = Endpoint::builder(presets::Empty)
         .alpns(vec![ALPN_H3.as_bytes().to_vec()])
         .bind()
         .instrument(tracing::error_span!("server-ep"))
@@ -89,11 +89,11 @@ async fn h3_smoke() -> n0_error::Result<()> {
 async fn quic_smoke() -> n0_error::Result<()> {
     const ALPN: &str = "moql";
 
-    let client = Endpoint::empty_builder().bind().await.unwrap();
+    let client = Endpoint::builder(presets::Empty).bind().await.unwrap();
     let client_id = client.id();
     let client = Client::new(client);
 
-    let server = Endpoint::empty_builder()
+    let server = Endpoint::builder(presets::Empty)
         .alpns(vec![ALPN.as_bytes().to_vec()])
         .bind()
         .await

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -16,15 +16,21 @@ all-features = true
 
 [features]
 default = ["aws-lc-rs"]
-aws-lc-rs = ["rustls/aws-lc-rs"]
-ring = ["rustls/ring"]
+aws-lc-rs = ["rustls/aws-lc-rs", "noq/aws-lc-rs"]
+ring = ["rustls/ring", "noq/ring"]
 
 [dependencies]
 bytes = "1"
 futures = "0.3"
 http = "1"
 
-noq = "0.18.0"
+noq = { version = "0.18.0", default-features = false, features = [
+    "tracing-log",
+    "platform-verifier",
+    "runtime-tokio",
+    "rustls",
+    "bloom",
+] }
 
 rustls = { version = "0.23", default-features = false, features = [
     "logging",

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1"
 futures = "0.3"
 http = "1"
 
-noq = "0.17.0"
+noq = "0.18.0"
 
 rustls = { version = "0.23", default-features = false, features = [
     "logging",


### PR DESCRIPTION
## Summary
This PR updates the iroh dependency to version 0.98.1 and migrates the codebase to use the new preset-based endpoint builder API. Additionally, TLS provider selection is now configurable through Cargo features.

## Key Changes

- **Iroh dependency update**: Upgraded from 0.97.0 to 0.98.1 with explicit feature selection
  - Disabled default features and explicitly enabled: `metrics`, `fast-apple-datapath`, and `portmapper`
  
- **Endpoint builder migration**: Updated all `Endpoint::empty_builder()` calls to use the new `Endpoint::builder(presets::Empty)` API
  - Updated in `src/tests.rs` for both h3_smoke and quic_smoke test cases
  
- **TLS provider configuration**: Added Cargo feature flags for TLS provider selection
  - `ring` feature (default): Uses `iroh/tls-ring`
  - `aws-lc-rs` feature: Uses `iroh/tls-aws-lc-rs`
  - This allows users to choose their preferred TLS backend at compile time

- **Minor dependency update**: Updated noq from 0.17.0 to 0.18.0 in web-transport-noq

## Implementation Details

The migration to preset-based builders is a breaking API change in iroh 0.98.1. The `presets::Empty` preset provides the same functionality as the previous `empty_builder()` method but follows the new builder pattern design.

https://claude.ai/code/session_01Vaijb8P5za8tQjyguAiMBw