### PR TITLE
deps: update to iroh 0.98 and noq 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,3 @@ resolver = "2"
 web-transport-proto = { path = "rs/web-transport-proto", version = "0.6" }
 web-transport-trait = { path = "rs/web-transport-trait", version = "0.3" }
 
-[patch.crates-io]
-noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
-noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,9 @@ resolver = "2"
 [workspace.dependencies]
 web-transport-proto = { path = "rs/web-transport-proto", version = "0.6" }
 web-transport-trait = { path = "rs/web-transport-trait", version = "0.3" }
+
+[patch.crates-io]
+noq = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-proto = { git = "https://github.com/n0-computer/noq", branch = "main" }
+noq-udp = { git = "https://github.com/n0-computer/noq", branch = "main" }
+iroh = { git = "https://github.com/n0-computer/iroh", branch = "main" }

--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -10,10 +10,18 @@ edition = "2024"
 keywords = ["quic", "http3", "webtransport", "iroh"]
 categories = ["network-programming", "web-programming"]
 
+[features]
+default = ["aws-lc-rs", "metrics", "portmapper"]
+aws-lc-rs = ["iroh/tls-aws-lc-rs"]
+ring = ["iroh/tls-ring"]
+metrics = ["iroh/metrics"]
+portmapper = ["iroh/portmapper"]
+qlog = ["iroh/qlog"]
+
 [dependencies]
 bytes = "1"
 http = "1"
-iroh = "0.97.0"
+iroh = { version = "0.97", default-features = false, features = ["fast-apple-datapath"] }
 n0-error = "0.1.2"
 n0-future = "0.3.1"
 tokio = { version = "1", default-features = false, features = [
@@ -28,3 +36,4 @@ web-transport-trait = { workspace = true }
 [dev-dependencies]
 n0-tracing-test = "0.3.0"
 tokio = { version = "1", features = ["full"] }
+iroh = { version = "0.97", features = ["tls-ring"] }

--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -21,7 +21,7 @@ qlog = ["iroh/qlog"]
 [dependencies]
 bytes = "1"
 http = "1"
-iroh = { version = "0.97", default-features = false, features = ["fast-apple-datapath"] }
+iroh = { version = "0.98", default-features = false, features = ["fast-apple-datapath"] }
 n0-error = "0.1.2"
 n0-future = "0.3.1"
 tokio = { version = "1", default-features = false, features = [
@@ -36,4 +36,4 @@ web-transport-trait = { workspace = true }
 [dev-dependencies]
 n0-tracing-test = "0.3.0"
 tokio = { version = "1", features = ["full"] }
-iroh = { version = "0.97", features = ["tls-ring"] }
+iroh = { version = "0.98", features = ["tls-ring"] }

--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -34,6 +34,6 @@ web-transport-proto = { workspace = true }
 web-transport-trait = { workspace = true }
 
 [dev-dependencies]
+iroh = { version = "0.98", features = ["tls-ring"] }
 n0-tracing-test = "0.3.0"
 tokio = { version = "1", features = ["full"] }
-iroh = { version = "0.98", features = ["tls-ring"] }

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use iroh::{Endpoint, endpoint::ConnectionError};
+use iroh::{
+    Endpoint,
+    endpoint::{ConnectionError, presets},
+};
 use n0_tracing_test::traced_test;
 use tokio::time::timeout;
 use tracing::Instrument;

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -11,15 +11,14 @@ use crate::{ALPN_H3, Client, H3Request, QuicRequest, SessionError};
 #[tokio::test]
 #[traced_test]
 async fn h3_smoke() -> n0_error::Result<()> {
-    let client = Endpoint::empty_builder()
-        .bind()
+    let client = Endpoint::bind(presets::Minimal)
         .instrument(tracing::error_span!("client-ep"))
         .await
         .unwrap();
     let client_id = client.id();
     let client = Client::new(client);
 
-    let server = Endpoint::empty_builder()
+    let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![ALPN_H3.as_bytes().to_vec()])
         .bind()
         .instrument(tracing::error_span!("server-ep"))
@@ -89,11 +88,11 @@ async fn h3_smoke() -> n0_error::Result<()> {
 async fn quic_smoke() -> n0_error::Result<()> {
     const ALPN: &str = "moql";
 
-    let client = Endpoint::empty_builder().bind().await.unwrap();
+    let client = Endpoint::bind(presets::Minimal).await.unwrap();
     let client_id = client.id();
     let client = Client::new(client);
 
-    let server = Endpoint::empty_builder()
+    let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![ALPN.as_bytes().to_vec()])
         .bind()
         .await

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -23,7 +23,7 @@ ring = ["noq/ring", "rustls/ring"]
 bytes = "1"
 futures = "0.3"
 http = "1"
-noq = { version = "0.17.0", default-features = false, features = [
+noq = { version = "0.18.0", default-features = false, features = [
     "tracing-log",
     "platform-verifier",
     "runtime-tokio",

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -28,7 +28,7 @@ noq = { version = "0.18.0", default-features = false, features = [
     "platform-verifier",
     "runtime-tokio",
     "rustls",
-    "bloom"
+    "bloom",
 ] }
 rustls = { version = "0.23", default-features = false, features = [
     "logging",

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -16,23 +16,26 @@ all-features = true
 
 [features]
 default = ["aws-lc-rs"]
-aws-lc-rs = ["rustls/aws-lc-rs"]
-ring = ["rustls/ring"]
+aws-lc-rs = ["noq/aws-lc-rs", "rustls/aws-lc-rs"]
+ring = ["noq/ring", "rustls/ring"]
 
 [dependencies]
 bytes = "1"
 futures = "0.3"
 http = "1"
-
-noq = "0.17.0"
-
+noq = { version = "0.17.0", default-features = false, features = [
+    "tracing-log",
+    "platform-verifier",
+    "runtime-tokio",
+    "rustls",
+    "bloom"
+] }
 rustls = { version = "0.23", default-features = false, features = [
     "logging",
     "std",
 ] }
 rustls-native-certs = "0.8"
 thiserror = "2"
-
 tokio = { version = "1", default-features = false, features = [
     "io-util",
     "macros",


### PR DESCRIPTION
This updates `web-transport-iroh` to `iroh@0.98` and `web-transport-noq` to `noq@0.18`. This is a breaking change for both crates.