### PR TITLE
chore: bump web-transport-iroh to 0.4.0

### DIFF
--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -4,7 +4,7 @@ description = "WebTransport library for Iroh"
 authors = ["Franz Heinzmann <frando@n0.computer>"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "iroh"]


### PR DESCRIPTION
#230 is a breaking change to web-transport-iroh, but the release-plz workflow didn't catch it. This updates it.