### PR TITLE
Wire up W3C protocols option and protocol getter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,18 +28,18 @@
     },
     "js/web-transport": {
       "name": "@moq/web-transport",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@napi-rs/cli": "^3",
         "@types/node": "^24.3.0",
         "typescript": "^5.9.2",
       },
       "optionalDependencies": {
-        "@moq/web-transport-darwin-arm64": "0.1.0",
-        "@moq/web-transport-darwin-x64": "0.1.0",
-        "@moq/web-transport-linux-arm64-gnu": "0.1.0",
-        "@moq/web-transport-linux-x64-gnu": "0.1.0",
-        "@moq/web-transport-win32-x64-msvc": "0.1.0",
+        "@moq/web-transport-darwin-arm64": "0.1.1",
+        "@moq/web-transport-darwin-x64": "0.1.1",
+        "@moq/web-transport-linux-arm64-gnu": "0.1.1",
+        "@moq/web-transport-linux-x64-gnu": "0.1.1",
+        "@moq/web-transport-win32-x64-msvc": "0.1.1",
       },
     },
     "js/web-transport-ws": {
@@ -192,6 +192,16 @@
     "@moq/qmux": ["@moq/qmux@workspace:js/qmux"],
 
     "@moq/web-transport": ["@moq/web-transport@workspace:js/web-transport"],
+
+    "@moq/web-transport-darwin-arm64": ["@moq/web-transport-darwin-arm64@0.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CkE0AkKab+0Yu77riOZsGKwaTytjThYiVon4Pq+2ye8iBC1QHoGddfHBBjvEsgllWOgg3nosb5EIIO8Q3h+2Mg=="],
+
+    "@moq/web-transport-darwin-x64": ["@moq/web-transport-darwin-x64@0.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-T0Nk5Fj3SxbeREK9saWVjMirOhQIsaT858sWkBGQgudKGN9SXvOtmtiBMEMsxHUQKtoOw1My33wedsPZJPI5fQ=="],
+
+    "@moq/web-transport-linux-arm64-gnu": ["@moq/web-transport-linux-arm64-gnu@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ICdsu3gchDToZmPOhMfgztr9kX1HMRu9bnXdq1sVD1ewplO3q21ftVjSli8WqDAVOdsP8fzNSJ+sVxFzbgU33A=="],
+
+    "@moq/web-transport-linux-x64-gnu": ["@moq/web-transport-linux-x64-gnu@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-1/YvemSqVVUjbzNk4uoSUwmpuuL2iU3A4Ag11FIIxghNpzVG5Ls5qgWhl1uagb4vV7Cv8VIywkpgFGv+jwyJmQ=="],
+
+    "@moq/web-transport-win32-x64-msvc": ["@moq/web-transport-win32-x64-msvc@0.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-10NJGJ6IM/gfvRs+QdnbT5xWG9JA6ioPQZWVL9y1lp+uDEEpXe17wnkUP+ZT7cvEfxrmgHGdZPBNFyde9hD46w=="],
 
     "@moq/web-transport-ws": ["@moq/web-transport-ws@workspace:js/web-transport-ws"],
 

--- a/js/web-transport/README.md
+++ b/js/web-transport/README.md
@@ -39,6 +39,16 @@ const session = new Session("https://localhost:4443", {
 });
 ```
 
+### Subprotocol negotiation
+
+```ts
+const session = new Session("https://example.com:4443/path", {
+	protocols: ["moqt-16"],
+});
+await session.ready;
+console.log(session.protocol); // "moqt-16" (server-selected)
+```
+
 ### Polyfill
 
 Install `Session` as the global `WebTransport` for libraries that expect the browser API:

--- a/js/web-transport/napi.d.ts
+++ b/js/web-transport/napi.d.ts
@@ -20,7 +20,7 @@ export declare class NapiClient {
 	/** Create a client that validates server certificates by SHA-256 hash. */
 	static withCertificateHashes(hashes: Array<Buffer>): NapiClient;
 	/** Connect to a WebTransport server at the given URL. */
-	connect(urlStr: string): Promise<NapiSession>;
+	connect(urlStr: string, options?: NapiConnectOptions | undefined | null): Promise<NapiSession>;
 }
 
 /** A receive stream for reading data. */
@@ -65,6 +65,8 @@ export declare class NapiServer {
 
 /** An established WebTransport session. */
 export declare class NapiSession {
+	/** The subprotocol selected by the server during WT-Available-Protocols negotiation. */
+	get protocol(): string | null;
 	/** Accept an incoming unidirectional stream. */
 	acceptUni(): Promise<NapiRecvStream>;
 	/** Accept an incoming bidirectional stream. */
@@ -83,6 +85,12 @@ export declare class NapiSession {
 	close(code: number, reason: string): void;
 	/** Wait for the session to close, returning close info matching W3C WebTransportCloseInfo. */
 	closed(): Promise<NapiCloseInfo>;
+}
+
+/** Options for connecting to a WebTransport server. */
+export interface NapiConnectOptions {
+	/** Subprotocols for WT-Available-Protocols negotiation. */
+	protocols?: Array<string> | undefined | null;
 }
 
 /** Info about why a session was closed, matching W3C WebTransportCloseInfo. */

--- a/js/web-transport/src/session.ts
+++ b/js/web-transport/src/session.ts
@@ -91,8 +91,10 @@ export default class Session implements WebTransport {
 				client = NapiClient.withSystemRoots();
 			}
 
+			const connectOptions = options?.protocols ? { protocols: options.protocols } : null;
+
 			client
-				.connect(url)
+				.connect(url, connectOptions)
 				.then((session) => {
 					// Check if close() was called before connect completed.
 					if (this.#pendingClose) {
@@ -117,6 +119,10 @@ export default class Session implements WebTransport {
 					closed.resolve({ closeCode: 0, reason: String(err) });
 				});
 		}
+	}
+
+	get protocol(): string {
+		return this.#session?.protocol ?? "";
 	}
 
 	get incomingBidirectionalStreams(): ReadableStream<WebTransportBidirectionalStream> {

--- a/js/web-transport/src/session.ts
+++ b/js/web-transport/src/session.ts
@@ -34,6 +34,8 @@ function wrapSendStream(send: NapiSendStream): WritableStream<Uint8Array> {
 export interface SessionOptions extends WebTransportOptions {
 	/** Skip all certificate verification. Only use for testing. */
 	serverCertificateDisableVerify?: boolean;
+	/** Subprotocols for WT-Available-Protocols negotiation. */
+	protocols?: string[];
 }
 
 export default class Session implements WebTransport {

--- a/rs/web-transport-node/src/lib.rs
+++ b/rs/web-transport-node/src/lib.rs
@@ -64,13 +64,23 @@ impl NapiClient {
 
     /// Connect to a WebTransport server at the given URL.
     #[napi]
-    pub async fn connect(&self, url_str: String) -> Result<NapiSession> {
+    pub async fn connect(
+        &self,
+        url_str: String,
+        options: Option<NapiConnectOptions>,
+    ) -> Result<NapiSession> {
         let url: url::Url = url_str
             .parse()
             .map_err(|e: url::ParseError| Error::from_reason(e.to_string()))?;
+        let mut request = web_transport_quinn::proto::ConnectRequest::new(url);
+        if let Some(opts) = options {
+            if let Some(protocols) = opts.protocols {
+                request = request.with_protocols(protocols);
+            }
+        }
         let session = self
             .inner
-            .connect(url)
+            .connect(request)
             .await
             .map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(NapiSession {
@@ -78,6 +88,13 @@ impl NapiClient {
             closed: Mutex::new(None),
         })
     }
+}
+
+/// Options for connecting to a WebTransport server.
+#[napi(object)]
+pub struct NapiConnectOptions {
+    /// Subprotocols for WT-Available-Protocols negotiation.
+    pub protocols: Option<Vec<String>>,
 }
 
 /// A WebTransport server that accepts incoming sessions.
@@ -243,6 +260,12 @@ impl NapiBiStream {
 
 #[napi]
 impl NapiSession {
+    /// The subprotocol selected by the server during WT-Available-Protocols negotiation.
+    #[napi(getter)]
+    pub fn protocol(&self) -> Option<String> {
+        self.inner.response().protocol.clone()
+    }
+
     /// Accept an incoming unidirectional stream.
     #[napi]
     pub async fn accept_uni(&self) -> Result<NapiRecvStream> {


### PR DESCRIPTION
## Summary

The W3C WebTransport spec defines `protocols` on the constructor and `protocol` on the session for subprotocol negotiation. The Rust layer already supports this via `ConnectRequest::with_protocols()` and `ConnectResponse::protocol` — this wires it through the NAPI binding.

- Add `NapiConnectOptions` struct with `protocols: Option<Vec<String>>`
- Thread it through `NapiClient::connect(url, options)`
- Expose `NapiSession::protocol()` getter
- Update `Session` JS wrapper to pass `options.protocols` and expose `session.protocol`
- Update README with subprotocol negotiation example

## Motivation

Without protocol negotiation, Node.js clients cannot connect to multi-version relays that require `WT-Available-Protocols` to select a draft version. This was discovered during MoQT interop testing — draft-16 connections to moq-dev and moqx relays failed because the polyfill wasn't sending the protocol token.

## Test plan

- Verified backwards compatibility: `new Session(url)` and `new Session(url, {})` still work
- Verified `session.protocol` returns `""` before connect and when server doesn't negotiate
- Verified negotiation against live relays:
  - `cdn.moq.dev` with `protocols: ["moqt-16"]` → `protocol === "moqt-16"`
  - `moqx-000.ci.openmoq.org` with `protocols: ["moqt-16"]` → `protocol === "moqt-16"`
  - Cloudflare (dedicated endpoint, no negotiation) → `protocol === ""`
- Verified multiple protocols: `["moqt-99", "moqt-16"]` → server picks `"moqt-16"`
- Verified empty array: `protocols: []` → no negotiation header sent