### PR TITLE
Remove @moq/web-transport-ws from release workflow

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -84,10 +84,6 @@ jobs:
         working-directory: js/qmux
         run: nix develop --command bun run release
 
-      - name: Release @moq/web-transport-ws
-        working-directory: js/web-transport-ws
-        run: nix develop --command bun run release
-
   release-native:
     if: github.repository_owner == 'moq-dev'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Removes the release step for the `@moq/web-transport-ws` package from the automated release workflow.

## Changes
- Removed the "Release @moq/web-transport-ws" job step from `.github/workflows/release-js.yml`
  - This package will no longer be automatically released to NPM as part of the CI/CD pipeline

## Notes
This change indicates that `@moq/web-transport-ws` is either being deprecated, consolidated into another package, or will be released through a different mechanism. The package directory itself remains in the repository but is excluded from automated releases.

https://claude.ai/code/session_015UigqyQ8LxuPNPzsGz7QVQ