### PR TITLE
deps: bump tokio-quiche 0.12→0.19 and assorted dependencies

### DIFF
--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 tokio-rustls = { version = "0.26", optional = true }
 
 # Optional: WebSocket
-tokio-tungstenite = { version = "0.28", optional = true }
+tokio-tungstenite = { version = "0.29", optional = true }
 tracing = "0.1"
 web-transport-proto = { workspace = true }
 web-transport-trait = { workspace = true }

--- a/rs/web-transport-ffi/Cargo.toml
+++ b/rs/web-transport-ffi/Cargo.toml
@@ -40,6 +40,6 @@ web-transport-quinn = { workspace = true }
 uniffi = { version = "0.31", features = ["build"] }
 
 [dev-dependencies]
-rcgen = "0.13"
-sha2 = "0.10"
+rcgen = "0.14"
+sha2 = "0.11"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/rs/web-transport-ffi/src/test.rs
+++ b/rs/web-transport-ffi/src/test.rs
@@ -17,7 +17,7 @@ fn self_signed_cert() -> (Vec<Vec<u8>>, Vec<u8>) {
     let cert = rcgen::generate_simple_self_signed(["localhost".to_string()])
         .expect("generate self-signed cert");
     let cert_der = cert.cert.der().to_vec();
-    let key_der = cert.key_pair.serialize_der();
+    let key_der = cert.signing_key.serialize_der();
     (vec![cert_der], key_der)
 }
 

--- a/rs/web-transport-quiche/Cargo.toml
+++ b/rs/web-transport-quiche/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 [dependencies]
 boring = "4"
 bytes = "1"
-flume = "0.11"
+flume = "0.12"
 futures = "0.3"
 http = "1"
 rustls-pki-types = "1"
@@ -31,7 +31,7 @@ tokio = { version = "1", default-features = false, features = [
     "time",
 ] }
 
-tokio-quiche = "0.12"
+tokio-quiche = "0.19"
 tracing = "0.1"
 web-transport-proto = { workspace = true }
 web-transport-trait = { workspace = true }

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Poll, Waker},
 };
 use tokio_quiche::{
-    buf_factory::{BufFactory, PooledBuf},
+    buf_factory::BufFactory,
     quic::{HandshakeInfo, QuicheConnection},
 };
 
@@ -195,7 +195,7 @@ pub(super) struct Driver {
     send: HashMap<StreamId, Lock<SendState>>,
     recv: HashMap<StreamId, Lock<RecvState>>,
 
-    buf: PooledBuf,
+    buf: Vec<u8>,
 
     accept_bi: flume::Sender<(SendStream, RecvStream)>,
     accept_uni: flume::Sender<RecvStream>,
@@ -211,7 +211,7 @@ impl Driver {
             state,
             send: HashMap::new(),
             recv: HashMap::new(),
-            buf: BufFactory::get_max_buf(),
+            buf: vec![0u8; BufFactory::MAX_BUF_SIZE],
             accept_bi,
             accept_uni,
         }

--- a/rs/web-transport-quiche/src/ez/server.rs
+++ b/rs/web-transport-quiche/src/ez/server.rs
@@ -113,7 +113,7 @@ impl<M: Metrics> ServerBuilder<M, ServerWithListener> {
 
         let listener = QuicListener {
             socket,
-            socket_cookie: self.state.listeners.len() as _,
+            cid_generator: Arc::new(SimpleConnectionIdGenerator),
             capabilities,
         };
 
@@ -177,12 +177,8 @@ impl<M: Metrics> ServerBuilder<M, ServerWithListener> {
             .collect();
 
         let params = tokio_quiche::ConnectionParams::new_server(self.settings, dummy_tls, hooks);
-        let server = tokio_quiche::listen_with_capabilities(
-            self.state.listeners,
-            params,
-            SimpleConnectionIdGenerator,
-            self.metrics,
-        )?;
+        let server =
+            tokio_quiche::listen_with_capabilities(self.state.listeners, params, self.metrics)?;
         Ok(Server::new(server, local_addrs))
     }
 }


### PR DESCRIPTION
## Summary

- **web-transport-quiche**: bump `tokio-quiche` 0.12 → 0.19 and `flume` 0.11 → 0.12. The tokio-quiche jump required adapting to three API changes:
  - `buf_factory::PooledBuf` was removed; replaced with `Vec<u8>` sized to `BufFactory::MAX_BUF_SIZE` (matches the pattern used by tokio-quiche's own `H3Driver`).
  - `QuicListener` lost its `socket_cookie` field and gained `cid_generator: Arc<dyn ConnectionIdGenerator>`.
  - `listen_with_capabilities` no longer takes a separate CID generator — it lives on each listener now — so the call site is 3 args instead of 4.
- **qmux**: `tokio-tungstenite` 0.28 → 0.29 (clean bump, no source changes).
- **web-transport-ffi**: dev-deps `rcgen` 0.13 → 0.14 and `sha2` 0.10 → 0.11. rcgen renamed `CertifiedKey.key_pair` → `signing_key`, updated in `src/test.rs`.

## Deferred

- **boring 4 → 5**: tokio-quiche (even master) still pins `boring = "4.3"`, so bumping `web-transport-quiche` to boring 5 would split the dep tree and break the `ConnectionHook` types we pass into tokio-quiche. Wait for upstream.
- **iroh / noq**: both pinned at `=1.0.0-rc.0`, already current.
- **rustls / quinn / napi / uniffi**: already on the latest published minor.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `just check` (clippy, fmt, feature powerset, cargo-shear, cargo-sort, biome)
- [x] `just fix` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)