### PR TITLE
qmux: bump to 0.1.1

### DIFF
--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]


### PR DESCRIPTION
## Summary

- Bumps `@moq/qmux` and `qmux` to 0.1.1 on both JS and Rust sides.
- 0.1.0 was yanked from crates.io and npm after the redesign in #243 landed, but the `qmux-v0.1.0` git tag still exists, so release-plz refuses to recompute the next version (`local package qmux has a greater version (0.1.0) than registry (0.0.8), but the git tag qmux-v0.1.0 exists`). Bumping to 0.1.1 unblocks the next release run.
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)