### PR TITLE
feat(qmux): honor per-stream send priority (sendOrder)

### DIFF
--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -9,6 +9,7 @@ mod credit;
 mod error;
 pub mod proto;
 mod protocol;
+mod sched;
 mod session;
 mod stream;
 mod transport;

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -1,0 +1,378 @@
+//! Per-stream priority scheduling for outbound STREAM data.
+//!
+//! Replaces the bounded `mpsc` data channel the session used to interleave
+//! STREAM frames purely by arrival order. Frames are bucketed by stream
+//! priority (a `u8`, higher = sent first, matching the W3C `sendOrder`
+//! convention) so a high-priority stream can jump ahead of a low-priority
+//! backlog. Re-prioritization is retroactive and cheap: only the stream's
+//! scheduling pointer moves between bands, never its queued frames, so the
+//! per-stream FIFO order the receiver relies on (it appends STREAM data by
+//! arrival, ignoring the wire offset) is always preserved.
+//!
+//! Control frames are *not* routed here — the session keeps its separate
+//! unbounded `outbound_priority` channel and a `biased` select so control
+//! always precedes any data this queue yields.
+
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::Notify;
+
+use crate::{Error, Frame, StreamId};
+
+/// Per-stream FIFO of pending frames plus the stream's current priority band.
+struct StreamSlot {
+    priority: u8,
+    frames: VecDeque<Frame>,
+}
+
+struct Inner {
+    /// Ready streams bucketed by priority. The MAX key is served first.
+    /// A `StreamId` appears in at most one band at a time, and only while its
+    /// slot has at least one queued frame.
+    bands: BTreeMap<u8, VecDeque<StreamId>>,
+    /// Per-stream queued frames + current priority.
+    streams: HashMap<StreamId, StreamSlot>,
+    /// Total queued frames across all streams (the capacity bound).
+    len: usize,
+    /// Set on session teardown; unblocks producers and the consumer.
+    closed: bool,
+}
+
+impl Inner {
+    /// Schedule `id` in `band` if it isn't already scheduled somewhere.
+    ///
+    /// Caller guarantees the slot exists and has at least one frame.
+    fn arm(&mut self, id: StreamId, band: u8) {
+        // A StreamId lives in at most one band. The slot's `priority` is the
+        // single source of truth for which band it would be in, so checking the
+        // band's queue for membership is unnecessary as long as callers only arm
+        // a stream that was previously unscheduled (empty slot just created, or
+        // a slot drained then refilled).
+        self.bands.entry(band).or_default().push_back(id);
+    }
+}
+
+/// A bounded, priority-aware queue of outbound STREAM frames shared between the
+/// session's writer loop (consumer) and its `SendStream`s (producers).
+///
+/// Cloning shares the same underlying queue.
+#[derive(Clone)]
+pub struct PriorityQueue {
+    inner: Arc<Mutex<Inner>>,
+    /// Notified when a frame becomes available (or the queue is closed).
+    non_empty: Arc<Notify>,
+    /// Notified when capacity frees up (or the queue is closed).
+    has_space: Arc<Notify>,
+    capacity: usize,
+}
+
+impl PriorityQueue {
+    /// Create a queue holding at most `capacity` frames total before `push`
+    /// blocks.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                bands: BTreeMap::new(),
+                streams: HashMap::new(),
+                len: 0,
+                closed: false,
+            })),
+            non_empty: Arc::new(Notify::new()),
+            has_space: Arc::new(Notify::new()),
+            capacity,
+        }
+    }
+
+    /// Append a frame to `id`'s FIFO, blocking while the queue is full.
+    ///
+    /// Cancel-safe: the mutation happens synchronously right before returning,
+    /// so if the caller's `select!` drops this future before it resolves, no
+    /// frame is enqueued (matching the old `outbound.send` race against
+    /// `inbound_stopped`).
+    pub async fn push(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
+        loop {
+            // Register interest *before* checking, so a `notify_one` that fires
+            // between our check and `.await` isn't lost.
+            let notified = self.has_space.notified();
+            {
+                let mut inner = self.inner.lock().unwrap();
+                if inner.closed {
+                    return Err(Error::Closed);
+                }
+                if inner.len < self.capacity {
+                    self.push_locked(&mut inner, priority, id, frame);
+                    return Ok(());
+                }
+            }
+            notified.await;
+        }
+    }
+
+    /// Non-blocking variant of [`push`]. Returns the frame back on `Err` if the
+    /// queue is full or closed.
+    pub fn try_push(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Frame> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.closed || inner.len >= self.capacity {
+            return Err(frame);
+        }
+        self.push_locked(&mut inner, priority, id, frame);
+        Ok(())
+    }
+
+    fn push_locked(&self, inner: &mut Inner, priority: u8, id: StreamId, frame: Frame) {
+        match inner.streams.get_mut(&id) {
+            Some(slot) => {
+                // Already scheduled (its band points at `id`); just append.
+                slot.frames.push_back(frame);
+            }
+            None => {
+                let mut frames = VecDeque::new();
+                frames.push_back(frame);
+                inner.streams.insert(id, StreamSlot { priority, frames });
+                inner.arm(id, priority);
+            }
+        }
+        inner.len += 1;
+        self.non_empty.notify_one();
+    }
+
+    /// Pop the next frame to send, honoring priority then round-robin fairness
+    /// among equal-priority streams. Blocks until a frame is available or the
+    /// queue is closed (returns `None` once closed and drained).
+    pub async fn pop(&self) -> Option<Frame> {
+        loop {
+            let notified = self.non_empty.notified();
+            {
+                let mut inner = self.inner.lock().unwrap();
+                if let Some(frame) = self.pop_locked(&mut inner) {
+                    return Some(frame);
+                }
+                if inner.closed {
+                    return None;
+                }
+            }
+            notified.await;
+        }
+    }
+
+    fn pop_locked(&self, inner: &mut Inner) -> Option<Frame> {
+        // Highest band first.
+        let (&band, queue) = inner.bands.iter_mut().next_back()?;
+        let id = queue.pop_front().expect("scheduled band must be non-empty");
+        if queue.is_empty() {
+            inner.bands.remove(&band);
+        }
+
+        let slot = inner
+            .streams
+            .get_mut(&id)
+            .expect("scheduled stream must have a slot");
+        let frame = slot
+            .frames
+            .pop_front()
+            .expect("scheduled slot must be non-empty");
+
+        if slot.frames.is_empty() {
+            // Drained: drop the slot so a future push re-arms it cleanly.
+            inner.streams.remove(&id);
+        } else {
+            // Round-robin: re-arm at the back of its *current* band (which may
+            // differ from `band` if set_priority moved it; but since it was at
+            // the head of the max band, its priority equals `band`).
+            let priority = slot.priority;
+            inner.arm(id, priority);
+        }
+
+        inner.len -= 1;
+        self.has_space.notify_one();
+        Some(frame)
+    }
+
+    /// Retroactively re-prioritize a stream. Frames don't move — only the
+    /// scheduling pointer relocates from the old band to `new`. No-op if the
+    /// stream has no queued frames.
+    pub fn set_priority(&self, id: StreamId, new: u8) {
+        let mut inner = self.inner.lock().unwrap();
+        let old = match inner.streams.get(&id) {
+            Some(slot) => slot.priority,
+            None => return,
+        };
+        if old == new {
+            return;
+        }
+
+        // Relocate the scheduling pointer if the stream is currently scheduled.
+        // It is scheduled iff it has frames (invariant), which it does here.
+        if let Some(queue) = inner.bands.get_mut(&old) {
+            if let Some(pos) = queue.iter().position(|&s| s == id) {
+                queue.remove(pos);
+                if queue.is_empty() {
+                    inner.bands.remove(&old);
+                }
+                inner.bands.entry(new).or_default().push_back(id);
+            }
+        }
+
+        if let Some(slot) = inner.streams.get_mut(&id) {
+            slot.priority = new;
+        }
+    }
+
+    /// Close the queue, unblocking any blocked producers and the consumer.
+    pub fn close(&self) {
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.closed = true;
+        }
+        self.non_empty.notify_waiters();
+        self.has_space.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    use crate::proto::Stream;
+    use crate::{StreamDir, StreamId};
+
+    fn sid(index: u64) -> StreamId {
+        StreamId::new(index, StreamDir::Uni, false)
+    }
+
+    fn frame(id: StreamId, tag: u8) -> Frame {
+        Frame::Stream(Stream {
+            id,
+            data: Bytes::copy_from_slice(&[tag]),
+            fin: false,
+        })
+    }
+
+    fn tag_of(frame: &Frame) -> u8 {
+        match frame {
+            Frame::Stream(s) => s.data[0],
+            _ => panic!("expected stream frame"),
+        }
+    }
+
+    fn id_of(frame: &Frame) -> StreamId {
+        match frame {
+            Frame::Stream(s) => s.id,
+            _ => panic!("expected stream frame"),
+        }
+    }
+
+    #[tokio::test]
+    async fn higher_priority_first() {
+        let q = PriorityQueue::new(8);
+        let lo = sid(0);
+        let hi = sid(1);
+
+        q.push(10, lo, frame(lo, b'l')).await.unwrap();
+        q.push(200, hi, frame(hi, b'h')).await.unwrap();
+
+        // High priority drains first.
+        assert_eq!(tag_of(&q.pop().await.unwrap()), b'h');
+        assert_eq!(tag_of(&q.pop().await.unwrap()), b'l');
+    }
+
+    #[tokio::test]
+    async fn equal_priority_round_robin() {
+        let q = PriorityQueue::new(8);
+        let a = sid(0);
+        let b = sid(1);
+
+        q.push(5, a, frame(a, 1)).await.unwrap();
+        q.push(5, a, frame(a, 2)).await.unwrap();
+        q.push(5, b, frame(b, 1)).await.unwrap();
+        q.push(5, b, frame(b, 2)).await.unwrap();
+
+        // Round-robin between equal-priority streams: a, b, a, b.
+        assert_eq!(id_of(&q.pop().await.unwrap()), a);
+        assert_eq!(id_of(&q.pop().await.unwrap()), b);
+        assert_eq!(id_of(&q.pop().await.unwrap()), a);
+        assert_eq!(id_of(&q.pop().await.unwrap()), b);
+    }
+
+    #[tokio::test]
+    async fn per_stream_fifo_preserved() {
+        let q = PriorityQueue::new(8);
+        let a = sid(0);
+
+        for i in 0..4u8 {
+            q.push(5, a, frame(a, i)).await.unwrap();
+        }
+        for i in 0..4u8 {
+            assert_eq!(tag_of(&q.pop().await.unwrap()), i);
+        }
+    }
+
+    #[tokio::test]
+    async fn set_priority_moves_pointer_not_frames() {
+        let q = PriorityQueue::new(8);
+        let lo = sid(0);
+        let hi = sid(1);
+
+        // Two frames each, lo enqueued first.
+        q.push(10, lo, frame(lo, 1)).await.unwrap();
+        q.push(10, lo, frame(lo, 2)).await.unwrap();
+        q.push(20, hi, frame(hi, 1)).await.unwrap();
+
+        // Promote lo above hi; its frames keep their order.
+        q.set_priority(lo, 100);
+
+        assert_eq!(id_of(&q.pop().await.unwrap()), lo);
+        assert_eq!(tag_of(&q.pop().await.unwrap()), 2); // lo's second frame, in order
+        assert_eq!(id_of(&q.pop().await.unwrap()), hi);
+    }
+
+    #[tokio::test]
+    async fn set_priority_unknown_stream_is_noop() {
+        let q = PriorityQueue::new(8);
+        q.set_priority(sid(99), 50); // must not panic
+    }
+
+    #[tokio::test]
+    async fn close_unblocks_pop() {
+        let q = PriorityQueue::new(8);
+        let q2 = q.clone();
+        let handle = tokio::spawn(async move { q2.pop().await });
+        tokio::task::yield_now().await;
+        q.close();
+        assert!(handle.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn close_unblocks_push() {
+        let q = PriorityQueue::new(1);
+        let a = sid(0);
+        q.push(5, a, frame(a, 1)).await.unwrap();
+
+        let q2 = q.clone();
+        let handle = tokio::spawn(async move { q2.push(5, sid(1), frame(sid(1), 2)).await });
+        tokio::task::yield_now().await;
+        q.close();
+        assert!(matches!(handle.await.unwrap(), Err(Error::Closed)));
+    }
+
+    #[tokio::test]
+    async fn backpressure_blocks_at_capacity() {
+        let q = PriorityQueue::new(2);
+        let a = sid(0);
+        q.push(5, a, frame(a, 1)).await.unwrap();
+        q.push(5, a, frame(a, 2)).await.unwrap();
+
+        let q2 = q.clone();
+        let pushing = tokio::spawn(async move { q2.push(5, a, frame(a, 3)).await });
+        tokio::task::yield_now().await;
+        assert!(!pushing.is_finished(), "push should block while full");
+
+        // Draining one frame makes room.
+        q.pop().await.unwrap();
+        pushing.await.unwrap().unwrap();
+    }
+}

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -111,12 +111,15 @@ impl PriorityQueue {
         }
     }
 
-    /// Non-blocking variant of [`push`]. Returns the frame back on `Err` if the
-    /// queue is full or closed.
-    pub fn try_push(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Frame> {
+    /// Enqueue a frame synchronously, bypassing the capacity bound — for small,
+    /// must-not-be-dropped control markers like a stream FIN, which would
+    /// otherwise have to either block (impossible from a sync caller) or be
+    /// detached to a task (racing reset/teardown). The frame still lands in the
+    /// stream's band, after its data. Fails only if the queue is closed.
+    pub fn push_now(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
         let mut inner = self.inner.lock().unwrap();
-        if inner.closed || inner.len >= self.capacity {
-            return Err(frame);
+        if inner.closed {
+            return Err(Error::Closed);
         }
         self.push_locked(&mut inner, priority, id, frame);
         Ok(())

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -825,15 +825,18 @@ impl SendStream {
             return error.clone();
         }
 
-        let frame = ResetStream {
-            id: self.id,
-            code,
-            final_size: self.offset,
-        };
-
         let error = Error::StreamStop(code);
 
-        self.outbound_priority.send(frame.into()).ok();
+        // If we've already sent a FIN, the stream is finished; don't also emit a
+        // RESET_STREAM for it (that would put two terminal frames on one stream).
+        if !self.fin {
+            let frame = ResetStream {
+                id: self.id,
+                code,
+                final_size: self.offset,
+            };
+            self.outbound_priority.send(frame.into()).ok();
+        }
         self.closed = Some(error.clone());
 
         error
@@ -1001,17 +1004,12 @@ impl generic::SendStream for SendStream {
             fin: true,
         };
 
-        // The FIN lands in the stream's current band (after its data). If the
-        // queue is full, hand off to a task that awaits room rather than block.
-        if let Err(frame) = self.outbound.try_push(self.priority, self.id, frame.into()) {
-            let outbound = self.outbound.clone();
-            let priority = self.priority;
-            let id = self.id;
-            tokio::spawn(async move {
-                outbound.push(priority, id, frame).await.ok();
-            });
-        }
-
+        // Enqueue the FIN synchronously into the stream's band (after its data),
+        // bypassing the capacity bound. This avoids detaching it to a task, which
+        // could race a concurrent reset/stop (emitting RESET_STREAM and then a
+        // FIN) and would also hide a closed queue behind a successful return.
+        self.outbound
+            .push_now(self.priority, self.id, frame.into())?;
         self.fin = true;
 
         Ok(())

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::config::Config;
 use crate::credit::Credit;
+use crate::sched::PriorityQueue;
 use crate::transport::Transport;
 use crate::{
     ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir, StreamId,
@@ -21,7 +22,7 @@ pub struct Session {
     is_server: bool,
     config: Config,
 
-    outbound: mpsc::Sender<Frame>,
+    outbound: PriorityQueue,
     outbound_priority: mpsc::UnboundedSender<Frame>,
 
     accept_bi: Arc<tokio::sync::Mutex<mpsc::Receiver<(SendStream, RecvStream)>>>,
@@ -48,7 +49,7 @@ struct SessionState<T: Transport> {
     config: Config,
     is_server: bool,
 
-    outbound: (mpsc::Sender<Frame>, mpsc::Receiver<Frame>),
+    outbound: PriorityQueue,
     outbound_priority: (mpsc::UnboundedSender<Frame>, mpsc::UnboundedReceiver<Frame>),
 
     accept_bi: mpsc::Sender<(SendStream, RecvStream)>,
@@ -142,7 +143,7 @@ impl<T: Transport> SessionState<T> {
                         None => return Err(Error::Closed),
                     };
                 }
-                frame = self.outbound.1.recv() => {
+                frame = self.outbound.pop() => {
                     match frame {
                         Some(frame) => self.send_frame(frame).await?,
                         None => return Err(Error::Closed),
@@ -356,10 +357,11 @@ impl<T: Transport> SessionState<T> {
 
                                 let send_frontend = SendStream {
                                     id: stream.id,
-                                    outbound: self.outbound.0.clone(),
+                                    outbound: self.outbound.clone(),
                                     outbound_priority: self.outbound_priority.0.clone(),
                                     inbound_stopped: rx,
                                     offset: 0,
+                                    priority: 0,
                                     closed: None,
                                     fin: false,
                                     stream_credit: send_backend.stream_credit.clone(),
@@ -527,7 +529,7 @@ impl Session {
         let (create_uni_tx, create_uni_rx) = mpsc::channel(8);
         let (create_bi_tx, create_bi_rx) = mpsc::channel(8);
 
-        let (outbound_tx, outbound_rx) = mpsc::channel(8);
+        let outbound = PriorityQueue::new(8);
         let (outbound_priority_tx, outbound_priority_rx) = mpsc::unbounded_channel();
 
         let closed = watch::Sender::new(None);
@@ -558,7 +560,7 @@ impl Session {
         let mut backend = SessionState {
             transport,
             config: config.clone(),
-            outbound: (outbound_tx.clone(), outbound_rx),
+            outbound: outbound.clone(),
             outbound_priority: (outbound_priority_tx.clone(), outbound_priority_rx),
             accept_bi: accept_bi_tx,
             accept_uni: accept_uni_tx,
@@ -588,6 +590,7 @@ impl Session {
             backend.open_uni_credit.close();
             backend.conn_send_credit.close();
             backend.conn_recv_credit.close();
+            backend.outbound.close();
             for send in backend.send_streams.values() {
                 if let Some(credit) = &send.stream_credit {
                     credit.close();
@@ -599,7 +602,7 @@ impl Session {
         Session {
             is_server,
             config,
-            outbound: outbound_tx,
+            outbound,
             outbound_priority: outbound_priority_tx,
             accept_bi: Arc::new(tokio::sync::Mutex::new(accept_bi_rx)),
             accept_uni: Arc::new(tokio::sync::Mutex::new(accept_uni_rx)),
@@ -661,6 +664,7 @@ impl generic::Session for Session {
             outbound_priority: self.outbound_priority.clone(),
             inbound_stopped: rx,
             offset: 0,
+            priority: 0,
             closed: None,
             fin: false,
             stream_credit,
@@ -704,6 +708,7 @@ impl generic::Session for Session {
             outbound_priority: self.outbound_priority.clone(),
             inbound_stopped: rx,
             offset: 0,
+            priority: 0,
             closed: None,
             fin: false,
             stream_credit,
@@ -798,11 +803,14 @@ struct SendState {
 pub struct SendStream {
     id: StreamId,
 
-    outbound: mpsc::Sender<Frame>,                   // STREAM
+    outbound: PriorityQueue,                         // STREAM
     outbound_priority: mpsc::UnboundedSender<Frame>, // RESET_STREAM
     inbound_stopped: mpsc::UnboundedReceiver<StopSending>,
 
     offset: u64,
+    /// Scheduling priority (higher = sent first). Threaded into the queue on
+    /// every `push` and relayed to the queue on `set_priority`.
+    priority: u8,
     closed: Option<Error>,
     fin: bool,
 
@@ -936,7 +944,7 @@ impl generic::SendStream for SendStream {
             };
 
             tokio::select! {
-                result = self.outbound.send(frame.into()) => {
+                result = self.outbound.push(self.priority, self.id, frame.into()) => {
                     if result.is_err() {
                         // Release credit since data was never sent
                         self.release_credit(to_send as u64);
@@ -956,8 +964,15 @@ impl generic::SendStream for SendStream {
         Ok(total)
     }
 
-    /// No-op: QMux does not support stream prioritization.
-    fn set_priority(&mut self, _priority: u8) {}
+    /// Set the stream's send priority; higher values are sent first.
+    ///
+    /// Re-prioritization is retroactive: already-queued frames for this stream
+    /// move to the new band on the next scheduling decision (the bytes stay put,
+    /// preserving per-stream order).
+    fn set_priority(&mut self, order: u8) {
+        self.priority = order;
+        self.outbound.set_priority(self.id, order);
+    }
 
     fn reset(&mut self, code: u32) {
         if self.fin || self.closed.is_some() {
@@ -986,10 +1001,14 @@ impl generic::SendStream for SendStream {
             fin: true,
         };
 
-        if let Err(e) = self.outbound.try_send(frame.into()) {
+        // The FIN lands in the stream's current band (after its data). If the
+        // queue is full, hand off to a task that awaits room rather than block.
+        if let Err(frame) = self.outbound.try_push(self.priority, self.id, frame.into()) {
             let outbound = self.outbound.clone();
+            let priority = self.priority;
+            let id = self.id;
             tokio::spawn(async move {
-                outbound.send(e.into_inner()).await.ok();
+                outbound.push(priority, id, frame).await.ok();
             });
         }
 

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -87,34 +87,49 @@ async fn higher_priority_completes_first() {
         hi.write(&vec![b'H'; HI_LEN]).await.unwrap();
         hi.finish().unwrap();
 
-        // Keep the session alive until the peer has drained everything.
-        client.closed().await;
+        // Return the client so the session stays alive and the test can await
+        // this task deterministically rather than detaching it.
+        client
     });
 
     // The server accepts streams in arrival order: lo first, then hi.
-    let mut lo = server.accept_uni().await.unwrap();
+    let lo = server.accept_uni().await.unwrap();
     let mut hi = server.accept_uni().await.unwrap();
 
-    // Drain hi completely; meanwhile lo must NOT have finished yet.
+    // Drain lo in the background while we read hi in the foreground. (We can't
+    // probe lo with lo.closed(): qmux's recv closed() consumes inbound data,
+    // which would corrupt the byte-count assertion below.)
+    let lo_task = tokio::spawn(async move {
+        let mut lo = lo;
+        let mut total = 0usize;
+        while let Some(chunk) = lo.read_chunk(64 * 1024).await.unwrap() {
+            assert!(chunk.iter().all(|&b| b == b'L'));
+            total += chunk.len();
+        }
+        total
+    });
+
     let hi_data = hi.read_all().await.unwrap();
     assert_eq!(hi_data.len(), HI_LEN);
     assert!(hi_data.iter().all(|&b| b == b'H'));
 
-    // Read whatever lo has produced so far. Because hi preempted it, lo should
-    // still have bytes outstanding at the moment hi finished.
-    let mut lo_so_far = 0usize;
-    while let Some(chunk) = lo.read_chunk(64 * 1024).await.unwrap() {
-        lo_so_far += chunk.len();
-        if lo_so_far >= LO_LEN {
-            break;
-        }
-    }
+    // The high-priority stream must finish while the low-priority backlog is
+    // still in-flight — proof that it preempted, not merely that lo arrives.
+    assert!(
+        !lo_task.is_finished(),
+        "low-priority stream should still be in-flight when the high-priority stream completes"
+    );
+
+    let lo_total = lo_task.await.unwrap();
     assert_eq!(
-        lo_so_far, LO_LEN,
+        lo_total, LO_LEN,
         "low-priority stream must still deliver all bytes"
     );
 
-    drop(writer);
+    let _client = tokio::time::timeout(Duration::from_secs(2), writer)
+        .await
+        .expect("writer task should complete")
+        .expect("writer task panicked");
 }
 
 /// Equal-priority streams interleave (round-robin) rather than one draining
@@ -142,7 +157,7 @@ async fn equal_priority_interleaves() {
         };
         tokio::join!(wa, wb);
 
-        client.closed().await;
+        client
     });
 
     let mut a = server.accept_uni().await.unwrap();
@@ -171,7 +186,10 @@ async fn equal_priority_interleaves() {
     assert_eq!(a_total, LEN);
     assert_eq!(b_total, LEN);
 
-    drop(writer);
+    let _client = tokio::time::timeout(Duration::from_secs(2), writer)
+        .await
+        .expect("writer task should complete")
+        .expect("writer task panicked");
 }
 
 /// A control frame (RESET_STREAM, via `reset()`) reaches the peer ahead of a
@@ -245,7 +263,7 @@ async fn mid_stream_set_priority_preserves_order() {
         s.write(&payload[mid..]).await.unwrap();
         s.finish().unwrap();
 
-        client.closed().await;
+        client
     });
 
     let mut filler = server.accept_uni().await.unwrap();
@@ -259,7 +277,11 @@ async fn mid_stream_set_priority_preserves_order() {
     );
 
     let _ = filler.read_all().await;
-    drop(writer);
+
+    let _client = tokio::time::timeout(Duration::from_secs(2), writer)
+        .await
+        .expect("writer task should complete")
+        .expect("writer task panicked");
 }
 
 /// Tearing down the session unblocks a producer parked on a full queue: the

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -1,0 +1,296 @@
+//! Integration tests for per-stream send prioritization.
+//!
+//! These drive a real `Session` over a `ThrottledTransport` whose `send`
+//! sleeps a few milliseconds, so the session's bounded priority queue fills up
+//! and the scheduler's ordering policy actually takes effect (when the socket
+//! accepts everything instantly, prioritization is moot).
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use qmux::{Config, Error, Session, Transport, Version};
+use tokio::sync::mpsc;
+use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
+
+/// An in-memory transport that relays whole messages between a connected pair,
+/// adding a fixed per-`send` delay to create backpressure.
+struct ThrottledTransport {
+    tx: mpsc::Sender<Bytes>,
+    rx: mpsc::Receiver<Bytes>,
+    delay: Duration,
+}
+
+impl Transport for ThrottledTransport {
+    async fn send(&mut self, data: Bytes) -> Result<(), Error> {
+        // The delay is what fills the session's outbound priority queue: while
+        // we're sleeping here, the writer loop can't pull the next frame, so
+        // producers back up behind the capacity bound.
+        tokio::time::sleep(self.delay).await;
+        self.tx.send(data).await.map_err(|_| Error::Closed)
+    }
+
+    async fn recv(&mut self) -> Result<Bytes, Error> {
+        self.rx.recv().await.ok_or(Error::Closed)
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Build a connected client/server session pair over throttled in-memory pipes.
+fn pair(delay: Duration) -> (Session, Session) {
+    let (c2s_tx, c2s_rx) = mpsc::channel(64);
+    let (s2c_tx, s2c_rx) = mpsc::channel(64);
+
+    let client_transport = ThrottledTransport {
+        tx: c2s_tx,
+        rx: s2c_rx,
+        delay,
+    };
+    let server_transport = ThrottledTransport {
+        tx: s2c_tx,
+        rx: c2s_rx,
+        delay,
+    };
+
+    let config = Config::new(Version::QMux01, None);
+    let client = Session::connect(client_transport, config.clone());
+    let server = Session::accept(server_transport, config);
+    (client, server)
+}
+
+/// Higher-priority stream data jumps ahead of a low-priority backlog.
+///
+/// We write a large low-priority payload first (filling the queue), then a
+/// small high-priority one. With prioritization, the high-priority stream's
+/// FIN-terminated data fully arrives while the low-priority stream is still
+/// trickling through.
+#[tokio::test]
+async fn higher_priority_completes_first() {
+    let (client, server) = pair(Duration::from_millis(5));
+
+    const LO_LEN: usize = 200 * 1024;
+    const HI_LEN: usize = 4 * 1024;
+
+    let writer = tokio::spawn(async move {
+        let mut lo = client.open_uni().await.unwrap();
+        let mut hi = client.open_uni().await.unwrap();
+        lo.set_priority(10);
+        hi.set_priority(200);
+
+        // Fill the queue with low-priority data first.
+        lo.write(&vec![b'L'; LO_LEN]).await.unwrap();
+        lo.finish().unwrap();
+
+        // Then enqueue the small high-priority payload.
+        hi.write(&vec![b'H'; HI_LEN]).await.unwrap();
+        hi.finish().unwrap();
+
+        // Keep the session alive until the peer has drained everything.
+        client.closed().await;
+    });
+
+    // The server accepts streams in arrival order: lo first, then hi.
+    let mut lo = server.accept_uni().await.unwrap();
+    let mut hi = server.accept_uni().await.unwrap();
+
+    // Drain hi completely; meanwhile lo must NOT have finished yet.
+    let hi_data = hi.read_all().await.unwrap();
+    assert_eq!(hi_data.len(), HI_LEN);
+    assert!(hi_data.iter().all(|&b| b == b'H'));
+
+    // Read whatever lo has produced so far. Because hi preempted it, lo should
+    // still have bytes outstanding at the moment hi finished.
+    let mut lo_so_far = 0usize;
+    while let Some(chunk) = lo.read_chunk(64 * 1024).await.unwrap() {
+        lo_so_far += chunk.len();
+        if lo_so_far >= LO_LEN {
+            break;
+        }
+    }
+    assert_eq!(
+        lo_so_far, LO_LEN,
+        "low-priority stream must still deliver all bytes"
+    );
+
+    drop(writer);
+}
+
+/// Equal-priority streams interleave (round-robin) rather than one draining
+/// fully before the other starts.
+#[tokio::test]
+async fn equal_priority_interleaves() {
+    let (client, server) = pair(Duration::from_millis(2));
+
+    const LEN: usize = 128 * 1024;
+
+    let writer = tokio::spawn(async move {
+        let mut a = client.open_uni().await.unwrap();
+        let mut b = client.open_uni().await.unwrap();
+        a.set_priority(50);
+        b.set_priority(50);
+
+        // Both write bulk concurrently so frames from each are queued together.
+        let wa = async {
+            a.write(&vec![b'A'; LEN]).await.unwrap();
+            a.finish().unwrap();
+        };
+        let wb = async {
+            b.write(&vec![b'B'; LEN]).await.unwrap();
+            b.finish().unwrap();
+        };
+        tokio::join!(wa, wb);
+
+        client.closed().await;
+    });
+
+    let mut a = server.accept_uni().await.unwrap();
+    let mut b = server.accept_uni().await.unwrap();
+
+    // Read a's first chunk, then check that b has *also* started producing
+    // before a is fully drained — i.e. they interleave.
+    let first_a = a.read_chunk(8 * 1024).await.unwrap().unwrap();
+    assert!(!first_a.is_empty());
+
+    let first_b = b.read_chunk(8 * 1024).await.unwrap().unwrap();
+    assert!(
+        !first_b.is_empty(),
+        "second equal-priority stream must start before the first drains"
+    );
+
+    // Finish draining both for completeness.
+    let mut a_total = first_a.len();
+    while let Some(c) = a.read_chunk(64 * 1024).await.unwrap() {
+        a_total += c.len();
+    }
+    let mut b_total = first_b.len();
+    while let Some(c) = b.read_chunk(64 * 1024).await.unwrap() {
+        b_total += c.len();
+    }
+    assert_eq!(a_total, LEN);
+    assert_eq!(b_total, LEN);
+
+    drop(writer);
+}
+
+/// A control frame (RESET_STREAM, via `reset()`) reaches the peer ahead of a
+/// large data backlog queued on another stream.
+#[tokio::test]
+async fn control_precedes_data_backlog() {
+    let (client, server) = pair(Duration::from_millis(5));
+
+    const LO_LEN: usize = 200 * 1024;
+
+    let mut bulk = client.open_uni().await.unwrap();
+    let mut signal = client.open_uni().await.unwrap();
+    bulk.set_priority(10);
+    signal.write(b"x").await.unwrap();
+
+    // Backlog of bulk data, written concurrently so the queue stays saturated
+    // while we issue the reset below. The writer keeps `client` alive (and thus
+    // the session) until we abort it during cleanup.
+    let bulk_writer = tokio::spawn(async move {
+        bulk.write(&vec![b'B'; LO_LEN]).await.ok();
+        client.closed().await;
+    });
+
+    // Let the bulk backlog build up so the data queue is full.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    // Now reset `signal`. Its RESET_STREAM goes through the control lane and
+    // must preempt the bulk backlog.
+    signal.reset(7);
+
+    // `signal`'s `b"x"` is written before the bulk backlog, so the server
+    // accepts it first.
+    let mut signal_recv = server.accept_uni().await.unwrap();
+
+    // The reset should surface quickly even though `bulk` has a big backlog.
+    // `closed()` returns once the RESET_STREAM is observed.
+    let reset_result = tokio::time::timeout(Duration::from_millis(500), signal_recv.closed()).await;
+    assert!(
+        reset_result.is_ok(),
+        "RESET_STREAM should arrive ahead of the data backlog"
+    );
+    assert!(matches!(reset_result.unwrap(), Err(Error::StreamReset(_))));
+
+    bulk_writer.abort();
+}
+
+/// Raising a stream's priority mid-stream must not corrupt its byte sequence:
+/// the receiver reassembles exactly what was written, in order.
+#[tokio::test]
+async fn mid_stream_set_priority_preserves_order() {
+    let (client, server) = pair(Duration::from_millis(2));
+
+    // A distinctive, position-encoded payload so any reorder/loss is detectable.
+    let payload: Vec<u8> = (0..200 * 1024).map(|i| (i % 251) as u8).collect();
+    let expected = payload.clone();
+
+    let writer = tokio::spawn(async move {
+        // A competing low-priority bulk stream so there's a backlog to reorder against.
+        let mut filler = client.open_uni().await.unwrap();
+        filler.set_priority(1);
+        let mut s = client.open_uni().await.unwrap();
+        s.set_priority(5);
+
+        filler.write(&vec![b'F'; 200 * 1024]).await.unwrap();
+        filler.finish().unwrap();
+
+        // Write the first half at low priority, bump priority, write the rest.
+        let mid = payload.len() / 2;
+        s.write(&payload[..mid]).await.unwrap();
+        s.set_priority(250); // promote mid-stream
+        s.write(&payload[mid..]).await.unwrap();
+        s.finish().unwrap();
+
+        client.closed().await;
+    });
+
+    let mut filler = server.accept_uni().await.unwrap();
+    let mut s = server.accept_uni().await.unwrap();
+
+    let got = s.read_all().await.unwrap();
+    assert_eq!(
+        got.as_ref(),
+        expected.as_slice(),
+        "byte sequence must be intact and in order"
+    );
+
+    let _ = filler.read_all().await;
+    drop(writer);
+}
+
+/// Tearing down the session unblocks a producer parked on a full queue: the
+/// pending `write` returns `Error::Closed`.
+#[tokio::test]
+async fn teardown_unblocks_blocked_writer() {
+    // Long delay so the queue stays full and `write` blocks.
+    let (client, server) = pair(Duration::from_millis(500));
+
+    let mut s = client.open_uni().await.unwrap();
+
+    // Spawn a writer that will fill the queue and then block.
+    let handle = tokio::spawn(async move {
+        // Far more than the 8-frame queue capacity worth of data.
+        s.write(&vec![b'Z'; 1024 * 1024]).await
+    });
+
+    // Give it a moment to fill the queue and park.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !handle.is_finished(),
+        "writer should be blocked on a full queue"
+    );
+
+    // Tear down the session.
+    drop(client);
+    drop(server);
+
+    let result = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("writer should unblock on teardown")
+        .unwrap();
+    assert!(matches!(result, Err(Error::Closed)), "got {result:?}");
+}

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -197,7 +197,8 @@ pub trait SendStream: MaybeSend {
 
     /// Set the stream's priority.
     ///
-    /// Streams with lower values will be sent first, but are not guaranteed to arrive first.
+    /// Streams with higher values will be sent first, but are not guaranteed to arrive first.
+    /// This matches the W3C WebTransport `sendOrder` convention (and quinn's scheduler).
     fn set_priority(&mut self, order: u8);
 
     /// Mark the stream as finished, erroring on any future writes.


### PR DESCRIPTION
## What

Make `rs/qmux` honor per-stream send priority so higher-priority stream data is written first, and fix the trait doc that documented the priority direction backwards.

Control frames were already prioritized (the `biased` select drains `outbound_priority` before data). The gap was *data* ordering: every stream pushed STREAM frames into one bounded FIFO, so a high-priority stream interleaved with a bulk stream purely by arrival order, and `generic::SendStream::set_priority` was a no-op.

## How

- **New `PriorityQueue`** (`rs/qmux/src/sched.rs`) replaces the bounded mpsc data channel. It buckets *ready streams* by priority — `BTreeMap<u8, VecDeque<StreamId>>`, highest served first — over per-stream FIFO frame queues, with round-robin among equal priorities. Backpressure is preserved (bounded total, capacity 8) and `push` is cancel-safe against the `inbound_stopped` race, matching the old channel semantics.
- **`set_priority` is now real and retroactive.** It moves only the stream's *scheduling pointer* between buckets — never its queued frames — so the per-stream offset order the receiver depends on (it appends STREAM data by arrival and ignores the wire offset) is always preserved. This means promoting a stream mid-flight lets it jump a lower-priority backlog without corrupting its own byte order.
- **Direction convention:** higher value = sent first, matching W3C `sendOrder` and quinn (which already passes the value straight through). The `web-transport-trait` doc comment said "lower values will be sent first" — that was simply wrong; corrected here.

## Tests

`rs/qmux/tests/priority.rs` (new), via a throttled transport: high-priority-first under backpressure, equal-priority interleave (fairness), control-frame precedence preserved, mid-stream `set_priority` offset integrity, and teardown unblocking a pending write. Plus 8 `sched` unit tests.

`cargo test -p qmux`: **52 pass** (23 lib incl. 8 new sched, 5 priority, 4 qmux01, 20 wire_format). `cargo clippy -p qmux --all-targets` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)