### PR TITLE
feat(qmux): prioritized send scheduler + @moq/web-socket-stream polyfill

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "web-transport-workspace",
@@ -12,6 +11,9 @@
     "js/qmux": {
       "name": "@moq/qmux",
       "version": "0.1.1",
+      "dependencies": {
+        "@moq/web-socket-stream": "workspace:*",
+      },
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^24.3.0",
@@ -25,6 +27,17 @@
       "devDependencies": {
         "@parcel/transformer-inline-string": "^2.10.3",
         "parcel": "^2.10.3",
+      },
+    },
+    "js/web-socket-stream": {
+      "name": "@moq/web-socket-stream",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "@types/node": "^24.3.0",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2",
       },
     },
     "js/web-transport": {
@@ -178,6 +191,8 @@
     "@mischnic/json-sourcemap": ["@mischnic/json-sourcemap@0.1.1", "", { "dependencies": { "@lezer/common": "^1.0.0", "@lezer/lr": "^1.0.0", "json5": "^2.2.1" } }, "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w=="],
 
     "@moq/qmux": ["@moq/qmux@workspace:js/qmux"],
+
+    "@moq/web-socket-stream": ["@moq/web-socket-stream@workspace:js/web-socket-stream"],
 
     "@moq/web-transport": ["@moq/web-transport@workspace:js/web-transport"],
 

--- a/js/qmux/src/credit.ts
+++ b/js/qmux/src/credit.ts
@@ -1,3 +1,20 @@
+/** Decide the new receive-window limit to advertise (MAX_DATA / MAX_STREAM_DATA).
+ *
+ * Replenishes only when the remaining advertised window has dropped to at most
+ * half, and always sets the new limit relative to bytes the application has
+ * actually **consumed** (`consumed` is cumulative) — never relative to bytes
+ * received. That keeps the peer's send credit bounded to one `window` ahead of
+ * the reader: a stalled reader stops advancing `consumed`, so the limit stops
+ * moving and the peer's credit drains.
+ *
+ * Returns the new limit, or `null` if no update is warranted.
+ */
+export function replenishWindow(consumed: bigint, currentMax: bigint, window: bigint): bigint | null {
+	if (window === 0n) return null;
+	if (currentMax - consumed <= window / 2n) return consumed + window;
+	return null;
+}
+
 /** Tracks used/max credit for flow control.
  *
  * Mirrors the Rust `Credit` struct. Callers can synchronously try to claim

--- a/js/qmux/src/recv.test.ts
+++ b/js/qmux/src/recv.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { replenishWindow } from "./credit.ts";
+import { RecvStream } from "./recv.ts";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("RecvStream", () => {
+	test("delivers buffered chunks in order, crediting each on delivery", async () => {
+		const consumed: number[] = [];
+		const recv = new RecvStream(
+			(b) => consumed.push(b),
+			() => {},
+		);
+		recv.push(new Uint8Array([1]));
+		recv.push(new Uint8Array([2, 2]));
+		recv.push(new Uint8Array([3, 3, 3]));
+		recv.finish();
+
+		const reader = recv.readable.getReader();
+		expect((await reader.read()).value).toEqual(new Uint8Array([1]));
+		expect((await reader.read()).value).toEqual(new Uint8Array([2, 2]));
+		expect((await reader.read()).value).toEqual(new Uint8Array([3, 3, 3]));
+		expect((await reader.read()).done).toBe(true);
+
+		// One onConsume per delivered chunk, by byte length.
+		expect(consumed).toEqual([1, 2, 3]);
+	});
+
+	test("does not credit undelivered data (slow-reader backpressure)", async () => {
+		let consumed = 0;
+		const recv = new RecvStream(
+			(b) => {
+				consumed += b;
+			},
+			() => {},
+		);
+		// Buffer 1000 bytes the application never reads.
+		for (let i = 0; i < 10; i++) recv.push(new Uint8Array(100));
+		await tick();
+
+		// The stream eagerly pulls at most its high-water mark (one chunk); the rest
+		// stays buffered and uncredited until read. Crucially, credit does NOT track
+		// receipt — otherwise this would be 1000.
+		expect(consumed).toBeLessThanOrEqual(100);
+	});
+
+	test("reading resumes crediting", async () => {
+		let consumed = 0;
+		const recv = new RecvStream(
+			(b) => {
+				consumed += b;
+			},
+			() => {},
+		);
+		for (let i = 0; i < 5; i++) recv.push(new Uint8Array(10));
+		await tick();
+		const before = consumed;
+
+		const reader = recv.readable.getReader();
+		await reader.read();
+		await reader.read();
+		await tick();
+
+		expect(consumed).toBeGreaterThan(before);
+	});
+
+	test("finish with no data closes immediately", async () => {
+		const recv = new RecvStream(
+			() => {},
+			() => {},
+		);
+		recv.finish();
+		expect((await recv.readable.getReader().read()).done).toBe(true);
+	});
+
+	test("error aborts the readable and discards buffered data", async () => {
+		const recv = new RecvStream(
+			() => {},
+			() => {},
+		);
+		recv.push(new Uint8Array(50));
+		recv.error(new Error("RESET_STREAM"));
+		await expect(recv.readable.getReader().read()).rejects.toThrow("RESET_STREAM");
+	});
+
+	test("cancel invokes onCancel (STOP_SENDING)", async () => {
+		let cancelled = false;
+		const recv = new RecvStream(
+			() => {},
+			() => {
+				cancelled = true;
+			},
+		);
+		await recv.readable.getReader().cancel();
+		expect(cancelled).toBe(true);
+	});
+});
+
+describe("replenishWindow", () => {
+	const W = 1000n;
+
+	test("no update while more than half the window remains", () => {
+		// Fresh window: max=W, consumed=0 → W remaining → no update.
+		expect(replenishWindow(0n, W, W)).toBeNull();
+		// 400 consumed → 600 remaining (> 500) → no update.
+		expect(replenishWindow(400n, W, W)).toBeNull();
+	});
+
+	test("replenishes relative to consumed once half is reached", () => {
+		// 500 consumed → 500 remaining (≤ half) → new max = consumed + window.
+		expect(replenishWindow(500n, W, W)).toBe(1500n);
+		expect(replenishWindow(900n, W, W)).toBe(1900n);
+	});
+
+	test("bounds the peer to one window beyond consumed", () => {
+		// Simulate a greedy peer + reader consuming W/2 per round; the advertised
+		// limit must stay exactly consumed + window, never drifting upward.
+		let max = W;
+		let consumed = 0n;
+		for (let round = 0; round < 5; round++) {
+			consumed += W / 2n;
+			const next = replenishWindow(consumed, max, W);
+			expect(next).toBe(consumed + W);
+			if (next !== null) max = next;
+			// Unacked-in-flight ceiling = max - consumed is always exactly the window.
+			expect(max - consumed).toBe(W);
+		}
+	});
+
+	test("disabled when window is zero", () => {
+		expect(replenishWindow(0n, 0n, 0n)).toBeNull();
+	});
+});

--- a/js/qmux/src/recv.ts
+++ b/js/qmux/src/recv.ts
@@ -44,7 +44,10 @@ export class RecvStream {
 				}
 				const chunk = this.#queue.shift() as Uint8Array;
 				controller.enqueue(chunk);
-				// Credit only now — the application is receiving these bytes.
+				// Credit must track *delivery*, not receipt — do NOT move onConsume
+				// into push(). This is the line that bounds the peer to one receive
+				// window ahead of a slow reader; crediting on receipt would let the
+				// buffer grow without bound.
 				onConsume(chunk.byteLength);
 			},
 			cancel: () => onCancel(),

--- a/js/qmux/src/recv.ts
+++ b/js/qmux/src/recv.ts
@@ -1,0 +1,82 @@
+/** The receive half of a multiplexed stream.
+ *
+ * Buffers incoming STREAM data and hands it to the application's
+ * `ReadableStream` *on demand* (pull-driven). `onConsume` fires only when bytes
+ * are actually delivered to the reader — never on mere receipt — so flow-control
+ * credit (MAX_STREAM_DATA) tracks the application's read rate. Combined with the
+ * sender claiming credit before sending, this bounds how far the peer can run
+ * ahead of a slow reader: it can buffer at most one receive window of undelivered
+ * data before its credit is exhausted.
+ *
+ * The default queuing strategy (high-water mark 1) means at most one delivered
+ * chunk sits in the `ReadableStream` itself; everything else waits in our buffer
+ * until pulled.
+ */
+export class RecvStream {
+	#queue: Uint8Array[] = [];
+	#fin = false;
+	#error?: Error;
+	#wake?: () => void;
+
+	/** The application-facing readable. */
+	readonly readable: ReadableStream<Uint8Array>;
+
+	/**
+	 * @param onConsume Invoked with each chunk's byte length as it is delivered
+	 *   to the reader. Drives MAX_STREAM_DATA.
+	 * @param onCancel Invoked when the application cancels the readable (→ STOP_SENDING).
+	 */
+	constructor(onConsume: (bytes: number) => void, onCancel: () => void) {
+		this.readable = new ReadableStream<Uint8Array>({
+			pull: async (controller) => {
+				while (this.#queue.length === 0) {
+					if (this.#error) {
+						controller.error(this.#error);
+						return;
+					}
+					if (this.#fin) {
+						controller.close();
+						return;
+					}
+					await new Promise<void>((resolve) => {
+						this.#wake = resolve;
+					});
+				}
+				const chunk = this.#queue.shift() as Uint8Array;
+				controller.enqueue(chunk);
+				// Credit only now — the application is receiving these bytes.
+				onConsume(chunk.byteLength);
+			},
+			cancel: () => onCancel(),
+		});
+	}
+
+	/** Buffer a received chunk for delivery. Ignored after FIN/error. */
+	push(chunk: Uint8Array): void {
+		if (this.#fin || this.#error) return;
+		this.#queue.push(chunk);
+		this.#signal();
+	}
+
+	/** Mark end-of-stream; the readable closes once buffered data drains. */
+	finish(): void {
+		this.#fin = true;
+		this.#signal();
+	}
+
+	/** Abort the readable, discarding undelivered buffered data. */
+	error(err: Error): void {
+		if (this.#error) return;
+		this.#error = err;
+		this.#queue = [];
+		this.#signal();
+	}
+
+	#signal(): void {
+		const wake = this.#wake;
+		if (wake) {
+			this.#wake = undefined;
+			wake();
+		}
+	}
+}

--- a/js/qmux/src/scheduler.test.ts
+++ b/js/qmux/src/scheduler.test.ts
@@ -20,6 +20,9 @@ class GatedSink implements SendSink {
 		this.#onWrite = fn;
 	}
 
+	/** When set, the next `write()` rejects with this error. */
+	failNext?: Error;
+
 	get hasRoom(): boolean {
 		return this.#admits > 0;
 	}
@@ -35,6 +38,11 @@ class GatedSink implements SendSink {
 
 	async write(bytes: Uint8Array): Promise<void> {
 		this.#admits -= 1;
+		if (this.failNext) {
+			const err = this.failNext;
+			this.failNext = undefined;
+			throw err;
+		}
 		this.written.push(bytes[0]);
 		this.#onWrite?.();
 	}
@@ -198,6 +206,42 @@ describe("SendScheduler", () => {
 
 		expect(await settled).toBe("rejected");
 		expect(sink.written).toEqual([99]); // control flushed, stream dropped
+	});
+
+	test("a failed write rejects that stream's promise and tears the scheduler down", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+		sched.setSendOrder(2n, 0);
+
+		const first = sched.enqueueStream(1n, frame(1));
+		const firstSettled = first.then(
+			() => "resolved",
+			(e) => `rejected:${e.message}`,
+		);
+		sink.failNext = new Error("boom");
+		sink.release(1);
+
+		// The in-flight frame's promise rejects with the write error...
+		expect(await firstSettled).toBe("rejected:boom");
+		// ...and the scheduler is now closed, so further enqueues reject too.
+		await expect(sched.enqueueStream(2n, frame(2))).rejects.toThrow("boom");
+		expect(sink.written).toEqual([]);
+	});
+
+	test("enqueueStream rejects a duplicate frame for the same stream", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+
+		const first = sched.enqueueStream(1n, frame(1));
+		// Second enqueue for the same stream before the first is serviced.
+		await expect(sched.enqueueStream(1n, frame(2))).rejects.toThrow("already has a queued frame");
+
+		// The original frame is untouched and still delivers.
+		sink.release(1);
+		await first;
+		expect(sink.written).toEqual([1]);
 	});
 
 	test("onActivity fires once per written frame", async () => {

--- a/js/qmux/src/scheduler.test.ts
+++ b/js/qmux/src/scheduler.test.ts
@@ -33,7 +33,7 @@ class GatedSink implements SendSink {
 		}
 	}
 
-	write(bytes: Uint8Array): void {
+	async write(bytes: Uint8Array): Promise<void> {
 		this.#admits -= 1;
 		this.written.push(bytes[0]);
 		this.#onWrite?.();
@@ -46,11 +46,20 @@ class GatedSink implements SendSink {
 	}
 }
 
-/** Spin the microtask/macrotask queue until `fn()` is true or we give up. */
+/** Yield to the event loop `n` times to let queued work run. */
+async function tick(n = 1): Promise<void> {
+	for (let i = 0; i < n; i++) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+/** Wait until `fn()` is true, throwing if it never becomes true within budget —
+ *  so a scheduler regression fails the test instead of silently proceeding. */
 async function until(fn: () => boolean, tries = 200): Promise<void> {
 	for (let i = 0; i < tries && !fn(); i++) {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
+	if (!fn()) throw new Error("until: condition not met within timeout");
 }
 
 const frame = (tag: number) => new Uint8Array([tag]);
@@ -65,7 +74,7 @@ describe("SendScheduler", () => {
 		void sched.enqueueStream(2n, frame(20));
 		sched.enqueueControl(frame(99));
 
-		await until(() => false, 5); // let everything queue
+		await tick(5); // let everything queue
 		sink.release(3);
 		await until(() => sink.written.length === 3);
 
@@ -83,7 +92,7 @@ describe("SendScheduler", () => {
 		void sched.enqueueStream(2n, frame(1));
 		void sched.enqueueStream(3n, frame(9));
 
-		await until(() => false, 5);
+		await tick(5);
 		sink.release(3);
 		await until(() => sink.written.length === 3);
 
@@ -108,7 +117,7 @@ describe("SendScheduler", () => {
 		armA();
 		armB();
 
-		await until(() => false, 5);
+		await tick(5);
 		sink.release(6);
 		await until(() => sink.written.length === 6);
 
@@ -124,7 +133,7 @@ describe("SendScheduler", () => {
 		void sched.enqueueStream(1n, frame(1));
 		void sched.enqueueStream(2n, frame(2));
 
-		await until(() => false, 5);
+		await tick(5);
 		sched.setSendOrder(2n, 100); // promote stream 2 while both are queued
 		sink.release(2);
 		await until(() => sink.written.length === 2);
@@ -142,7 +151,7 @@ describe("SendScheduler", () => {
 			if (left-- > 0) sched.enqueueStream(1n, frame(1)).then(arm);
 		};
 		arm();
-		await until(() => false, 5);
+		await tick(5);
 
 		sink.release(5); // drain a few stream frames
 		await until(() => sink.written.length === 5);
@@ -165,7 +174,7 @@ describe("SendScheduler", () => {
 		);
 		sched.dropStream(1n, new Error("reset"));
 		sink.release(5);
-		await until(() => false, 10);
+		await tick(10);
 
 		expect(await rejected).toBe("rejected");
 		expect(sink.written).toEqual([]); // nothing written
@@ -199,7 +208,7 @@ describe("SendScheduler", () => {
 		void sched.enqueueStream(1n, frame(1));
 		sched.enqueueControl(frame(99));
 
-		await until(() => false, 5);
+		await tick(5);
 		sink.release(2);
 		await until(() => sink.written.length === 2);
 

--- a/js/qmux/src/scheduler.test.ts
+++ b/js/qmux/src/scheduler.test.ts
@@ -23,10 +23,6 @@ class GatedSink implements SendSink {
 	/** When set, the next `write()` rejects with this error. */
 	failNext?: Error;
 
-	get hasRoom(): boolean {
-		return this.#admits > 0;
-	}
-
 	async ready(): Promise<void> {
 		while (this.#admits <= 0) {
 			await this.#gate;

--- a/js/qmux/src/scheduler.test.ts
+++ b/js/qmux/src/scheduler.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { SendScheduler, type SendSink } from "./scheduler.ts";
+
+/** A sink that starts backpressured; `release()` admits exactly one write. */
+class GatedSink implements SendSink {
+	written: number[] = [];
+	#gate: Promise<void>;
+	#open!: () => void;
+	#admits = 0;
+	#onWrite?: () => void;
+
+	constructor() {
+		this.#gate = new Promise((resolve) => {
+			this.#open = resolve;
+		});
+	}
+
+	/** Record each written frame's first byte so tests can assert ordering. */
+	onWrite(fn: () => void) {
+		this.#onWrite = fn;
+	}
+
+	get hasRoom(): boolean {
+		return this.#admits > 0;
+	}
+
+	async ready(): Promise<void> {
+		while (this.#admits <= 0) {
+			await this.#gate;
+			this.#gate = new Promise((resolve) => {
+				this.#open = resolve;
+			});
+		}
+	}
+
+	write(bytes: Uint8Array): void {
+		this.#admits -= 1;
+		this.written.push(bytes[0]);
+		this.#onWrite?.();
+	}
+
+	/** Allow `n` more writes through. */
+	release(n = 1): void {
+		this.#admits += n;
+		this.#open();
+	}
+}
+
+/** Spin the microtask/macrotask queue until `fn()` is true or we give up. */
+async function until(fn: () => boolean, tries = 200): Promise<void> {
+	for (let i = 0; i < tries && !fn(); i++) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+const frame = (tag: number) => new Uint8Array([tag]);
+
+describe("SendScheduler", () => {
+	test("control frames preempt stream data", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+
+		sched.setSendOrder(1n, 0);
+		void sched.enqueueStream(1n, frame(10));
+		void sched.enqueueStream(2n, frame(20));
+		sched.enqueueControl(frame(99));
+
+		await until(() => false, 5); // let everything queue
+		sink.release(3);
+		await until(() => sink.written.length === 3);
+
+		expect(sink.written[0]).toBe(99); // control first
+	});
+
+	test("higher sendOrder is sent first", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+
+		sched.setSendOrder(1n, 5);
+		sched.setSendOrder(2n, 1);
+		sched.setSendOrder(3n, 9);
+		void sched.enqueueStream(1n, frame(5));
+		void sched.enqueueStream(2n, frame(1));
+		void sched.enqueueStream(3n, frame(9));
+
+		await until(() => false, 5);
+		sink.release(3);
+		await until(() => sink.written.length === 3);
+
+		expect(sink.written).toEqual([9, 5, 1]);
+	});
+
+	test("round-robin among equal sendOrder", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+		sched.setSendOrder(2n, 0);
+
+		// Each stream re-arms after its frame is written, like a real writer task.
+		let aLeft = 3;
+		let bLeft = 3;
+		const armA = () => {
+			if (aLeft-- > 0) sched.enqueueStream(1n, frame(0xa)).then(armA);
+		};
+		const armB = () => {
+			if (bLeft-- > 0) sched.enqueueStream(2n, frame(0xb)).then(armB);
+		};
+		armA();
+		armB();
+
+		await until(() => false, 5);
+		sink.release(6);
+		await until(() => sink.written.length === 6);
+
+		// Strict alternation A,B,A,B,A,B (0xa, 0xb).
+		expect(sink.written).toEqual([0xa, 0xb, 0xa, 0xb, 0xa, 0xb]);
+	});
+
+	test("promoting a stream mid-backlog lets it jump ahead", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+		sched.setSendOrder(2n, 0);
+		void sched.enqueueStream(1n, frame(1));
+		void sched.enqueueStream(2n, frame(2));
+
+		await until(() => false, 5);
+		sched.setSendOrder(2n, 100); // promote stream 2 while both are queued
+		sink.release(2);
+		await until(() => sink.written.length === 2);
+
+		expect(sink.written).toEqual([2, 1]);
+	});
+
+	test("control is not starved by a stream flood", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+
+		let left = 50;
+		const arm = () => {
+			if (left-- > 0) sched.enqueueStream(1n, frame(1)).then(arm);
+		};
+		arm();
+		await until(() => false, 5);
+
+		sink.release(5); // drain a few stream frames
+		await until(() => sink.written.length === 5);
+		sched.enqueueControl(frame(99)); // control arrives mid-flood
+		sink.release(1);
+		await until(() => sink.written.length === 6);
+
+		expect(sink.written[5]).toBe(99); // served on the very next write
+	});
+
+	test("dropStream discards queued data and rejects its promise", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+
+		const p = sched.enqueueStream(1n, frame(1));
+		const rejected = p.then(
+			() => "resolved",
+			() => "rejected",
+		);
+		sched.dropStream(1n, new Error("reset"));
+		sink.release(5);
+		await until(() => false, 10);
+
+		expect(await rejected).toBe("rejected");
+		expect(sink.written).toEqual([]); // nothing written
+	});
+
+	test("close rejects pending stream frames but flushes queued control", async () => {
+		const sink = new GatedSink();
+		const sched = new SendScheduler(sink);
+		sched.setSendOrder(1n, 0);
+
+		const p = sched.enqueueStream(1n, frame(1));
+		const settled = p.then(
+			() => "resolved",
+			() => "rejected",
+		);
+		sched.enqueueControl(frame(99));
+		sched.close(new Error("closing"));
+
+		sink.release(5);
+		await until(() => sink.written.length === 1, 50);
+
+		expect(await settled).toBe("rejected");
+		expect(sink.written).toEqual([99]); // control flushed, stream dropped
+	});
+
+	test("onActivity fires once per written frame", async () => {
+		const sink = new GatedSink();
+		let activity = 0;
+		const sched = new SendScheduler(sink, { onActivity: () => activity++ });
+		sched.setSendOrder(1n, 0);
+		void sched.enqueueStream(1n, frame(1));
+		sched.enqueueControl(frame(99));
+
+		await until(() => false, 5);
+		sink.release(2);
+		await until(() => sink.written.length === 2);
+
+		expect(activity).toBe(2);
+	});
+});

--- a/js/qmux/src/scheduler.ts
+++ b/js/qmux/src/scheduler.ts
@@ -1,0 +1,233 @@
+/** Prioritized send scheduler for a QMux session.
+ *
+ * A single writer loop owns the socket. Frames are written in priority order:
+ * control frames (flow control, resets, pings, close) always preempt stream
+ * data, and among stream data the highest `sendOrder` wins (W3C WebTransport
+ * convention — larger value is sent first), with round-robin among equal
+ * priorities. Prioritization only bites under backpressure; when the sink has
+ * room every frame is written as soon as it's queued.
+ *
+ * The backpressure source is abstracted behind {@link SendSink} so we can use
+ * `WebSocketStream`'s real (event-driven) backpressure where available and fall
+ * back to polling `WebSocket.bufferedAmount` everywhere else.
+ */
+
+/** A write sink over the underlying socket, exposing backpressure. */
+export interface SendSink {
+	/** Resolve once the sink can accept another write without exceeding its
+	 *  high-water mark. Rejects if the socket is closed/errored. */
+	ready(): Promise<void>;
+	/** Write bytes to the socket now. Call only after {@link ready} resolves. */
+	write(bytes: Uint8Array): void;
+	/** Whether a write can proceed right now without buffering past high-water. */
+	readonly hasRoom: boolean;
+}
+
+/** Backpressure-aware sink over a `WebSocketStream` writable. The writable's
+ *  `writer.ready` is the backpressure signal — native `WebSocketStream` ties it
+ *  to the real send buffer, while the `@moq/web-socket-stream` ponyfill drives
+ *  it from `bufferedAmount` against a (resizable) high-water mark. */
+export class WritableStreamSink implements SendSink {
+	#writer: WritableStreamDefaultWriter<Uint8Array>;
+
+	constructor(writable: WritableStream<Uint8Array>) {
+		this.#writer = writable.getWriter();
+	}
+
+	get hasRoom(): boolean {
+		// desiredSize is null once the stream errors/closes.
+		return (this.#writer.desiredSize ?? 0) > 0;
+	}
+
+	ready(): Promise<void> {
+		return this.#writer.ready;
+	}
+
+	write(bytes: Uint8Array): void {
+		// Backpressure is observed via ready(); the write itself is fire-and-forget.
+		void this.#writer.write(bytes).catch(() => {
+			// Surfaced to the loop on the next ready() call, which will reject.
+		});
+	}
+}
+
+/** One stream's single in-flight frame, awaiting its turn on the wire. */
+interface Waiter {
+	seq: number;
+	bytes: Uint8Array;
+	resolve: () => void;
+	reject: (err: Error) => void;
+}
+
+export interface SchedulerOptions {
+	/** Called after each frame is actually written (to track send activity). */
+	onActivity?: () => void;
+	/** Soft cap on buffered control bytes before we warn. */
+	controlHighWater?: number;
+}
+
+/** Default `sendOrder` for streams that don't set one. */
+export const DEFAULT_SEND_ORDER = 0;
+
+export class SendScheduler {
+	#sink: SendSink;
+	#onActivity: () => void;
+	#controlHighWater: number;
+	#closed?: Error;
+
+	// Control frames preempt all stream data, FIFO among themselves.
+	#control: Uint8Array[] = [];
+	#controlBytes = 0;
+
+	// Per-stream send priority and the single pending frame per ready stream.
+	// Invariant: a stream has at most one Waiter at a time, because its writer
+	// task awaits each enqueue before producing the next frame. This keeps
+	// per-stream byte order (offsets) sequential.
+	#sendOrders = new Map<bigint, number>();
+	#ready = new Map<bigint, Waiter>();
+	#seq = 0;
+
+	// Resolver for the loop when it's parked with no work.
+	#wake?: () => void;
+
+	constructor(sink: SendSink, options?: SchedulerOptions) {
+		this.#sink = sink;
+		this.#onActivity = options?.onActivity ?? (() => {});
+		this.#controlHighWater = options?.controlHighWater ?? 256 * 1024;
+		// Start the writer loop. It never rejects — failures are captured by #fail.
+		void this.#run();
+	}
+
+	/** Queue a pre-encoded control frame. Preempts all stream data. */
+	enqueueControl(bytes: Uint8Array): void {
+		if (this.#closed) throw this.#closed;
+		this.#control.push(bytes);
+		this.#controlBytes += bytes.byteLength;
+		if (this.#controlBytes > this.#controlHighWater) {
+			// Control frames now ride behind transport backpressure (the loop), so
+			// they can't flood the socket buffer — but a wedged socket can still let
+			// them pile up in memory. Warn rather than drop: dropping flow-control or
+			// reset frames would corrupt the session.
+			console.warn(`qmux: control backlog ${this.#controlBytes} bytes exceeds high-water`);
+		}
+		this.#signal();
+	}
+
+	/** Set (or update) a stream's send priority. Takes effect immediately,
+	 *  including for the stream's already-queued frame (priority is read at
+	 *  selection time), so promoting a stream lets it jump a lower-priority
+	 *  backlog without reordering its own bytes. */
+	setSendOrder(streamId: bigint, order: number): void {
+		this.#sendOrders.set(streamId, order);
+	}
+
+	/** Queue a stream-data frame. Resolves once the bytes hit the socket;
+	 *  rejects if the session closes or the stream is dropped first. */
+	enqueueStream(streamId: bigint, bytes: Uint8Array): Promise<void> {
+		if (this.#closed) return Promise.reject(this.#closed);
+		return new Promise<void>((resolve, reject) => {
+			this.#ready.set(streamId, { seq: this.#seq++, bytes, resolve, reject });
+			this.#signal();
+		});
+	}
+
+	/** Drop a stream's pending data (reset / abort). Rejects its in-flight frame. */
+	dropStream(streamId: bigint, err: Error): void {
+		this.#sendOrders.delete(streamId);
+		const waiter = this.#ready.get(streamId);
+		if (waiter) {
+			this.#ready.delete(streamId);
+			waiter.reject(err);
+		}
+	}
+
+	/** Forget a stream that finished cleanly (its FIN is already queued/sent).
+	 *  Frees the per-stream priority entry so it doesn't accumulate. */
+	forget(streamId: bigint): void {
+		this.#sendOrders.delete(streamId);
+	}
+
+	/** Close the scheduler: reject all pending stream frames, but let the loop
+	 *  flush any already-queued control frames (e.g. CONNECTION_CLOSE). */
+	close(err: Error): void {
+		if (this.#closed) return;
+		this.#closed = err;
+		for (const waiter of this.#ready.values()) waiter.reject(err);
+		this.#ready.clear();
+		this.#sendOrders.clear();
+		this.#signal();
+	}
+
+	#signal(): void {
+		const wake = this.#wake;
+		if (wake) {
+			this.#wake = undefined;
+			wake();
+		}
+	}
+
+	/** Pick the next stream to service: highest sendOrder, oldest seq to break
+	 *  ties (round-robin, since a stream re-arms with a fresh seq each frame). */
+	#pickStream(): bigint {
+		let bestId: bigint | undefined;
+		let bestOrder = Number.NEGATIVE_INFINITY;
+		let bestSeq = Number.POSITIVE_INFINITY;
+		for (const [id, waiter] of this.#ready) {
+			const order = this.#sendOrders.get(id) ?? DEFAULT_SEND_ORDER;
+			if (order > bestOrder || (order === bestOrder && waiter.seq < bestSeq)) {
+				bestOrder = order;
+				bestSeq = waiter.seq;
+				bestId = id;
+			}
+		}
+		// Non-null: only called when #ready is non-empty.
+		return bestId as bigint;
+	}
+
+	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: invoked from the constructor; Biome's analysis misses the call into this infinite writer loop.
+	async #run(): Promise<void> {
+		try {
+			while (true) {
+				if (this.#control.length === 0 && this.#ready.size === 0) {
+					if (this.#closed) return;
+					await new Promise<void>((resolve) => {
+						this.#wake = resolve;
+					});
+					continue;
+				}
+
+				// Block until the socket can take a write, THEN pick — so a frame
+				// that arrives during backpressure is considered before we commit.
+				await this.#sink.ready();
+
+				if (this.#control.length > 0) {
+					const bytes = this.#control.shift() as Uint8Array;
+					this.#controlBytes -= bytes.byteLength;
+					this.#sink.write(bytes);
+					this.#onActivity();
+					continue;
+				}
+
+				if (this.#closed) return; // closed with only stream frames left (already rejected)
+				if (this.#ready.size === 0) continue;
+
+				const id = this.#pickStream();
+				const waiter = this.#ready.get(id) as Waiter;
+				this.#ready.delete(id);
+				this.#sink.write(waiter.bytes);
+				this.#onActivity();
+				waiter.resolve();
+			}
+		} catch (err) {
+			this.#fail(err instanceof Error ? err : new Error(String(err)));
+		}
+	}
+
+	#fail(err: Error): void {
+		this.#closed ??= err;
+		for (const waiter of this.#ready.values()) waiter.reject(err);
+		this.#ready.clear();
+		this.#control.length = 0;
+		this.#controlBytes = 0;
+	}
+}

--- a/js/qmux/src/scheduler.ts
+++ b/js/qmux/src/scheduler.ts
@@ -17,8 +17,10 @@ export interface SendSink {
 	/** Resolve once the sink can accept another write without exceeding its
 	 *  high-water mark. Rejects if the socket is closed/errored. */
 	ready(): Promise<void>;
-	/** Write bytes to the socket now. Call only after {@link ready} resolves. */
-	write(bytes: Uint8Array): void;
+	/** Write bytes to the socket, resolving once the write is accepted. Rejects
+	 *  if the write fails — the scheduler must observe this rather than resolve
+	 *  the frame's promise as if it succeeded. */
+	write(bytes: Uint8Array): Promise<void>;
 	/** Whether a write can proceed right now without buffering past high-water. */
 	readonly hasRoom: boolean;
 }
@@ -43,11 +45,9 @@ export class WritableStreamSink implements SendSink {
 		return this.#writer.ready;
 	}
 
-	write(bytes: Uint8Array): void {
-		// Backpressure is observed via ready(); the write itself is fire-and-forget.
-		void this.#writer.write(bytes).catch(() => {
-			// Surfaced to the loop on the next ready() call, which will reject.
-		});
+	write(bytes: Uint8Array): Promise<void> {
+		// Propagate failures so the scheduler can reject the frame's promise.
+		return this.#writer.write(bytes);
 	}
 }
 
@@ -125,6 +125,11 @@ export class SendScheduler {
 	 *  rejects if the session closes or the stream is dropped first. */
 	enqueueStream(streamId: bigint, bytes: Uint8Array): Promise<void> {
 		if (this.#closed) return Promise.reject(this.#closed);
+		// Enforce the one-frame-per-stream invariant: a producer must await each
+		// enqueue before the next. A duplicate would orphan the previous promise.
+		if (this.#ready.has(streamId)) {
+			return Promise.reject(new Error(`stream ${streamId} already has a queued frame`));
+		}
 		return new Promise<void>((resolve, reject) => {
 			this.#ready.set(streamId, { seq: this.#seq++, bytes, resolve, reject });
 			this.#signal();
@@ -203,7 +208,7 @@ export class SendScheduler {
 				if (this.#control.length > 0) {
 					const bytes = this.#control.shift() as Uint8Array;
 					this.#controlBytes -= bytes.byteLength;
-					this.#sink.write(bytes);
+					await this.#sink.write(bytes);
 					this.#onActivity();
 					continue;
 				}
@@ -214,7 +219,14 @@ export class SendScheduler {
 				const id = this.#pickStream();
 				const waiter = this.#ready.get(id) as Waiter;
 				this.#ready.delete(id);
-				this.#sink.write(waiter.bytes);
+				try {
+					await this.#sink.write(waiter.bytes);
+				} catch (err) {
+					// The frame never made it; reject this stream's promise (it's no
+					// longer in #ready, so #fail wouldn't) and tear down the rest.
+					waiter.reject(err instanceof Error ? err : new Error(String(err)));
+					throw err;
+				}
 				this.#onActivity();
 				waiter.resolve();
 			}

--- a/js/qmux/src/scheduler.ts
+++ b/js/qmux/src/scheduler.ts
@@ -21,8 +21,6 @@ export interface SendSink {
 	 *  if the write fails — the scheduler must observe this rather than resolve
 	 *  the frame's promise as if it succeeded. */
 	write(bytes: Uint8Array): Promise<void>;
-	/** Whether a write can proceed right now without buffering past high-water. */
-	readonly hasRoom: boolean;
 }
 
 /** Backpressure-aware sink over a `WebSocketStream` writable. The writable's
@@ -34,11 +32,6 @@ export class WritableStreamSink implements SendSink {
 
 	constructor(writable: WritableStream<Uint8Array>) {
 		this.#writer = writable.getWriter();
-	}
-
-	get hasRoom(): boolean {
-		// desiredSize is null once the stream errors/closes.
-		return (this.#writer.desiredSize ?? 0) > 0;
 	}
 
 	ready(): Promise<void> {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as Frame from "./frame.ts";
+import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
+import Session, { type Config } from "./session.ts";
+import * as Stream from "./stream.ts";
+
+// A scripted peer standing in for the `WebSocketStream` transport. The test
+// plays the remote end: it injects frames into the Session's readable and
+// captures frames the Session writes. Installed as `globalThis.WebSocketStream`
+// so `openWebSocketStream` (which Session uses) picks it up instead of the real
+// ponyfill (it's a distinct class, so the `Native !== WebSocketStream` guard
+// holds).
+class FakePeer {
+	static last: FakePeer | undefined;
+
+	readonly url: string;
+	readonly opened: Promise<{
+		readable: ReadableStream<Uint8Array | string>;
+		writable: WritableStream<Uint8Array>;
+		protocol: string;
+		extensions: string;
+	}>;
+	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
+	#closedResolve!: (info: { closeCode?: number; reason?: string }) => void;
+	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
+	#sentWaiters: Array<() => void> = [];
+
+	/** Raw chunks the Session has written. */
+	sent: Uint8Array[] = [];
+	closeInfo: { closeCode?: number; reason?: string } | undefined;
+
+	constructor(url: string) {
+		this.url = url;
+		FakePeer.last = this;
+		const readable = new ReadableStream<Uint8Array | string>({
+			start: (c) => {
+				this.#recv = c;
+			},
+		});
+		const writable = new WritableStream<Uint8Array>({
+			write: (chunk) => {
+				this.sent.push(chunk);
+				for (const w of this.#sentWaiters.splice(0)) w();
+			},
+		});
+		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
+		this.closed = new Promise((resolve) => {
+			this.#closedResolve = resolve;
+		});
+	}
+
+	close(info: { closeCode?: number; reason?: string } = {}) {
+		this.closeInfo = info;
+		this.#closedResolve(info);
+	}
+	setHighWaterMark() {}
+
+	// --- test controls ---
+	/** Inject a frame as if sent by the peer. */
+	send(frame: Frame.Any) {
+		this.#recv.enqueue(Frame.encode(frame, "qmux-01"));
+	}
+	/** Inject a raw text frame (invalid for QMux). */
+	sendText(text: string) {
+		this.#recv.enqueue(text);
+	}
+	/** All frames the Session has written so far, decoded. */
+	received(): Frame.Any[] {
+		return this.sent.flatMap((b) => Frame.decodeRecord(b));
+	}
+}
+
+function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
+	return {
+		maxIdleTimeout: 0n,
+		initialMaxData: 1_000_000n,
+		initialMaxStreamDataBidiLocal: 100_000n,
+		initialMaxStreamDataBidiRemote: 100_000n,
+		initialMaxStreamDataUni: 100_000n,
+		initialMaxStreamsBidi: 100n,
+		initialMaxStreamsUni: 100n,
+		maxRecordSize: DEFAULT_MAX_RECORD_SIZE,
+		...overrides,
+	};
+}
+
+function connect(config?: Config): { session: Session; peer: FakePeer } {
+	(globalThis as { WebSocketStream?: unknown }).WebSocketStream = FakePeer;
+	// Idle timer off so a stray interval can't interfere with the test.
+	const session = new Session("https://example/test", {
+		withoutProtocol: true,
+		config: { maxIdleTimeout: 0n, ...config },
+	});
+	const peer = FakePeer.last as FakePeer;
+	return { session, peer };
+}
+
+/** Yield repeatedly so the Session's async loops (open, read, scheduler) run. */
+async function settle(): Promise<void> {
+	for (let i = 0; i < 10; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("Session integration (scripted peer)", () => {
+	afterEach(() => {
+		delete (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
+	});
+
+	test("handshake: sends TRANSPORT_PARAMETERS and resolves ready", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		await settle();
+		expect(peer.received().some((f) => f.type === "transport_parameters")).toBe(true);
+		session.close();
+	});
+
+	test("a uni stream write produces a STREAM frame on the wire", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+		await settle();
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array([1, 2, 3]));
+		await settle();
+
+		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data | undefined;
+		expect(stream?.data).toEqual(new Uint8Array([1, 2, 3]));
+		session.close();
+	});
+
+	test("close() sends CONNECTION_CLOSE, resolves closed, and is idempotent", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+
+		session.close({ closeCode: 42, reason: "bye" });
+		const info = await session.closed;
+		expect(info).toEqual({ closeCode: 42, reason: "bye" });
+		await settle();
+		expect(peer.received().some((f) => f.type === "connection_close")).toBe(true);
+
+		// Second close is a no-op: the resolved info is unchanged.
+		session.close({ closeCode: 7, reason: "again" });
+		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
+	});
+
+	test("a text frame closes the session with a protocol error", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.sendText("not binary");
+		const info = await session.closed;
+		expect(info.closeCode).toBe(1003);
+	});
+
+	test("MAX_STREAM_DATA is extended on delivery to the app, not on receipt", async () => {
+		// Small per-stream window so a few chunks cross the half-window threshold.
+		const { session, peer } = connect({ maxStreamDataUni: 1000n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+		await settle();
+
+		// Peer opens a server-initiated uni stream and sends 4×200B (=800 ≤ window).
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		for (let i = 0; i < 4; i++) {
+			peer.send({ type: "stream", id, data: new Uint8Array(200), fin: false });
+		}
+		await settle();
+
+		const maxStreamDataCount = () => peer.received().filter((f) => f.type === "max_stream_data").length;
+		// Before the app reads, at most the eagerly-pulled first chunk is delivered
+		// (200B < half the 1000B window), so no window update has gone out.
+		expect(maxStreamDataCount()).toBe(0);
+
+		// App takes the incoming stream and drains it.
+		const reader = session.incomingUnidirectionalStreams.getReader();
+		const { value: incoming } = await reader.read();
+		reader.releaseLock();
+		const streamReader = (incoming as ReadableStream<Uint8Array>).getReader();
+		let got = 0;
+		while (got < 800) {
+			const { value, done } = await streamReader.read();
+			if (done) break;
+			got += value.byteLength;
+		}
+		await settle();
+
+		// Now that the bytes have been delivered, the window has been replenished.
+		expect(got).toBe(800);
+		expect(maxStreamDataCount()).toBeGreaterThan(0);
+		session.close();
+	});
+});

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -23,7 +23,6 @@ class FakePeer {
 	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
 	#closedResolve!: (info: { closeCode?: number; reason?: string }) => void;
 	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
-	#sentWaiters: Array<() => void> = [];
 
 	/** Raw chunks the Session has written. */
 	sent: Uint8Array[] = [];
@@ -40,7 +39,6 @@ class FakePeer {
 		const writable = new WritableStream<Uint8Array>({
 			write: (chunk) => {
 				this.sent.push(chunk);
-				for (const w of this.#sentWaiters.splice(0)) w();
 			},
 		});
 		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
@@ -67,6 +65,21 @@ class FakePeer {
 	/** All frames the Session has written so far, decoded. */
 	received(): Frame.Any[] {
 		return this.sent.flatMap((b) => Frame.decodeRecord(b));
+	}
+	has(type: Frame.Any["type"]): boolean {
+		return this.received().some((f) => f.type === type);
+	}
+	count(type: Frame.Any["type"]): number {
+		return this.received().filter((f) => f.type === type).length;
+	}
+}
+
+/** Poll an observable condition with a bounded timeout (no fixed-yield sleeps). */
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+	const start = Date.now();
+	while (!check()) {
+		if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
+		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
 }
 
@@ -95,21 +108,21 @@ function connect(config?: Config): { session: Session; peer: FakePeer } {
 	return { session, peer };
 }
 
-/** Yield repeatedly so the Session's async loops (open, read, scheduler) run. */
-async function settle(): Promise<void> {
-	for (let i = 0; i < 10; i++) await new Promise((resolve) => setTimeout(resolve, 0));
-}
+const ORIGINAL_WSS = (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
 
 describe("Session integration (scripted peer)", () => {
 	afterEach(() => {
-		delete (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
+		if (ORIGINAL_WSS === undefined) {
+			delete (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
+		} else {
+			(globalThis as { WebSocketStream?: unknown }).WebSocketStream = ORIGINAL_WSS;
+		}
 	});
 
 	test("handshake: sends TRANSPORT_PARAMETERS and resolves ready", async () => {
 		const { session, peer } = connect();
 		await session.ready;
-		await settle();
-		expect(peer.received().some((f) => f.type === "transport_parameters")).toBe(true);
+		await waitFor(() => peer.has("transport_parameters"));
 		session.close();
 	});
 
@@ -117,14 +130,14 @@ describe("Session integration (scripted peer)", () => {
 		const { session, peer } = connect();
 		await session.ready;
 		peer.send({ type: "transport_parameters", params: peerParams() });
-		await settle();
 
+		// createUnidirectionalStream blocks until the peer's stream-count credit arrives.
 		const writable = await session.createUnidirectionalStream();
 		await writable.getWriter().write(new Uint8Array([1, 2, 3]));
-		await settle();
 
-		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data | undefined;
-		expect(stream?.data).toEqual(new Uint8Array([1, 2, 3]));
+		await waitFor(() => peer.has("stream"));
+		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data;
+		expect(stream.data).toEqual(new Uint8Array([1, 2, 3]));
 		session.close();
 	});
 
@@ -133,10 +146,8 @@ describe("Session integration (scripted peer)", () => {
 		await session.ready;
 
 		session.close({ closeCode: 42, reason: "bye" });
-		const info = await session.closed;
-		expect(info).toEqual({ closeCode: 42, reason: "bye" });
-		await settle();
-		expect(peer.received().some((f) => f.type === "connection_close")).toBe(true);
+		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
+		await waitFor(() => peer.has("connection_close"));
 
 		// Second close is a no-op: the resolved info is unchanged.
 		session.close({ closeCode: 7, reason: "again" });
@@ -152,40 +163,43 @@ describe("Session integration (scripted peer)", () => {
 	});
 
 	test("MAX_STREAM_DATA is extended on delivery to the app, not on receipt", async () => {
-		// Small per-stream window so a few chunks cross the half-window threshold.
+		// Small per-stream window so a few delivered chunks cross the half-window threshold.
 		const { session, peer } = connect({ maxStreamDataUni: 1000n });
 		await session.ready;
 		peer.send({ type: "transport_parameters", params: peerParams() });
-		await settle();
 
 		// Peer opens a server-initiated uni stream and sends 4×200B (=800 ≤ window).
 		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
 		for (let i = 0; i < 4; i++) {
 			peer.send({ type: "stream", id, data: new Uint8Array(200), fin: false });
 		}
-		await settle();
+		// A ping after the data acts as a barrier: the Session processes frames in
+		// order, so once we see the PONG, all four STREAM frames have been received.
+		peer.send({ type: "ping_request", sequence: 1n });
+		await waitFor(() => peer.has("ping_response"));
 
-		const maxStreamDataCount = () => peer.received().filter((f) => f.type === "max_stream_data").length;
-		// Before the app reads, at most the eagerly-pulled first chunk is delivered
-		// (200B < half the 1000B window), so no window update has gone out.
-		expect(maxStreamDataCount()).toBe(0);
+		// All bytes are received but not yet delivered to the app (only the eagerly
+		// pulled first chunk, 200B < half the window). Credit-on-receipt would have
+		// already emitted MAX_STREAM_DATA here; credit-on-delivery has not.
+		expect(peer.count("max_stream_data")).toBe(0);
 
 		// App takes the incoming stream and drains it.
 		const reader = session.incomingUnidirectionalStreams.getReader();
-		const { value: incoming } = await reader.read();
+		const { value: incoming, done } = await reader.read();
 		reader.releaseLock();
-		const streamReader = (incoming as ReadableStream<Uint8Array>).getReader();
+		if (done || !incoming) throw new Error("expected an incoming unidirectional stream");
+
+		const streamReader = incoming.getReader();
 		let got = 0;
 		while (got < 800) {
-			const { value, done } = await streamReader.read();
-			if (done) break;
-			got += value.byteLength;
+			const chunk = await streamReader.read();
+			if (chunk.done) break;
+			got += chunk.value.byteLength;
 		}
-		await settle();
-
-		// Now that the bytes have been delivered, the window has been replenished.
 		expect(got).toBe(800);
-		expect(maxStreamDataCount()).toBeGreaterThan(0);
+
+		// Delivering the buffered bytes replenishes the window.
+		await waitFor(() => peer.count("max_stream_data") > 0);
 		session.close();
 	});
 });

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1,7 +1,9 @@
+import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-stream";
 import { Credit } from "./credit.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD } from "./frame.ts";
+import { DEFAULT_SEND_ORDER, SendScheduler, type SendSink, WritableStreamSink } from "./scheduler.ts";
 import * as Stream from "./stream.ts";
 import { VarInt } from "./varint.ts";
 
@@ -123,7 +125,20 @@ export interface SessionOptions extends WebTransportOptions {
 
 	/** QMux flow control configuration. Only used for the QMux wire formats. */
 	config?: Config;
+
+	/** Initial send-buffer high-water mark in bytes, used for write
+	 *  backpressure. Only takes effect when falling back to the
+	 *  `@moq/web-socket-stream` ponyfill (no native `WebSocketStream`); the
+	 *  native API sizes its own send buffer. Defaults to 64 KiB.
+	 *
+	 *  For best throughput *and* prioritization, set this to roughly the
+	 *  bandwidth-delay product (RTT × estimated throughput) and adjust it at
+	 *  runtime with {@link Session.setSendBufferSize}. */
+	sendBufferSize?: number;
 }
+
+/** Default send-buffer high-water mark (bytes) for the WebSocketStream ponyfill. */
+const DEFAULT_SEND_BUFFER_SIZE = 64 * 1024;
 
 /** Get the subprotocol prefix for a QMux wire-format version. */
 function versionPrefix(version: Version): string {
@@ -233,7 +248,12 @@ interface StreamFlowState {
 }
 
 export default class Session implements WebTransport {
-	#ws: WebSocket;
+	// The transport: a native `WebSocketStream` when the platform has one (real
+	// backpressure), otherwise the `@moq/web-socket-stream` ponyfill over a plain
+	// `WebSocket` (bufferedAmount-based backpressure). Either way, one API.
+	#wss?: WebSocketStreamLike;
+	#scheduler?: SendScheduler;
+	#sendBufferSize: number;
 	#isServer = false;
 	#closed?: Error;
 	#closeReason?: Error;
@@ -332,11 +352,11 @@ export default class Session implements WebTransport {
 			options?.versions ?? {},
 			options?.withoutProtocol ?? false,
 		);
-		this.#ws = new WebSocket(toWebSocketUrl(url), subprotocols);
 
 		// Merge user config with defaults
 		this.#config = { ...DEFAULT_CONFIG, ...options?.config };
 		this.#ourParams = configToTransportParams(this.#config);
+		this.#sendBufferSize = options?.sendBufferSize ?? DEFAULT_SEND_BUFFER_SIZE;
 
 		// Recv stream count limits are version-independent.
 		this.#recvBiCredit = new Credit(this.#config.maxStreamsBidi);
@@ -349,12 +369,6 @@ export default class Session implements WebTransport {
 		const closed = Promise.withResolvers<WebTransportCloseInfo>();
 		this.closed = closed.promise;
 		this.#closedResolve = closed.resolve;
-
-		this.#ws.binaryType = "arraybuffer";
-		this.#ws.onopen = () => this.#handleOpen();
-		this.#ws.onmessage = (event) => this.#handleMessage(event);
-		this.#ws.onerror = (event) => this.#handleError(event);
-		this.#ws.onclose = (event) => this.#handleClose(event);
 
 		this.incomingBidirectionalStreams = new ReadableStream<WebTransportBidirectionalStream>({
 			start: (controller) => {
@@ -371,12 +385,72 @@ export default class Session implements WebTransport {
 		if (!this.#incomingBidirectionalStreams || !this.#incomingUnidirectionalStreams) {
 			throw new Error("ReadableStream didn't call start");
 		}
+
+		this.#connect(toWebSocketUrl(url), subprotocols);
 	}
 
-	#handleOpen() {
-		const version = detectVersion(this.#ws.protocol);
+	/** Open the transport via `WebSocketStream` — native when present (real
+	 *  backpressure), else the ponyfill over a plain `WebSocket`. One code path
+	 *  for both, so the path exercised in tests is the one Chromium runs natively. */
+	#connect(url: string, subprotocols: string[]) {
+		const wss = openWebSocketStream(url, {
+			protocols: subprotocols,
+			highWaterMark: this.#sendBufferSize,
+		});
+		this.#wss = wss;
+
+		wss.opened.then(
+			(conn) => {
+				this.#startSession(conn.protocol, new WritableStreamSink(conn.writable));
+				void this.#readLoop(conn.readable.getReader());
+			},
+			(err: unknown) => {
+				if (this.#closed) return;
+				this.#closed = err instanceof Error ? err : new Error("WebSocketStream failed to open");
+				this.#close(1006, "WebSocketStream error");
+			},
+		);
+		wss.closed.then(
+			(info) => {
+				if (this.#closed) return;
+				this.#closed = new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
+				this.#close(info.closeCode ?? 1006, info.reason ?? "");
+			},
+			() => {
+				if (this.#closed) return;
+				this.#closed = new Error("WebSocketStream closed");
+				this.#close(1006, "WebSocketStream error");
+			},
+		);
+	}
+
+	async #readLoop(reader: ReadableStreamDefaultReader<Uint8Array | string>) {
+		try {
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				// QMux is a binary protocol; ignore any text frames.
+				if (typeof value !== "string") this.#onData(value);
+			}
+		} catch (err) {
+			if (this.#closed) return;
+			this.#closed = err instanceof Error ? err : new Error("WebSocketStream read error");
+			this.#close(1006, "WebSocketStream read error");
+		}
+	}
+
+	/** Derive the wire-format version, start the send scheduler, and (for QMux
+	 *  drafts) exchange transport parameters. Shared by both transports. */
+	#startSession(rawProtocol: string, sink: SendSink) {
+		const version = detectVersion(rawProtocol);
 		this.#version = version;
-		this.#protocol = parseProtocol(this.#ws.protocol, version);
+		this.#protocol = parseProtocol(rawProtocol, version);
+
+		this.#scheduler = new SendScheduler(sink, {
+			onActivity: () => {
+				this.#lastSendAt = Date.now();
+			},
+		});
 
 		// QMux drafts wait for the peer's TRANSPORT_PARAMETERS before sending,
 		// so reset the unlimited (webtransport-shaped) defaults to zero credits.
@@ -394,10 +468,7 @@ export default class Session implements WebTransport {
 		this.#readyResolve();
 	}
 
-	#handleMessage(event: MessageEvent) {
-		if (!(event.data instanceof ArrayBuffer)) return;
-
-		const data = new Uint8Array(event.data);
+	#onData(data: Uint8Array) {
 		this.#lastRecvAt = Date.now();
 		try {
 			if (this.#version === "qmux-01") {
@@ -418,20 +489,6 @@ export default class Session implements WebTransport {
 		}
 	}
 
-	#handleError(event: Event) {
-		if (this.#closed) return;
-
-		this.#closed = new Error(`WebSocket error: ${event.type}`);
-		this.#close(1006, "WebSocket error");
-	}
-
-	#handleClose(event: CloseEvent) {
-		if (this.#closed) return;
-
-		this.#closed = new Error(`Connection closed: ${event.code} ${event.reason}`);
-		this.#close(event.code, event.reason);
-	}
-
 	#recvFrame(frame: Frame.Any) {
 		if (frame.type === "stream") {
 			this.#handleStreamFrame(frame);
@@ -441,7 +498,7 @@ export default class Session implements WebTransport {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
 			this.#closeReason = new Error(`Connection closed: ${frame.code.value}: ${frame.reason}`);
-			this.#ws.close();
+			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
 			this.#handleTransportParameters(frame.params);
 		} else if (frame.type === "max_data") {
@@ -522,7 +579,7 @@ export default class Session implements WebTransport {
 		if (now - this.#lastRecvAt > timeoutMs) {
 			// Peer has gone silent past the negotiated limit.
 			this.#closeReason = new Error("idle timeout");
-			this.#ws.close();
+			this.#transportClose();
 			if (this.#idleTimer) clearInterval(this.#idleTimer);
 			return;
 		}
@@ -768,6 +825,7 @@ export default class Session implements WebTransport {
 					},
 					abort: (e) => {
 						console.warn("abort", e);
+						this.#scheduler?.dropStream(streamId, e instanceof Error ? e : new Error("stream aborted"));
 						this.#sendPriorityFrame({
 							type: "reset_stream",
 							id: frame.id,
@@ -778,20 +836,14 @@ export default class Session implements WebTransport {
 						this.#maybeDeleteStreamFlow(streamId);
 					},
 					close: async () => {
-						await Promise.race([
-							this.#sendFrame({
-								type: "stream",
-								id: frame.id,
-								data: new Uint8Array(),
-								fin: true,
-							}),
-							this.closed,
-						]);
+						await Promise.race([this.#sendStreamFin(frame.id), this.closed]);
 
 						this.#sendStreams.delete(streamId);
+						this.#scheduler?.forget(streamId);
 						this.#maybeDeleteStreamFlow(streamId);
 					},
 				});
+				this.#attachSendOrder(writer, streamId, DEFAULT_SEND_ORDER);
 
 				this.#incomingBidirectionalStreams.enqueue({ readable: reader, writable: writer });
 			} else {
@@ -841,6 +893,7 @@ export default class Session implements WebTransport {
 
 		stream.error(new Error(`STOP_SENDING: ${frame.code.value}`));
 		this.#sendStreams.delete(streamId);
+		this.#scheduler?.dropStream(streamId, new Error(`STOP_SENDING: ${frame.code.value}`));
 
 		this.#sendPriorityFrame({
 			type: "reset_stream",
@@ -852,17 +905,14 @@ export default class Session implements WebTransport {
 	}
 
 	#sendTransportParameters() {
-		const frame: Frame.TransportParameters = {
-			type: "transport_parameters",
-			params: this.#ourParams,
-		};
 		// QMux01 over WebSocket uses the WS message boundary as the implicit record
-		// boundary; no extra size prefix is required.
-		this.#sendBytes(Frame.encode(frame, this.#version));
+		// boundary; no extra size prefix is required. This is the first frame on the
+		// wire, so it leads the control queue ahead of any stream data.
+		this.#sendPriorityFrame({ type: "transport_parameters", params: this.#ourParams });
 	}
 
-	/** Send raw frame bytes, validating against the peer's max_record_size for QMux01. */
-	#sendBytes(bytes: Uint8Array) {
+	/** Validate an encoded record against the peer's max_record_size (QMux01). */
+	#validateRecordSize(bytes: Uint8Array) {
 		if (this.#version === "qmux-01") {
 			// Before the peer's TRANSPORT_PARAMETERS arrive, use the draft-01 default
 			// (16382) so we don't accidentally send something the peer will reject.
@@ -871,8 +921,15 @@ export default class Session implements WebTransport {
 				throw new Error(`record exceeds peer max_record_size (${bytes.byteLength} > ${limit})`);
 			}
 		}
-		this.#ws.send(bytes);
-		this.#lastSendAt = Date.now();
+	}
+
+	/** Encode and enqueue a stream-data/fin frame, resolving once it hits the wire. */
+	async #enqueueStreamFrame(streamId: bigint, frame: Frame.Data) {
+		const scheduler = this.#scheduler;
+		if (!scheduler) throw this.#closed ?? new Error("session not open");
+		const bytes = Frame.encode(frame, this.#version);
+		this.#validateRecordSize(bytes);
+		await scheduler.enqueueStream(streamId, bytes);
 	}
 
 	async #sendStreamDataWithFlowControl(id: Stream.Id, streamId: bigint, data: Uint8Array) {
@@ -896,12 +953,7 @@ export default class Session implements WebTransport {
 			const chunk = data.subarray(offset, offset + sendable);
 
 			try {
-				await this.#sendFrame({
-					type: "stream",
-					id,
-					data: chunk,
-					fin: false,
-				});
+				await this.#enqueueStreamFrame(streamId, { type: "stream", id, data: chunk, fin: false });
 			} catch (e) {
 				// Return claimed credits on send failure
 				if (sendable > 0) {
@@ -924,35 +976,48 @@ export default class Session implements WebTransport {
 			for (let offset = 0; offset < data.byteLength; offset += MAX_FRAME_PAYLOAD) {
 				const end = Math.min(offset + MAX_FRAME_PAYLOAD, data.byteLength);
 				const chunk = data.subarray(offset, end);
-				await this.#sendFrame({
-					type: "stream",
-					id,
-					data: chunk,
-					fin: false,
-				});
+				await this.#enqueueStreamFrame(streamId, { type: "stream", id, data: chunk, fin: false });
 			}
 		}
 	}
 
-	async #sendFrame(frame: Frame.Any) {
-		// Add some backpressure so we don't saturate the connection
-		while (this.#ws.bufferedAmount > 64 * 1024) {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-		}
-
-		this.#sendBytes(Frame.encode(frame, this.#version));
+	/** Send the FIN. Routed through the stream's own queue so it stays ordered
+	 *  after that stream's data (not via the control lane, which would jump ahead). */
+	async #sendStreamFin(id: Stream.Id) {
+		await this.#enqueueStreamFrame(id.value.value, { type: "stream", id, data: new Uint8Array(), fin: true });
 	}
 
 	#sendPriorityFrame(frame: Frame.Any) {
-		this.#sendBytes(Frame.encode(frame, this.#version));
+		const bytes = Frame.encode(frame, this.#version);
+		this.#validateRecordSize(bytes);
+		this.#scheduler?.enqueueControl(bytes);
 	}
 
-	async createBidirectionalStream(): Promise<WebTransportBidirectionalStream> {
+	/** Register a stream's initial send priority and expose a mutable `sendOrder`
+	 *  accessor on its writable (matching the W3C `WebTransportSendStream` API).
+	 *  Updating it re-prioritizes the stream's queued data immediately. */
+	#attachSendOrder(writable: WritableStream<Uint8Array>, streamId: bigint, initial: number) {
+		this.#scheduler?.setSendOrder(streamId, initial);
+		let order = initial;
+		Object.defineProperty(writable, "sendOrder", {
+			configurable: true,
+			enumerable: true,
+			get: () => order,
+			set: (value: number) => {
+				order = value;
+				this.#scheduler?.setSendOrder(streamId, value);
+			},
+		});
+	}
+
+	async createBidirectionalStream(options?: WebTransportSendStreamOptions): Promise<WebTransportBidirectionalStream> {
 		await this.ready;
 
 		if (this.#closed) {
 			throw this.#closeReason || new Error("Connection closed");
 		}
+
+		const sendOrder = options?.sendOrder ?? DEFAULT_SEND_ORDER;
 
 		// Wait for stream count permit
 		await this.#bidiStreamCredit.claim(1n);
@@ -979,6 +1044,7 @@ export default class Session implements WebTransport {
 			},
 			abort: (e) => {
 				console.warn("abort", e);
+				this.#scheduler?.dropStream(streamIdVal, e instanceof Error ? e : new Error("stream aborted"));
 				this.#sendPriorityFrame({
 					type: "reset_stream",
 					id: streamId,
@@ -989,20 +1055,14 @@ export default class Session implements WebTransport {
 				this.#maybeDeleteStreamFlow(streamIdVal);
 			},
 			close: async () => {
-				await Promise.race([
-					this.#sendFrame({
-						type: "stream",
-						id: streamId,
-						data: new Uint8Array(),
-						fin: true,
-					}),
-					this.closed,
-				]);
+				await Promise.race([this.#sendStreamFin(streamId), this.closed]);
 
 				this.#sendStreams.delete(streamIdVal);
+				this.#scheduler?.forget(streamIdVal);
 				this.#maybeDeleteStreamFlow(streamIdVal);
 			},
 		});
+		this.#attachSendOrder(writer, streamIdVal, sendOrder);
 
 		const reader = new ReadableStream<Uint8Array>({
 			start: (controller) => {
@@ -1023,12 +1083,14 @@ export default class Session implements WebTransport {
 		return { readable: reader, writable: writer };
 	}
 
-	async createUnidirectionalStream(): Promise<WritableStream<Uint8Array>> {
+	async createUnidirectionalStream(options?: WebTransportSendStreamOptions): Promise<WritableStream<Uint8Array>> {
 		await this.ready;
 
 		if (this.#closed) {
 			throw this.#closed;
 		}
+
+		const sendOrder = options?.sendOrder ?? DEFAULT_SEND_ORDER;
 
 		// Wait for stream count permit
 		await this.#uniStreamCredit.claim(1n);
@@ -1057,6 +1119,7 @@ export default class Session implements WebTransport {
 			},
 			abort(e) {
 				console.warn("abort", e);
+				session.#scheduler?.dropStream(streamIdVal, e instanceof Error ? e : new Error("stream aborted"));
 				session.#sendPriorityFrame({
 					type: "reset_stream",
 					id: streamId,
@@ -1067,20 +1130,14 @@ export default class Session implements WebTransport {
 				session.#maybeDeleteStreamFlow(streamIdVal);
 			},
 			async close() {
-				await Promise.race([
-					session.#sendFrame({
-						type: "stream",
-						id: streamId,
-						data: new Uint8Array(),
-						fin: true,
-					}),
-					session.closed,
-				]);
+				await Promise.race([session.#sendStreamFin(streamId), session.closed]);
 
 				session.#sendStreams.delete(streamIdVal);
+				session.#scheduler?.forget(streamIdVal);
 				session.#maybeDeleteStreamFlow(streamIdVal);
 			},
 		});
+		this.#attachSendOrder(writer, streamIdVal, sendOrder);
 
 		return writer;
 	}
@@ -1127,6 +1184,19 @@ export default class Session implements WebTransport {
 		this.#uniStreamCredit.close();
 		this.#recvBiCredit.close();
 		this.#recvUniCredit.close();
+
+		// Reject pending stream writes; already-queued control (e.g. CONNECTION_CLOSE)
+		// still flushes before the socket is torn down.
+		this.#scheduler?.close(this.#closed ?? this.#closeReason ?? new Error("Connection closed"));
+	}
+
+	/** Tear down the underlying transport. The meaningful close code/reason
+	 *  already travels in the CONNECTION_CLOSE frame, so the WebSocket-level
+	 *  close is bare (avoids the WebSocket close-code validity constraints). */
+	#transportClose() {
+		try {
+			this.#wss?.close();
+		} catch {}
 	}
 
 	close(info?: { closeCode?: number; reason?: string }) {
@@ -1142,10 +1212,23 @@ export default class Session implements WebTransport {
 		});
 
 		setTimeout(() => {
-			this.#ws.close();
+			this.#transportClose();
 		}, 100);
 
 		this.#close(code, reason);
+	}
+
+	/** Resize the send-buffer high-water mark (bytes) used for write
+	 *  backpressure. A QMux extension beyond the standard `WebTransport` API:
+	 *  set this to roughly the bandwidth-delay product (RTT × estimated
+	 *  throughput) to keep the pipe full while leaving as much queued data as
+	 *  possible reprioritizable by the send scheduler.
+	 *
+	 *  No-op when a native `WebSocketStream` is in use (it sizes its own send
+	 *  buffer); effective with the `@moq/web-socket-stream` ponyfill fallback. */
+	setSendBufferSize(bytes: number) {
+		this.#sendBufferSize = Math.max(1, Math.floor(bytes));
+		this.#wss?.setHighWaterMark?.(this.#sendBufferSize);
 	}
 
 	get congestionControl(): string {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1,8 +1,9 @@
 import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-stream";
-import { Credit } from "./credit.ts";
+import { Credit, replenishWindow } from "./credit.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD } from "./frame.ts";
+import { RecvStream } from "./recv.ts";
 import { DEFAULT_SEND_ORDER, SendScheduler, type SendSink, WritableStreamSink } from "./scheduler.ts";
 import * as Stream from "./stream.ts";
 import { VarInt } from "./varint.ts";
@@ -259,7 +260,7 @@ export default class Session implements WebTransport {
 	#closeReason?: Error;
 
 	#sendStreams = new Map<bigint, WritableStreamDefaultController>();
-	#recvStreams = new Map<bigint, ReadableStreamDefaultController<Uint8Array>>();
+	#recvStreams = new Map<bigint, RecvStream>();
 
 	#nextUniStreamId = 0n;
 	#nextBiStreamId = 0n;
@@ -653,32 +654,33 @@ export default class Session implements WebTransport {
 		return true;
 	}
 
-	#accountConsumed(streamId: bigint, bytes: number) {
+	/** Connection-level credit. Accounted at receipt: MAX_DATA is a coarse
+	 *  aggregate limit, and per-stream backpressure (below) is what throttles a
+	 *  slow reader. `recvDataConsumed` is cumulative. */
+	#accountConnConsumed(bytes: number) {
 		if (!isQmux(this.#version) || bytes === 0) return;
-
-		// Track connection-level consumed (stable, not reset by per-stream updates)
 		this.#recvDataConsumed += BigInt(bytes);
+		this.#maybeSendMaxData();
+	}
 
+	/** Stream-level credit. Accounted on *delivery* to the application (driven by
+	 *  RecvStream.onConsume), so MAX_STREAM_DATA tracks the read rate and the peer
+	 *  can't buffer more than one window ahead of a slow reader. `recvConsumed`
+	 *  is cumulative. */
+	#accountStreamConsumed(streamId: bigint, bytes: number) {
+		if (!isQmux(this.#version) || bytes === 0) return;
 		const flow = this.#streamFlow.get(streamId);
 		if (flow) {
 			flow.recvConsumed += BigInt(bytes);
 			this.#maybeSendMaxStreamData(streamId, flow);
 		}
-		this.#maybeSendMaxData();
 	}
 
 	#maybeSendMaxData() {
-		const window = this.#ourParams.initialMaxData;
-		if (window === 0n) return;
-
-		const threshold = window / 2n;
-		if (this.#recvDataConsumed >= threshold) {
-			const newMax = this.#recvDataOffset + window;
-			if (newMax > this.#recvDataMax) {
-				this.#recvDataMax = newMax;
-				this.#recvDataConsumed = 0n;
-				this.#sendPriorityFrame({ type: "max_data", max: newMax });
-			}
+		const newMax = replenishWindow(this.#recvDataConsumed, this.#recvDataMax, this.#ourParams.initialMaxData);
+		if (newMax !== null) {
+			this.#recvDataMax = newMax;
+			this.#sendPriorityFrame({ type: "max_data", max: newMax });
 		}
 	}
 
@@ -696,16 +698,12 @@ export default class Session implements WebTransport {
 			initialWindow = this.#ourParams.initialMaxStreamDataUni;
 		}
 
-		if (initialWindow === 0n) return;
-
-		const threshold = initialWindow / 2n;
-		if (flow.recvConsumed >= threshold) {
-			const newMax = flow.recvOffset + initialWindow;
-			if (newMax > flow.recvMax) {
-				flow.recvMax = newMax;
-				flow.recvConsumed = 0n;
-				this.#sendPriorityFrame({ type: "max_stream_data", id, max: newMax });
-			}
+		// `recvConsumed` only grows on delivery to the application, so a stalled
+		// reader stops replenishing and the peer's send credit drains to the window.
+		const newMax = replenishWindow(flow.recvConsumed, flow.recvMax, initialWindow);
+		if (newMax !== null) {
+			flow.recvMax = newMax;
+			this.#sendPriorityFrame({ type: "max_stream_data", id, max: newMax });
 		}
 	}
 
@@ -747,8 +745,8 @@ export default class Session implements WebTransport {
 			throw new Error("Invalid stream ID direction");
 		}
 
-		let stream = this.#recvStreams.get(streamId);
-		if (!stream) {
+		let recv = this.#recvStreams.get(streamId);
+		if (!recv) {
 			// We created the stream, we can skip it.
 			if (frame.id.serverInitiated === this.#isServer) {
 				return;
@@ -792,12 +790,9 @@ export default class Session implements WebTransport {
 				return;
 			}
 
-			const reader = new ReadableStream<Uint8Array>({
-				start: (controller) => {
-					stream = controller;
-					this.#recvStreams.set(streamId, controller);
-				},
-				cancel: () => {
+			const recvStream = new RecvStream(
+				(bytes) => this.#accountStreamConsumed(streamId, bytes),
+				() => {
 					this.#sendPriorityFrame({
 						type: "stop_sending",
 						id: frame.id,
@@ -808,11 +803,10 @@ export default class Session implements WebTransport {
 					this.#replenishStreamCredit(frame.id.dir);
 					this.#maybeDeleteStreamFlow(streamId);
 				},
-			});
-
-			if (!stream) {
-				throw new Error("ReadableStream didn't call start");
-			}
+			);
+			this.#recvStreams.set(streamId, recvStream);
+			recv = recvStream;
+			const reader = recvStream.readable;
 
 			if (frame.id.dir === Stream.Dir.Bi) {
 				// Incoming bidirectional stream
@@ -858,13 +852,14 @@ export default class Session implements WebTransport {
 		}
 
 		if (frame.data.byteLength > 0) {
-			stream.enqueue(frame.data);
-			// Account consumed when data is enqueued to the reader
-			this.#accountConsumed(streamId, frame.data.byteLength);
+			recv.push(frame.data);
+			// Connection-level credit at receipt; stream-level credit is deferred to
+			// delivery (RecvStream.onConsume) so a slow reader backpressures the peer.
+			this.#accountConnConsumed(frame.data.byteLength);
 		}
 
 		if (frame.fin) {
-			stream.close();
+			recv.finish();
 			this.#recvStreams.delete(streamId);
 			if (frame.id.serverInitiated !== this.#isServer) {
 				this.#replenishStreamCredit(frame.id.dir);
@@ -875,10 +870,10 @@ export default class Session implements WebTransport {
 
 	#handleResetStream(frame: Frame.ResetStream) {
 		const streamId = frame.id.value.value;
-		const stream = this.#recvStreams.get(streamId);
-		if (!stream) return;
+		const recv = this.#recvStreams.get(streamId);
+		if (!recv) return;
 
-		stream.error(new Error(`RESET_STREAM: ${frame.code.value}`));
+		recv.error(new Error(`RESET_STREAM: ${frame.code.value}`));
 		this.#recvStreams.delete(streamId);
 		if (frame.id.serverInitiated !== this.#isServer) {
 			this.#replenishStreamCredit(frame.id.dir);
@@ -1064,11 +1059,9 @@ export default class Session implements WebTransport {
 		});
 		this.#attachSendOrder(writer, streamIdVal, sendOrder);
 
-		const reader = new ReadableStream<Uint8Array>({
-			start: (controller) => {
-				this.#recvStreams.set(streamIdVal, controller);
-			},
-			cancel: async () => {
+		const recvStream = new RecvStream(
+			(bytes) => this.#accountStreamConsumed(streamIdVal, bytes),
+			() => {
 				this.#sendPriorityFrame({
 					type: "stop_sending",
 					id: streamId,
@@ -1078,9 +1071,10 @@ export default class Session implements WebTransport {
 				this.#recvStreams.delete(streamIdVal);
 				this.#maybeDeleteStreamFlow(streamIdVal);
 			},
-		});
+		);
+		this.#recvStreams.set(streamIdVal, recvStream);
 
-		return { readable: reader, writable: writer };
+		return { readable: recvStream.readable, writable: writer };
 	}
 
 	async createUnidirectionalStream(options?: WebTransportSendStreamOptions): Promise<WritableStream<Uint8Array>> {
@@ -1164,9 +1158,10 @@ export default class Session implements WebTransport {
 				c.error(this.#closed);
 			} catch {}
 		}
-		for (const c of this.#recvStreams.values()) {
+		const closeErr = this.#closed ?? this.#closeReason ?? new Error("Connection closed");
+		for (const recv of this.#recvStreams.values()) {
 			try {
-				c.error(this.#closed);
+				recv.error(closeErr);
 			} catch {}
 		}
 		this.#sendStreams.clear();

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -544,8 +544,12 @@ export default class Session implements WebTransport {
 		this.#bidiStreamCredit.increaseMax(params.initialMaxStreamsBidi);
 		this.#uniStreamCredit.increaseMax(params.initialMaxStreamsUni);
 
-		// Update per-stream send credits for locally-opened streams created before params arrived.
-		// Peer-opened streams can't exist yet (params are the first frame on the wire).
+		// Update per-stream send credits for streams created before params arrived.
+		// The direction-only limit below is correct for locally-opened streams; we
+		// rely on a conforming peer sending TRANSPORT_PARAMETERS as its first frame,
+		// so no peer-opened stream exists here yet. This is NOT enforced — a peer
+		// that interleaved a STREAM frame ahead of its params would be mis-credited
+		// (a peer-opened bidi stream's send limit is bidi_local, cf. #handleStreamFrame).
 		for (const [streamIdVal, flow] of this.#streamFlow) {
 			const id = new Stream.Id(VarInt.from(streamIdVal));
 			const sendLimit =
@@ -600,8 +604,10 @@ export default class Session implements WebTransport {
 			this.#nextPingSeq = (this.#nextPingSeq + 1) >>> 0;
 			try {
 				this.#sendPriorityFrame({ type: "ping_request", sequence: BigInt(seq) });
-			} catch {
+			} catch (e) {
 				// Best effort — if the send fails, the close path will fire shortly.
+				// Log a breadcrumb so a never-fire encoder bug doesn't vanish silently.
+				console.warn("qmux: keep-alive ping failed", e);
 			}
 		}
 	}
@@ -824,7 +830,7 @@ export default class Session implements WebTransport {
 						this.#sendStreams.set(streamId, controller);
 					},
 					write: async (chunk) => {
-						await Promise.race([this.#sendStreamData(frame.id, chunk), this.closed]);
+						await this.#sendStreamData(frame.id, chunk);
 					},
 					abort: (e) => {
 						console.warn("abort", e);
@@ -839,7 +845,7 @@ export default class Session implements WebTransport {
 						this.#maybeDeleteStreamFlow(streamId);
 					},
 					close: async () => {
-						await Promise.race([this.#sendStreamFin(frame.id), this.closed]);
+						await this.#sendStreamFin(frame.id);
 
 						this.#sendStreams.delete(streamId);
 						this.#scheduler?.forget(streamId);
@@ -992,6 +998,10 @@ export default class Session implements WebTransport {
 	}
 
 	#sendPriorityFrame(frame: Frame.Any) {
+		// Once closed, the scheduler rejects new control frames; a late reset/stop
+		// from a stream teardown callback must be a no-op, not a throw. (The
+		// graceful CONNECTION_CLOSE is enqueued before #close sets #closed.)
+		if (this.#closed) return;
 		const bytes = Frame.encode(frame, this.#version);
 		this.#validateRecordSize(bytes);
 		this.#scheduler?.enqueueControl(bytes);
@@ -1044,7 +1054,7 @@ export default class Session implements WebTransport {
 				this.#sendStreams.set(streamIdVal, controller);
 			},
 			write: async (chunk) => {
-				await Promise.race([this.#sendStreamData(streamId, chunk), this.closed]);
+				await this.#sendStreamData(streamId, chunk);
 			},
 			abort: (e) => {
 				console.warn("abort", e);
@@ -1059,7 +1069,7 @@ export default class Session implements WebTransport {
 				this.#maybeDeleteStreamFlow(streamIdVal);
 			},
 			close: async () => {
-				await Promise.race([this.#sendStreamFin(streamId), this.closed]);
+				await this.#sendStreamFin(streamId);
 
 				this.#sendStreams.delete(streamIdVal);
 				this.#scheduler?.forget(streamIdVal);
@@ -1118,7 +1128,7 @@ export default class Session implements WebTransport {
 				session.#sendStreams.set(streamIdVal, controller);
 			},
 			async write(chunk) {
-				await Promise.race([session.#sendStreamData(streamId, chunk), session.closed]);
+				await session.#sendStreamData(streamId, chunk);
 			},
 			abort(e) {
 				console.warn("abort", e);
@@ -1133,7 +1143,7 @@ export default class Session implements WebTransport {
 				session.#maybeDeleteStreamFlow(streamIdVal);
 			},
 			async close() {
-				await Promise.race([session.#sendStreamFin(streamId), session.closed]);
+				await session.#sendStreamFin(streamId);
 
 				session.#sendStreams.delete(streamIdVal);
 				session.#scheduler?.forget(streamIdVal);

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -281,6 +281,7 @@ export default class Session implements WebTransport {
 
 	readonly ready: Promise<void>;
 	#readyResolve: () => void;
+	#readyReject: (err: Error) => void;
 	readonly closed: Promise<WebTransportCloseInfo>;
 	#closedResolve: (info: WebTransportCloseInfo) => void;
 
@@ -366,6 +367,10 @@ export default class Session implements WebTransport {
 		const ready = Promise.withResolvers<void>();
 		this.ready = ready.promise;
 		this.#readyResolve = ready.resolve;
+		this.#readyReject = ready.reject;
+		// Avoid an unhandled rejection if `ready` is rejected (early close) before
+		// the caller attaches a handler; real awaiters still observe the rejection.
+		this.ready.catch(() => {});
 
 		const closed = Promise.withResolvers<WebTransportCloseInfo>();
 		this.closed = closed.promise;
@@ -402,24 +407,23 @@ export default class Session implements WebTransport {
 
 		wss.opened.then(
 			(conn) => {
+				// The session may have been closed before the socket finished opening.
+				if (this.#closed) return;
 				this.#startSession(conn.protocol, new WritableStreamSink(conn.writable));
 				void this.#readLoop(conn.readable.getReader());
 			},
 			(err: unknown) => {
-				if (this.#closed) return;
-				this.#closed = err instanceof Error ? err : new Error("WebSocketStream failed to open");
+				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream failed to open");
 				this.#close(1006, "WebSocketStream error");
 			},
 		);
 		wss.closed.then(
 			(info) => {
-				if (this.#closed) return;
-				this.#closed = new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
+				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
 				this.#close(info.closeCode ?? 1006, info.reason ?? "");
 			},
 			() => {
-				if (this.#closed) return;
-				this.#closed = new Error("WebSocketStream closed");
+				this.#closeReason ??= new Error("WebSocketStream closed");
 				this.#close(1006, "WebSocketStream error");
 			},
 		);
@@ -430,12 +434,16 @@ export default class Session implements WebTransport {
 			while (true) {
 				const { value, done } = await reader.read();
 				if (done) break;
-				// QMux is a binary protocol; ignore any text frames.
-				if (typeof value !== "string") this.#onData(value);
+				// QMux is binary-only; a text frame is a protocol error, not something
+				// to silently drop (which would desync the session).
+				if (typeof value === "string") {
+					this.close({ closeCode: 1003, reason: "text frames are not valid for QMux" });
+					return;
+				}
+				this.#onData(value);
 			}
 		} catch (err) {
-			if (this.#closed) return;
-			this.#closed = err instanceof Error ? err : new Error("WebSocketStream read error");
+			this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream read error");
 			this.#close(1006, "WebSocketStream read error");
 		}
 	}
@@ -498,7 +506,8 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
-			this.#closeReason = new Error(`Connection closed: ${frame.code.value}: ${frame.reason}`);
+			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value}: ${frame.reason}`);
+			this.#close(Number(frame.code.value), frame.reason);
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
 			this.#handleTransportParameters(frame.params);
@@ -579,9 +588,9 @@ export default class Session implements WebTransport {
 		const now = Date.now();
 		if (now - this.#lastRecvAt > timeoutMs) {
 			// Peer has gone silent past the negotiated limit.
-			this.#closeReason = new Error("idle timeout");
+			this.#closeReason ??= new Error("idle timeout");
+			this.#close(0, "idle timeout");
 			this.#transportClose();
-			if (this.#idleTimer) clearInterval(this.#idleTimer);
 			return;
 		}
 		// Keep-alive: nudge the peer when our outbound side has been silent for a third
@@ -1136,11 +1145,21 @@ export default class Session implements WebTransport {
 		return writer;
 	}
 
+	/** The single, idempotent close transition: marks the session closed, settles
+	 *  `ready`/`closed`, and tears down streams, credits, and the scheduler.
+	 *  Protocol-close paths route through here before/while closing the socket. */
 	#close(code: number, reason: string) {
+		if (this.#closed) return;
+		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
+
 		if (this.#idleTimer) {
 			clearInterval(this.#idleTimer);
 			this.#idleTimer = undefined;
 		}
+
+		// Settle the WebTransport promises. Rejecting `ready` is a no-op once it
+		// has resolved (i.e. after a successful open).
+		this.#readyReject(this.#closed);
 		this.#closedResolve({
 			closeCode: code,
 			reason,
@@ -1206,11 +1225,12 @@ export default class Session implements WebTransport {
 			reason,
 		});
 
+		// Transition state and tear down now; give the queued CONNECTION_CLOSE a
+		// moment to flush before actually closing the socket.
+		this.#close(code, reason);
 		setTimeout(() => {
 			this.#transportClose();
 		}, 100);
-
-		this.#close(code, reason);
 	}
 
 	/** Resize the send-buffer high-water mark (bytes) used for write

--- a/js/web-socket-stream/README.md
+++ b/js/web-socket-stream/README.md
@@ -1,0 +1,59 @@
+# @moq/web-socket-stream
+
+A polyfill for the [`WebSocketStream`](https://github.com/ricea/websocketstream-explainer) API, which exposes a WebSocket as a `{ readable, writable }` pair of streams with backpressure on the writable.
+
+`WebSocketStream` currently ships only in Chromium. This package wraps a plain `WebSocket` to present the same surface (`opened`, `closed`, `close()`) on every platform — browsers, Node, and Bun.
+
+> **Note:** a ponyfill can only *approximate* write backpressure by polling `WebSocket.bufferedAmount` against a high-water mark; only the native API observes the real send buffer. Use [`openWebSocketStream`](#prefer-native) to get the native implementation when it's available.
+
+## Install
+
+```bash
+npm install @moq/web-socket-stream
+```
+
+## Usage
+
+### Prefer native
+
+`openWebSocketStream` returns the native `WebSocketStream` when present and falls back to this ponyfill otherwise:
+
+```ts
+import { openWebSocketStream } from "@moq/web-socket-stream"
+
+const wss = openWebSocketStream("wss://example.com", { protocols: ["my-proto"] })
+const { readable, writable, protocol } = await wss.opened
+
+const reader = readable.getReader()
+const writer = writable.getWriter()
+await writer.ready          // backpressure
+await writer.write(new Uint8Array([1, 2, 3]))
+```
+
+### Global polyfill
+
+Install as a global `WebSocketStream` if the platform doesn't ship one:
+
+```ts
+import { install } from "@moq/web-socket-stream"
+
+// Only installs if native WebSocketStream is unavailable
+install()
+
+const wss = new WebSocketStream("wss://example.com")
+```
+
+### Node / Bun
+
+Modern Node and Bun expose a global `WebSocket`, which is used automatically. To use a specific implementation (e.g. the [`ws`](https://www.npmjs.com/package/ws) package), inject it — this forces the ponyfill:
+
+```ts
+import WebSocket from "ws"
+import { WebSocketStream } from "@moq/web-socket-stream"
+
+const wss = new WebSocketStream("wss://example.com", { webSocket: WebSocket, highWaterMark: 32 * 1024 })
+```
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.

--- a/js/web-socket-stream/package.json
+++ b/js/web-socket-stream/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "@moq/qmux",
+	"name": "@moq/web-socket-stream",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.1",
-	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
+	"version": "0.1.0",
+	"description": "A WebSocketStream polyfill: a plain WebSocket wrapped as { readable, writable } streams with backpressure",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/web-transport",
@@ -13,14 +13,10 @@
 	"files": [
 		"./src"
 	],
-	"dependencies": {
-		"@moq/web-socket-stream": "workspace:*"
-	},
 	"scripts": {
 		"build": "rimraf dist && tsc && tsx ../common/package.ts",
 		"dev": "tsc --watch",
 		"check": "tsc --noEmit",
-		"example": "tsx examples/client.ts",
 		"release": "bun ../common/release.ts"
 	},
 	"devDependencies": {
@@ -31,11 +27,11 @@
 		"typescript": "^5.9.2"
 	},
 	"keywords": [
-		"qmux",
-		"webtransport",
+		"websocketstream",
 		"websocket",
 		"polyfill",
-		"quic",
-		"streams"
+		"ponyfill",
+		"streams",
+		"backpressure"
 	]
 }

--- a/js/web-socket-stream/src/index.test.ts
+++ b/js/web-socket-stream/src/index.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import {
+	install,
+	openWebSocketStream,
+	type WebSocketConstructor,
+	type WebSocketLike,
+	WebSocketStream,
+} from "./index.ts";
+
+/** A scriptable WebSocket stand-in implementing the bits the ponyfill uses. */
+class FakeWebSocket implements WebSocketLike {
+	static last: FakeWebSocket | undefined;
+
+	binaryType = "blob";
+	bufferedAmount = 0;
+	readyState = 0; // CONNECTING
+	protocol: string;
+	extensions = "";
+	sent: Array<string | ArrayBufferLike | ArrayBufferView> = [];
+	closeArgs: { code?: number; reason?: string } | undefined;
+
+	onopen: ((ev: unknown) => void) | null = null;
+	onmessage: ((ev: { data: unknown }) => void) | null = null;
+	onerror: ((ev: unknown) => void) | null = null;
+	onclose: ((ev: { code?: number; reason?: string }) => void) | null = null;
+
+	constructor(
+		readonly url: string,
+		protocols?: string | string[],
+	) {
+		this.protocol = Array.isArray(protocols) ? (protocols[0] ?? "") : (protocols ?? "");
+		FakeWebSocket.last = this;
+	}
+
+	send(data: string | ArrayBufferLike | ArrayBufferView): void {
+		this.sent.push(data);
+	}
+	close(code?: number, reason?: string): void {
+		this.closeArgs = { code, reason };
+		this.readyState = 3; // CLOSED
+	}
+
+	// Test helpers
+	open() {
+		this.readyState = 1; // OPEN
+		this.onopen?.({});
+	}
+	message(data: unknown) {
+		this.onmessage?.({ data });
+	}
+	error() {
+		this.onerror?.({});
+	}
+	fireClose(code = 1000, reason = "") {
+		this.readyState = 3;
+		this.onclose?.({ code, reason });
+	}
+}
+
+const ctor = FakeWebSocket as unknown as WebSocketConstructor;
+
+async function until(fn: () => boolean, tries = 200): Promise<void> {
+	for (let i = 0; i < tries && !fn(); i++) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+describe("WebSocketStream ponyfill", () => {
+	test("opened resolves with streams and negotiated protocol", async () => {
+		const wss = new WebSocketStream("wss://x/y", { webSocket: ctor, protocols: ["p1"] });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		expect(ws.binaryType).toBe("arraybuffer");
+		ws.open();
+		const { readable, writable, protocol } = await wss.opened;
+		expect(protocol).toBe("p1");
+		expect(readable).toBeInstanceOf(ReadableStream);
+		expect(writable).toBeInstanceOf(WritableStream);
+	});
+
+	test("incoming binary (ArrayBuffer) and text surface on the readable", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.open();
+		const { readable } = await wss.opened;
+		const reader = readable.getReader();
+
+		ws.message(new Uint8Array([1, 2, 3]).buffer);
+		ws.message("hello");
+
+		const a = await reader.read();
+		const b = await reader.read();
+		expect(a.value).toEqual(new Uint8Array([1, 2, 3]));
+		expect(b.value).toBe("hello");
+	});
+
+	test("writes are sent and backpressure follows bufferedAmount", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor, highWaterMark: 100 });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.open();
+		const { writable } = await wss.opened;
+		const writer = writable.getWriter();
+
+		// Under the mark: write resolves immediately.
+		await writer.write(new Uint8Array([1]));
+		expect(ws.sent.length).toBe(1);
+
+		// Over the mark: the next write's drain keeps `ready` pending until it falls.
+		ws.bufferedAmount = 1000;
+		const pending = writer.write(new Uint8Array([2]));
+		let settled = false;
+		void pending.then(() => {
+			settled = true;
+		});
+		await until(() => false, 5);
+		expect(settled).toBe(false); // still backpressured
+		expect(ws.sent.length).toBe(2); // but the bytes were already sent
+
+		ws.bufferedAmount = 0; // drained
+		await pending;
+		expect(settled).toBe(true);
+	});
+
+	test("setHighWaterMark resizes backpressure live (mid-drain)", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor, highWaterMark: 100 });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.open();
+		const { writable } = await wss.opened;
+		const writer = writable.getWriter();
+
+		ws.bufferedAmount = 500; // over the 100-byte mark
+		const pending = writer.write(new Uint8Array([1]));
+		let settled = false;
+		void pending.then(() => {
+			settled = true;
+		});
+		await until(() => false, 5);
+		expect(settled).toBe(false); // backpressured at 100
+
+		// Raise the mark above the buffered amount — the in-progress drain resolves
+		// without bufferedAmount having to change.
+		wss.setHighWaterMark(1000);
+		expect(wss.highWaterMark).toBe(1000);
+		await pending;
+		expect(settled).toBe(true);
+	});
+
+	test("close resolves the closed promise and shuts the readable", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.open();
+		const { readable } = await wss.opened;
+		const reader = readable.getReader();
+
+		ws.fireClose(1000, "bye");
+		const info = await wss.closed;
+		expect(info).toEqual({ closeCode: 1000, reason: "bye" });
+		expect((await reader.read()).done).toBe(true);
+	});
+
+	test("error before open rejects opened", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.error();
+		await expect(wss.opened).rejects.toThrow();
+	});
+
+	test("close() guards invalid WebSocket close codes", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+
+		wss.close({ closeCode: 0, reason: "nope" }); // 0 is invalid → bare close
+		expect(ws.closeArgs).toEqual({ code: undefined, reason: undefined });
+
+		ws.closeArgs = undefined;
+		const wss2 = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws2 = FakeWebSocket.last as FakeWebSocket;
+		wss2.close({ closeCode: 1000, reason: "ok" }); // valid → forwarded
+		expect(ws2.closeArgs).toEqual({ code: 1000, reason: "ok" });
+	});
+
+	test("openWebSocketStream uses the ponyfill when there's no native global", () => {
+		const wss = openWebSocketStream("wss://x", { webSocket: ctor });
+		expect(wss).toBeInstanceOf(WebSocketStream);
+	});
+
+	test("install sets the global only when absent", () => {
+		const had = "WebSocketStream" in globalThis;
+		const installed = install();
+		// In bun/node there's no native WebSocketStream, so it should install.
+		expect(installed).toBe(!had);
+		if (installed) {
+			expect((globalThis as { WebSocketStream?: unknown }).WebSocketStream).toBe(WebSocketStream);
+			// Second call is a no-op now that the global exists.
+			expect(install()).toBe(false);
+			delete (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
+		}
+	});
+});

--- a/js/web-socket-stream/src/index.test.ts
+++ b/js/web-socket-stream/src/index.test.ts
@@ -59,8 +59,9 @@ class FakeWebSocket implements WebSocketLike {
 
 const ctor = FakeWebSocket as unknown as WebSocketConstructor;
 
-async function until(fn: () => boolean, tries = 200): Promise<void> {
-	for (let i = 0; i < tries && !fn(); i++) {
+/** Yield to the event loop `n` times to let queued work run. */
+async function tick(n = 1): Promise<void> {
+	for (let i = 0; i < n; i++) {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
 }
@@ -111,7 +112,7 @@ describe("WebSocketStream ponyfill", () => {
 		void pending.then(() => {
 			settled = true;
 		});
-		await until(() => false, 5);
+		await tick(5);
 		expect(settled).toBe(false); // still backpressured
 		expect(ws.sent.length).toBe(2); // but the bytes were already sent
 
@@ -133,7 +134,7 @@ describe("WebSocketStream ponyfill", () => {
 		void pending.then(() => {
 			settled = true;
 		});
-		await until(() => false, 5);
+		await tick(5);
 		expect(settled).toBe(false); // backpressured at 100
 
 		// Raise the mark above the buffered amount — the in-progress drain resolves
@@ -178,9 +179,33 @@ describe("WebSocketStream ponyfill", () => {
 		expect(ws2.closeArgs).toEqual({ code: 1000, reason: "ok" });
 	});
 
+	test("closing the writable closes the underlying socket", async () => {
+		const wss = new WebSocketStream("wss://x", { webSocket: ctor });
+		const ws = FakeWebSocket.last as FakeWebSocket;
+		ws.open();
+		const { writable } = await wss.opened;
+		await writable.getWriter().close();
+		expect(ws.closeArgs).toBeDefined();
+	});
+
 	test("openWebSocketStream uses the ponyfill when there's no native global", () => {
 		const wss = openWebSocketStream("wss://x", { webSocket: ctor });
 		expect(wss).toBeInstanceOf(WebSocketStream);
+	});
+
+	test("openWebSocketStream keeps ponyfill-only options after install()", () => {
+		const g = globalThis as { WebSocket?: WebSocketConstructor; WebSocketStream?: unknown };
+		const prevWS = g.WebSocket;
+		g.WebSocket = ctor; // the ponyfill's default constructor — avoids real network
+		install(); // installs this very ponyfill as globalThis.WebSocketStream
+		try {
+			// Must NOT take the "native" branch and drop highWaterMark.
+			const wss = openWebSocketStream("wss://x", { highWaterMark: 4096 }) as WebSocketStream;
+			expect(wss.highWaterMark).toBe(4096);
+		} finally {
+			delete g.WebSocketStream;
+			g.WebSocket = prevWS;
+		}
 	});
 
 	test("install sets the global only when absent", () => {

--- a/js/web-socket-stream/src/index.ts
+++ b/js/web-socket-stream/src/index.ts
@@ -1,0 +1,233 @@
+/** A ponyfill/polyfill for the WHATWG [`WebSocketStream`][spec] API.
+ *
+ * `WebSocketStream` exposes a WebSocket as a pair of streams —
+ * `{ readable, writable }` — with backpressure on the writable. It currently
+ * ships only in Chromium. This package wraps a plain `WebSocket` to present the
+ * same surface (`opened`, `closed`, `close()`), applying write backpressure by
+ * polling `bufferedAmount` against a configurable high-water mark.
+ *
+ * Note: a ponyfill can only *approximate* backpressure via `bufferedAmount`;
+ * the native API observes the real send buffer. When the native API is present,
+ * prefer it via {@link openWebSocketStream}.
+ *
+ * [spec]: https://github.com/ricea/websocketstream-explainer
+ */
+
+/** The data yielded by the readable / accepted by the writable. */
+export type WebSocketStreamData = Uint8Array | string;
+
+/** Resolved value of {@link WebSocketStreamLike.opened}. */
+export interface WebSocketStreamOpenEvent {
+	readable: ReadableStream<WebSocketStreamData>;
+	writable: WritableStream<WebSocketStreamData>;
+	extensions: string;
+	protocol: string;
+}
+
+/** Resolved value of {@link WebSocketStreamLike.closed}. */
+export interface WebSocketStreamCloseEvent {
+	closeCode: number;
+	reason: string;
+}
+
+/** Argument to {@link WebSocketStreamLike.close}. */
+export interface WebSocketStreamCloseInfo {
+	closeCode?: number;
+	reason?: string;
+}
+
+/** The common shape implemented by both the native API and this ponyfill. */
+export interface WebSocketStreamLike {
+	readonly url: string;
+	readonly opened: Promise<WebSocketStreamOpenEvent>;
+	readonly closed: Promise<WebSocketStreamCloseEvent>;
+	close(closeInfo?: WebSocketStreamCloseInfo): void;
+	/** Ponyfill-only: resize the write-backpressure high-water mark at runtime
+	 *  (see {@link WebSocketStream.setHighWaterMark}). Absent on the native API,
+	 *  which sizes its own send buffer — callers should treat it as optional. */
+	setHighWaterMark?(bytes: number): void;
+}
+
+/** The slice of the `WebSocket` API this ponyfill relies on. Both the browser
+ *  `WebSocket` and Node's `ws` satisfy it. */
+export interface WebSocketLike {
+	binaryType: string;
+	readonly bufferedAmount: number;
+	readonly readyState: number;
+	readonly protocol: string;
+	readonly extensions: string;
+	send(data: string | ArrayBufferLike | ArrayBufferView): void;
+	close(code?: number, reason?: string): void;
+	onopen: ((ev: unknown) => void) | null;
+	onmessage: ((ev: { data: unknown }) => void) | null;
+	onerror: ((ev: unknown) => void) | null;
+	onclose: ((ev: { code?: number; reason?: string }) => void) | null;
+}
+
+/** Constructor for a {@link WebSocketLike} (e.g. the global `WebSocket` or `ws`). */
+export type WebSocketConstructor = new (url: string, protocols?: string | string[]) => WebSocketLike;
+
+export interface WebSocketStreamOptions {
+	/** Subprotocols to advertise via `Sec-WebSocket-Protocol`. */
+	protocols?: string[];
+	/** Abort the connection. */
+	signal?: AbortSignal;
+	/** Ponyfill-only: the `WebSocket` implementation to use. Defaults to
+	 *  `globalThis.WebSocket`. Pass Node's `ws` when there is no global. */
+	webSocket?: WebSocketConstructor;
+	/** Ponyfill-only: write backpressure kicks in once `bufferedAmount` exceeds
+	 *  this many bytes. Defaults to 64 KiB. */
+	highWaterMark?: number;
+}
+
+const OPEN = 1;
+const DEFAULT_HIGH_WATER_MARK = 64 * 1024;
+
+/** WebSocket close codes outside 1000 / 3000–4999 are rejected by `close()`. */
+function validCloseCode(code: number | undefined): code is number {
+	return code !== undefined && (code === 1000 || (code >= 3000 && code <= 4999));
+}
+
+/** Resolve once `bufferedAmount` drains below the mark (write backpressure).
+ *  The mark is read live via `highWaterMark()` on every check, so a runtime
+ *  resize (see {@link WebSocketStream.setHighWaterMark}) takes effect mid-drain.
+ *  Returns `undefined` synchronously when there's already room — no microtask
+ *  on the hot path, so `writer.ready` stays resolved when the socket is keeping up. */
+function drain(ws: WebSocketLike, highWaterMark: () => number): Promise<void> | undefined {
+	if (ws.bufferedAmount <= highWaterMark()) return undefined;
+	return (async () => {
+		while (ws.bufferedAmount > highWaterMark()) {
+			if (ws.readyState > OPEN) return; // CLOSING/CLOSED — stop blocking
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	})();
+}
+
+/** A `WebSocketStream` implemented over a plain `WebSocket`. */
+export class WebSocketStream implements WebSocketStreamLike {
+	readonly url: string;
+	readonly opened: Promise<WebSocketStreamOpenEvent>;
+	readonly closed: Promise<WebSocketStreamCloseEvent>;
+	#ws: WebSocketLike;
+	#highWaterMark: number;
+
+	constructor(url: string, options: WebSocketStreamOptions = {}) {
+		this.url = url;
+
+		const Ctor = options.webSocket ?? (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket;
+		if (!Ctor) {
+			throw new Error("No WebSocket implementation found; pass options.webSocket");
+		}
+		const ws = new Ctor(url, options.protocols);
+		ws.binaryType = "arraybuffer";
+		this.#ws = ws;
+		this.#highWaterMark = Math.max(1, Math.floor(options.highWaterMark ?? DEFAULT_HIGH_WATER_MARK));
+
+		const opened = Promise.withResolvers<WebSocketStreamOpenEvent>();
+		const closed = Promise.withResolvers<WebSocketStreamCloseEvent>();
+		this.opened = opened.promise;
+		this.closed = closed.promise;
+		// Avoid unhandled-rejection noise if a caller only awaits `closed`.
+		this.opened.catch(() => {});
+
+		let controller: ReadableStreamDefaultController<WebSocketStreamData> | undefined;
+		const readable = new ReadableStream<WebSocketStreamData>({
+			start: (c) => {
+				controller = c;
+			},
+			cancel: () => ws.close(),
+		});
+
+		const writable = new WritableStream<WebSocketStreamData>({
+			write: (chunk) => {
+				ws.send(chunk);
+				return drain(ws, () => this.#highWaterMark);
+			},
+			abort: () => ws.close(),
+		});
+
+		ws.onopen = () => {
+			opened.resolve({ readable, writable, extensions: ws.extensions, protocol: ws.protocol });
+		};
+		ws.onmessage = (event) => {
+			const data = event.data;
+			if (typeof data === "string") {
+				controller?.enqueue(data);
+			} else if (data instanceof ArrayBuffer) {
+				controller?.enqueue(new Uint8Array(data));
+			} else if (ArrayBuffer.isView(data)) {
+				const view = data as ArrayBufferView;
+				controller?.enqueue(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+			}
+		};
+		ws.onerror = () => {
+			const err = new Error("WebSocket connection error");
+			opened.reject(err);
+			try {
+				controller?.error(err);
+			} catch {}
+		};
+		ws.onclose = (event) => {
+			opened.reject(new Error("WebSocket closed before opening"));
+			try {
+				controller?.close();
+			} catch {}
+			closed.resolve({ closeCode: event.code ?? 1006, reason: event.reason ?? "" });
+		};
+
+		const { signal } = options;
+		if (signal) {
+			if (signal.aborted) ws.close();
+			else signal.addEventListener("abort", () => ws.close(), { once: true });
+		}
+	}
+
+	close(closeInfo: WebSocketStreamCloseInfo = {}): void {
+		if (validCloseCode(closeInfo.closeCode)) {
+			this.#ws.close(closeInfo.closeCode, closeInfo.reason);
+		} else {
+			// A reason can't be sent without a valid code, so drop both.
+			this.#ws.close();
+		}
+	}
+
+	/** The current write-backpressure high-water mark, in bytes. */
+	get highWaterMark(): number {
+		return this.#highWaterMark;
+	}
+
+	/** Resize the write-backpressure high-water mark at runtime (bytes).
+	 *
+	 * Set this to roughly the bandwidth-delay product (RTT × estimated
+	 * throughput): large enough to keep the socket busy, small enough that
+	 * queued bytes can still be reprioritized rather than committed to the OS
+	 * send buffer. Takes effect immediately, including for an in-progress drain.
+	 * Clamped to a minimum of 1 byte. */
+	setHighWaterMark(bytes: number): void {
+		this.#highWaterMark = Math.max(1, Math.floor(bytes));
+	}
+}
+
+/** Open a `WebSocketStream`, preferring the native API when available and
+ *  falling back to the {@link WebSocketStream} ponyfill otherwise. Passing
+ *  `options.webSocket` forces the ponyfill (the native API can't use an injected
+ *  socket). */
+export function openWebSocketStream(url: string | URL, options: WebSocketStreamOptions = {}): WebSocketStreamLike {
+	const href = typeof url === "string" ? url : url.toString();
+	const Native = (globalThis as { WebSocketStream?: typeof WebSocketStream }).WebSocketStream;
+	if (Native && !options.webSocket) {
+		return new Native(href, { protocols: options.protocols, signal: options.signal });
+	}
+	return new WebSocketStream(href, options);
+}
+
+/** Install {@link WebSocketStream} as the global `WebSocketStream` if the
+ *  platform doesn't ship one. Returns `true` if installed, `false` if a native
+ *  (or previously installed) implementation already existed. */
+export function install(): boolean {
+	if ("WebSocketStream" in globalThis) return false;
+	(globalThis as { WebSocketStream?: typeof WebSocketStream }).WebSocketStream = WebSocketStream;
+	return true;
+}
+
+export default WebSocketStream;

--- a/js/web-socket-stream/src/index.ts
+++ b/js/web-socket-stream/src/index.ts
@@ -97,7 +97,9 @@ function drain(ws: WebSocketLike, highWaterMark: () => number): Promise<void> | 
 	if (ws.bufferedAmount <= highWaterMark()) return undefined;
 	return (async () => {
 		while (ws.bufferedAmount > highWaterMark()) {
-			if (ws.readyState > OPEN) return; // CLOSING/CLOSED — stop blocking
+			// The socket closed mid-write: reject so the failure propagates rather
+			// than resolving the write as if it had succeeded.
+			if (ws.readyState > OPEN) throw new Error("WebSocket is closing");
 			await new Promise((resolve) => setTimeout(resolve, 10));
 		}
 	})();

--- a/js/web-socket-stream/src/index.ts
+++ b/js/web-socket-stream/src/index.ts
@@ -143,6 +143,9 @@ export class WebSocketStream implements WebSocketStreamLike {
 				ws.send(chunk);
 				return drain(ws, () => this.#highWaterMark);
 			},
+			// A WebSocket has no half-close, so closing/aborting the writable closes
+			// the whole socket. Without this, `writer.close()` would leave it open.
+			close: () => ws.close(),
 			abort: () => ws.close(),
 		});
 
@@ -215,7 +218,10 @@ export class WebSocketStream implements WebSocketStreamLike {
 export function openWebSocketStream(url: string | URL, options: WebSocketStreamOptions = {}): WebSocketStreamLike {
 	const href = typeof url === "string" ? url : url.toString();
 	const Native = (globalThis as { WebSocketStream?: typeof WebSocketStream }).WebSocketStream;
-	if (Native && !options.webSocket) {
+	// Only delegate to a *genuinely* native global — if `install()` put this very
+	// ponyfill on the global, fall through so ponyfill-only options (e.g.
+	// highWaterMark) aren't dropped on the floor.
+	if (Native && Native !== WebSocketStream && !options.webSocket) {
 		return new Native(href, { protocols: options.protocols, signal: options.signal });
 	}
 	return new WebSocketStream(href, options);

--- a/js/web-socket-stream/tsconfig.json
+++ b/js/web-socket-stream/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"lib": ["esnext", "dom", "dom.iterable"],
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"outDir": "./dist",
+		"declaration": true,
+		"isolatedModules": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"workspaces": [
 		"js/qmux",
 		"js/web-demo",
+		"js/web-socket-stream",
 		"js/web-transport"
 	],
 	"scripts": {


### PR DESCRIPTION
## What

When the WebSocket is backpressured, write the most important frames first: **control frames before stream data**, and among stream data the **higher `sendOrder`** first (W3C convention), with round-robin among equal priorities. Prioritization only matters under backpressure — when the socket keeps up, frames go out as soon as they're queued.

This also introduces a reusable **`@moq/web-socket-stream`** polyfill, since the prioritization needs a backpressure signal and the existing per-stream `bufferedAmount` polling couldn't order across streams.

## New package: `@moq/web-socket-stream`

A polyfill for the [`WebSocketStream`](https://github.com/ricea/websocketstream-explainer) API (Chromium-only today): wraps a plain `WebSocket` as `{ readable, writable }` with write backpressure. No maintained npm polyfill exists, and the two zombie packages that do don't implement `bufferedAmount` backpressure or work in Node.

- `openWebSocketStream(url, opts)` prefers the native API and falls back to the ponyfill; `install()` registers a global polyfill.
- **Runtime-resizable high-water mark** via `setHighWaterMark(bytes)`, read live mid-drain. The correct size is the **bandwidth-delay product** (RTT × throughput): large enough to keep the pipe full, small enough that queued bytes stay reprioritizable rather than committed to the OS send buffer.
- Browser + Node/Bun, binary-capable, TS-typed, 9 tests.

## `@moq/qmux` changes

- **`SendScheduler`** (`scheduler.ts`): a single writer loop owns the socket, fed by a control queue (preempts everything) plus per-stream ready slots ordered by `sendOrder`. Replaces the old design where each stream's `write()` independently polled `bufferedAmount` and raced — and where control frames bypassed backpressure entirely into the socket buffer.
- **`sendOrder`** flows through `createBidirectionalStream`/`createUnidirectionalStream` options and is exposed as a **mutable accessor** on the writable (retroactive re-prioritization, matching the W3C `WebTransportSendStream.sendOrder` attribute).
- **Single transport path:** always a `WebSocketStream` (native when present, ponyfill otherwise). Removes the dual sink / dual connection setup, so the code path tests exercise is the same one Chromium runs natively. All the `WebSocket` event wiring moved into the polyfill.
- **BDP knob:** `SessionOptions.sendBufferSize` (initial) and `Session.setSendBufferSize(bytes)` (runtime) forward the high-water mark to the ponyfill — a no-op under native `WebSocketStream`, which sizes its own buffer. A MoQ app that knows RTT and throughput can drive this directly.

## Direction convention

Higher `sendOrder` = sent first, per W3C. (The Rust side fixes the matching trait doc in a separate PR.)

## Tests

`scheduler.test.ts` (8): control-preempts, higher-first, round-robin, retroactive promote, no-starvation, drop, close-flush. `web-socket-stream` (9): open/binary/backpressure/close/error, **live `setHighWaterMark`**, native preference, install. Existing qmux codec tests unchanged. `tsc` + Biome clean across both packages.

## Notes

- Coupled into one PR because qmux's `package.json` depends on `@moq/web-socket-stream` and they share `bun.lock` / the workspace list — they can't land separately without breaking CI.
- Companion Rust PR (per-stream priority in `rs/qmux` + trait doc fix): #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)