### PR TITLE
qmux: replace withoutProtocol with requireProtocol, default to lenient (0.1.2)

### DIFF
--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/qmux/src/index.ts
+++ b/js/qmux/src/index.ts
@@ -7,13 +7,13 @@ export type { Config, SessionOptions, Version } from "./session.ts";
 export interface InstallOptions {
 	/** ALPN -> wire-format version(s). See [[SessionOptions.versions]]. */
 	versions?: Record<string, Version | Version[] | null>;
-	/** Also offer the bare version ALPNs. See [[SessionOptions.withoutProtocol]]. */
-	withoutProtocol?: boolean;
+	/** Require the peer to negotiate an app protocol. See [[SessionOptions.requireProtocol]]. */
+	requireProtocol?: boolean;
 }
 
 /** Install `Session` as the global `WebTransport` if the platform doesn't ship one.
  *
- * The `versions` map and `withoutProtocol` flag are forwarded to every
+ * The `versions` map and `requireProtocol` flag are forwarded to every
  * `Session` constructed via the polyfill. Callers that pass only explicit
  * `{qmux-VV}.{alpn}` pairs in their `protocols` list can omit the map.
  *
@@ -23,11 +23,11 @@ export interface InstallOptions {
 export function install(options?: InstallOptions): boolean {
 	if ("WebTransport" in globalThis) return false;
 	const versions = options?.versions;
-	const withoutProtocol = options?.withoutProtocol;
+	const requireProtocol = options?.requireProtocol;
 	// biome-ignore lint/suspicious/noExplicitAny: polyfill — extending Session to match the WebTransport constructor signature
 	(globalThis as any).WebTransport = class extends Session {
 		constructor(url: string | URL, options?: WebTransportOptions) {
-			super(url, { ...options, versions, withoutProtocol });
+			super(url, { ...options, versions, requireProtocol });
 		}
 	};
 	return true;

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -100,8 +100,8 @@ function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
 function connect(config?: Config): { session: Session; peer: FakePeer } {
 	(globalThis as { WebSocketStream?: unknown }).WebSocketStream = FakePeer;
 	// Idle timer off so a stray interval can't interfere with the test.
+	// Bare version ALPNs are offered by default (requireProtocol defaults to false).
 	const session = new Session("https://example/test", {
-		withoutProtocol: true,
 		config: { maxIdleTimeout: 0n, ...config },
 	});
 	const peer = FakePeer.last as FakePeer;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -115,14 +115,18 @@ export interface SessionOptions extends WebTransportOptions {
 	 */
 	versions?: Record<string, Version | Version[] | null>;
 
-	/** Also offer the bare version ALPNs `qmux-01`, `qmux-00`, and
-	 * `webtransport` (no application protocol attached). Use this when the
-	 * peer might only know a wire-format version and not the application
-	 * protocols you've configured — e.g. when talking to a relay that only
-	 * speaks the legacy `webtransport` wire format. Defaults to `false`,
-	 * which advertises only the configured prefixed pairs.
+	/** Require the peer to negotiate one of the app protocols in `protocols`.
+	 *
+	 * When `false` (the default), the bare version ALPNs `qmux-01`,
+	 * `qmux-00`, and `webtransport` (no application protocol attached) are
+	 * also offered, so a peer that only knows a wire-format version can still
+	 * connect. That covers a relay speaking the legacy `webtransport` format,
+	 * or one that negotiates the app protocol at a higher layer (e.g. moq's
+	 * SETUP message). Set to `true` to advertise only the configured prefixed
+	 * pairs, which makes the handshake fail unless the peer speaks one of your
+	 * app protocols.
 	 */
-	withoutProtocol?: boolean;
+	requireProtocol?: boolean;
 
 	/** QMux flow control configuration. Only used for the QMux wire formats. */
 	config?: Config;
@@ -173,7 +177,7 @@ function toWebSocketUrl(url: string | URL): string {
 	return `${scheme}//${u.host}${u.pathname}${u.search}`;
 }
 
-/** Bare version ALPNs appended when `withoutProtocol` is set. Newest first. */
+/** Bare version ALPNs appended unless `requireProtocol` is set. Newest first. */
 const BARE_ALPNS = ["qmux-01", "qmux-00", "webtransport"] as const;
 
 /** Resolve a `protocols` + `versions` pair to the wire subprotocol list.
@@ -181,16 +185,17 @@ const BARE_ALPNS = ["qmux-01", "qmux-00", "webtransport"] as const;
  * Expansion rules per bare entry's `versions` value: single `Version`
  * emits one pair; an array emits one pair per element; `null` emits one
  * pair per [[QMUX_VERSIONS]] entry. Entries already in `{qmux-VV}.{alpn}`
- * pair form pass through. When `withoutProtocol` is true, the bare version
+ * pair form pass through. Unless `requireProtocol` is true, the bare version
  * ALPNs (`qmux-01`, `qmux-00`, `webtransport`) are appended after the
- * prefixed pairs for peers that don't pin an app protocol.
+ * prefixed pairs so a peer that doesn't pin an app protocol can still
+ * negotiate a wire format.
  *
  * Throws if any bare entry has no matching `versions` mapping.
  */
-function resolveSubprotocols(
+export function resolveSubprotocols(
 	protocols: readonly string[],
 	versions: Readonly<Record<string, Version | Version[] | null>>,
-	withoutProtocol: boolean,
+	requireProtocol: boolean,
 ): string[] {
 	const out: string[] = [];
 	for (const entry of protocols) {
@@ -210,7 +215,7 @@ function resolveSubprotocols(
 			out.push(`${versionPrefix(v)}${entry}`);
 		}
 	}
-	if (withoutProtocol) {
+	if (!requireProtocol) {
 		out.push(...BARE_ALPNS);
 	}
 	return out;
@@ -352,7 +357,7 @@ export default class Session implements WebTransport {
 		const subprotocols = resolveSubprotocols(
 			options?.protocols ?? [],
 			options?.versions ?? {},
-			options?.withoutProtocol ?? false,
+			options?.requireProtocol ?? false,
 		);
 
 		// Merge user config with defaults

--- a/js/qmux/src/subprotocol.test.ts
+++ b/js/qmux/src/subprotocol.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSubprotocols } from "./session.ts";
+
+// The bare version ALPNs the polyfill appends when `requireProtocol` is false.
+const BARE = ["qmux-01", "qmux-00", "webtransport"];
+
+describe("resolveSubprotocols", () => {
+	test("no protocols still offers the bare version ALPNs by default", () => {
+		// Regression: a bare `new Session(url)` must advertise the wire-format
+		// ALPNs so a relay can negotiate without pinning an app protocol.
+		// Dropping this is what broke moq's WebSocket fallback in 0.1.x.
+		expect(resolveSubprotocols([], {}, false)).toEqual(BARE);
+	});
+
+	test("requireProtocol drops the bare ALPNs", () => {
+		expect(resolveSubprotocols([], {}, true)).toEqual([]);
+	});
+
+	test("a pinned app protocol still gets the bare versions appended by default", () => {
+		expect(resolveSubprotocols(["moq-lite-04"], { "moq-lite-04": "qmux-01" }, false)).toEqual([
+			"qmux-01.moq-lite-04",
+			...BARE,
+		]);
+	});
+
+	test("requireProtocol advertises only the configured pairs", () => {
+		expect(resolveSubprotocols(["moq-lite-04"], { "moq-lite-04": "qmux-01" }, true)).toEqual([
+			"qmux-01.moq-lite-04",
+		]);
+	});
+
+	test("null version expands to every qmux draft, newest first", () => {
+		expect(resolveSubprotocols(["moq-lite-04"], { "moq-lite-04": null }, true)).toEqual([
+			"qmux-01.moq-lite-04",
+			"qmux-00.moq-lite-04",
+		]);
+	});
+
+	test("array version preserves the caller's order", () => {
+		expect(resolveSubprotocols(["m"], { m: ["qmux-00", "qmux-01"] }, true)).toEqual(["qmux-00.m", "qmux-01.m"]);
+	});
+
+	test("already-prefixed pairs pass through without a versions entry", () => {
+		expect(resolveSubprotocols(["qmux-00.moq-transport-17"], {}, true)).toEqual(["qmux-00.moq-transport-17"]);
+	});
+
+	test("a bare entry with no versions mapping throws", () => {
+		expect(() => resolveSubprotocols(["moq-lite-04"], {}, true)).toThrow();
+	});
+});

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]

--- a/rs/qmux/src/alpn.rs
+++ b/rs/qmux/src/alpn.rs
@@ -5,9 +5,10 @@
 //! is emitted once per version, in order. An empty `versions` slice means
 //! "every QMux draft this crate knows about" (see [`QMUX_VERSIONS`]).
 //!
-//! Bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport` — no app protocol
-//! attached) are opt-in via the `without_protocol` flag; without it, only the
-//! configured prefixed pairs are advertised/accepted.
+//! Bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`, no app protocol
+//! attached) are advertised/accepted by default, so a peer that only knows a
+//! wire-format version can still connect. Set the `require_protocol` flag to
+//! suppress them and advertise/accept only the configured prefixed pairs.
 //!
 //! [`parse`] recovers `(Version, Option<String>)` from a negotiated wire-format
 //! ALPN. Only the QMux drafts appear in `{prefix}{alpn}` form; the legacy
@@ -19,8 +20,8 @@ use crate::Version;
 /// QMux versions that can ride under a `{prefix}{alpn}` pair, newest first.
 pub(crate) const QMUX_VERSIONS: &[Version] = &[Version::QMux01, Version::QMux00];
 
-/// Bare version ALPNs added (offered by clients, accepted by servers) when the
-/// caller opts in via `without_protocol`. Newest first.
+/// Bare version ALPNs added (offered by clients, accepted by servers) unless
+/// the caller opts out via `require_protocol`. Newest first.
 pub(crate) const BARE_ALPNS: &[Version] =
     &[Version::QMux01, Version::QMux00, Version::WebTransport];
 
@@ -37,30 +38,30 @@ pub(crate) fn expand_versions(versions: &[Version]) -> &[Version] {
 /// Build the ALPN list from `(alpn, versions)` entries.
 ///
 /// Each entry emits `{v.prefix()}{alpn}` per version in `expand_versions(versions)`.
-/// When `without_protocol` is set, the bare version ALPNs (`qmux-01`,
+/// Unless `require_protocol` is set, the bare version ALPNs (`qmux-01`,
 /// `qmux-00`, `webtransport`) are appended after the prefixed pairs as a
 /// fallback for peers that don't want to commit to an app protocol.
 ///
 /// Suitable for TLS ALPN or WebSocket `Sec-WebSocket-Protocol`.
 ///
 /// Passing `Version::WebTransport` inside an entry's `versions` is a usage
-/// bug (the bare ALPN is opt-in via `without_protocol`) and panics in debug
-/// builds.
+/// bug (the bare ALPN is controlled by `require_protocol`, not by listing it
+/// as a pair version) and panics in debug builds.
 pub(crate) fn build<'a>(
     entries: impl IntoIterator<Item = (&'a str, &'a [Version])>,
-    without_protocol: bool,
+    require_protocol: bool,
 ) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for (alpn, versions) in entries {
         for &version in expand_versions(versions) {
             debug_assert!(
                 version.is_qmux(),
-                "webtransport doesn't use prefixed ALPN; pair entries are qmux only. Bare ALPNs are opt-in via without_protocol."
+                "webtransport doesn't use prefixed ALPN; pair entries are qmux only. Bare ALPNs are controlled by require_protocol."
             );
             out.push(format!("{}{}", version.prefix(), alpn));
         }
     }
-    if without_protocol {
+    if !require_protocol {
         for &v in BARE_ALPNS {
             out.push(v.alpn().to_string());
         }
@@ -102,20 +103,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_emits_only_prefixed_pairs_by_default() {
-        let out = build(
-            [
-                ("moq-lite-04", &[Version::QMux01][..]),
-                ("moq-transport-17", &[Version::QMux00][..]),
-            ],
-            false,
-        );
-        assert_eq!(out, vec!["qmux-01.moq-lite-04", "qmux-00.moq-transport-17"]);
-    }
-
-    #[test]
-    fn build_appends_bare_alpns_when_without_protocol() {
-        let out = build([("moq-lite-04", &[Version::QMux01][..])], true);
+    fn build_appends_bare_alpns_by_default() {
+        let out = build([("moq-lite-04", &[Version::QMux01][..])], false);
         assert_eq!(
             out,
             vec!["qmux-01.moq-lite-04", "qmux-01", "qmux-00", "webtransport"]
@@ -123,8 +112,20 @@ mod tests {
     }
 
     #[test]
+    fn build_emits_only_prefixed_pairs_when_require_protocol() {
+        let out = build(
+            [
+                ("moq-lite-04", &[Version::QMux01][..]),
+                ("moq-transport-17", &[Version::QMux00][..]),
+            ],
+            true,
+        );
+        assert_eq!(out, vec!["qmux-01.moq-lite-04", "qmux-00.moq-transport-17"]);
+    }
+
+    #[test]
     fn build_expands_empty_versions_to_all_qmux_drafts() {
-        let out = build([("moq-lite-04", &[][..])], false);
+        let out = build([("moq-lite-04", &[][..])], true);
         assert_eq!(out, vec!["qmux-01.moq-lite-04", "qmux-00.moq-lite-04"]);
     }
 
@@ -132,22 +133,22 @@ mod tests {
     fn build_emits_one_pair_per_listed_version() {
         let out = build(
             [("moq-lite-04", &[Version::QMux00, Version::QMux01][..])],
-            false,
+            true,
         );
         assert_eq!(out, vec!["qmux-00.moq-lite-04", "qmux-01.moq-lite-04"]);
     }
 
     #[test]
-    fn build_empty_without_protocol_emits_only_bare_alpns() {
+    fn build_empty_by_default_emits_only_bare_alpns() {
         let entries: [(&str, &[Version]); 0] = [];
-        let out = build(entries, true);
+        let out = build(entries, false);
         assert_eq!(out, vec!["qmux-01", "qmux-00", "webtransport"]);
     }
 
     #[test]
-    fn build_empty_with_protocol_required_emits_nothing() {
+    fn build_empty_with_require_protocol_emits_nothing() {
         let entries: [(&str, &[Version]); 0] = [];
-        let out = build(entries, false);
+        let out = build(entries, true);
         assert!(out.is_empty());
     }
 

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -10,10 +10,10 @@ use crate::{alpn, Config, Error, Session, Version};
 ///
 /// Each entry's `versions` slice is expanded into the TLS ALPN list as
 /// `{v.prefix()}{alpn}` per version (empty = every QMux draft this crate
-/// knows about). When `without_protocol` is set, the bare version ALPNs
-/// (`qmux-01`, `qmux-00`, `webtransport`) are appended as well; otherwise
-/// only the prefixed pairs are offered. The peer's chosen ALPN determines
-/// the QMux wire-format version; the `alpn_protocols` field on the supplied
+/// knows about). The bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`)
+/// are appended as well unless `require_protocol` is set, in which case only
+/// the prefixed pairs are offered. The peer's chosen ALPN determines the QMux
+/// wire-format version; the `alpn_protocols` field on the supplied
 /// `rustls::ClientConfig` is ignored and rebuilt from `entries`.
 ///
 /// `server_name` is used for SNI and certificate verification.
@@ -22,7 +22,7 @@ pub async fn connect<'a>(
     server_name: &str,
     config: Arc<rustls::ClientConfig>,
     entries: impl IntoIterator<Item = (&'a str, &'a [Version])>,
-    without_protocol: bool,
+    require_protocol: bool,
 ) -> Result<Session, Error> {
     let stream = TcpStream::connect(&addr).await?;
 
@@ -30,7 +30,7 @@ pub async fn connect<'a>(
         .map_err(|e| Error::Io(e.to_string()))?
         .to_owned();
 
-    let prefixed = alpn::build(entries, without_protocol);
+    let prefixed = alpn::build(entries, require_protocol);
 
     let mut config = (*config).clone();
     config.alpn_protocols = prefixed.iter().map(|s| s.as_bytes().to_vec()).collect();
@@ -46,6 +46,15 @@ pub async fn connect<'a>(
 
     let (version, protocol) = alpn::parse(negotiated_str);
     tracing::debug!(?version, ?protocol, "parsed ALPN");
+
+    // In strict mode an unrecognized or absent ALPN would otherwise fall
+    // through to the legacy `webtransport` wire format with no app protocol,
+    // silently downgrading the negotiation we promised to enforce.
+    if require_protocol && protocol.is_none() {
+        return Err(Error::InvalidProtocol(
+            negotiated_str.unwrap_or("<none>").to_string(),
+        ));
+    }
 
     let session_config = Config::new(version, protocol);
     let transport = StreamTransport::new(tls_stream, version, session_config.max_record_size);

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -110,13 +110,13 @@ where
 /// version, in order; an empty `versions` slice expands to every QMux draft
 /// this crate knows about. Add multiple entries to negotiate across drafts in
 /// a single handshake; the wire-format version comes from the negotiated
-/// subprotocol. Call [`Client::without_protocol`] to also offer bare version
-/// ALPNs (`qmux-01`, `qmux-00`, `webtransport`) for peers that don't pin
-/// an app protocol.
+/// subprotocol. By default the bare version ALPNs (`qmux-01`, `qmux-00`,
+/// `webtransport`) are also offered for peers that don't pin an app protocol;
+/// call [`Client::require_protocol`] to offer only the configured pairs.
 #[derive(Default, Clone)]
 pub struct Client {
     protocols: Vec<(String, Vec<Version>)>,
-    without_protocol: bool,
+    require_protocol: bool,
     config: Option<tungstenite::protocol::WebSocketConfig>,
     keep_alive: Option<KeepAlive>,
     #[cfg(feature = "wss")]
@@ -150,13 +150,12 @@ impl Client {
         self
     }
 
-    /// Also offer the bare version ALPNs `qmux-01`, `qmux-00`, and
-    /// `webtransport` (no application protocol attached). Use this when the
-    /// peer might only know a wire-format version and not the application
-    /// protocols you've configured. Without this, the client only offers the
-    /// prefixed `(alpn, version)` pairs.
-    pub fn without_protocol(mut self) -> Self {
-        self.without_protocol = true;
+    /// Offer only the prefixed `(alpn, version)` pairs, suppressing the bare
+    /// version ALPNs (`qmux-01`, `qmux-00`, `webtransport`) that are offered by
+    /// default. Use this when the peer must commit to one of the application
+    /// protocols you've configured.
+    pub fn require_protocol(mut self) -> Self {
+        self.require_protocol = true;
         self
     }
 
@@ -198,7 +197,7 @@ impl Client {
             .protocols
             .iter()
             .map(|(a, vs)| (a.as_str(), vs.as_slice()));
-        let protocol_value = alpn::build(entries, self.without_protocol).join(", ");
+        let protocol_value = alpn::build(entries, self.require_protocol).join(", ");
 
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,
@@ -231,6 +230,15 @@ impl Client {
 
         let (version, protocol) = alpn::parse(negotiated);
 
+        // In strict mode an unrecognized or absent subprotocol would otherwise
+        // fall through to the legacy `webtransport` wire format with no app
+        // protocol, silently downgrading the negotiation we promised to enforce.
+        if self.require_protocol && protocol.is_none() {
+            return Err(Error::InvalidProtocol(
+                negotiated.unwrap_or("<none>").to_string(),
+            ));
+        }
+
         let transport = match self.keep_alive {
             Some(ka) => WsTransport::new(ws_stream).with_keep_alive(ka),
             None => WsTransport::new(ws_stream),
@@ -245,13 +253,14 @@ impl Client {
 /// ride on. The handshake callback matches each `{v.prefix()}{alpn}`
 /// permutation against the client's offered `Sec-WebSocket-Protocol` in
 /// declaration order. An empty `versions` slice expands to every QMux draft
-/// this crate knows about. Call [`Server::without_protocol`] to also accept
-/// bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`) for peers
-/// that don't pin an app protocol.
+/// this crate knows about. By default bare version ALPNs (`qmux-01`,
+/// `qmux-00`, `webtransport`) are also accepted for peers that don't pin an
+/// app protocol; call [`Server::require_protocol`] to accept only the
+/// configured pairs.
 #[derive(Default, Clone)]
 pub struct Server {
     protocols: Vec<(String, Vec<Version>)>,
-    without_protocol: bool,
+    require_protocol: bool,
     keep_alive: Option<KeepAlive>,
 }
 
@@ -282,13 +291,13 @@ impl Server {
         self
     }
 
-    /// Also accept bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`)
-    /// from clients that don't request an application protocol. The accepted
-    /// session has `Config::protocol == None` and uses the wire-format
-    /// version implied by the ALPN. Without this, only the configured
-    /// prefixed pairs are accepted.
-    pub fn without_protocol(mut self) -> Self {
-        self.without_protocol = true;
+    /// Accept only the configured prefixed pairs, rejecting clients that offer
+    /// just a bare version ALPN (`qmux-01`, `qmux-00`, `webtransport`) with no
+    /// application protocol. By default those bare ALPNs are accepted, yielding
+    /// a session with `Config::protocol == None` and the wire-format version
+    /// implied by the ALPN.
+    pub fn require_protocol(mut self) -> Self {
+        self.require_protocol = true;
         self
     }
 
@@ -316,7 +325,7 @@ impl Server {
         let negotiated = Arc::new(Mutex::new(None::<(Version, Option<String>)>));
         let negotiated_clone = negotiated.clone();
         let supported = self.protocols.clone();
-        let without_protocol = self.without_protocol;
+        let require_protocol = self.require_protocol;
 
         #[allow(clippy::result_large_err)]
         let callback = move |req: &server::Request,
@@ -349,11 +358,12 @@ impl Server {
                 }
             }
 
-            // Opt-in fallback: accept bare version ALPNs (qmux-01, qmux-00,
-            // webtransport) for clients that didn't request an app protocol.
-            // The session ends up with `protocol = None` and the wire-format
-            // version implied by whichever bare ALPN won.
-            if without_protocol {
+            // Default fallback: accept bare version ALPNs (qmux-01, qmux-00,
+            // webtransport) for clients that didn't request an app protocol,
+            // unless require_protocol was set. The session ends up with
+            // `protocol = None` and the wire-format version implied by
+            // whichever bare ALPN won.
+            if !require_protocol {
                 for &version in alpn::BARE_ALPNS {
                     let bare = version.alpn();
                     if header_protocols.contains(&bare) {


### PR DESCRIPTION
## Summary

`@moq/qmux` 0.1.x put the bare wire-format ALPNs (`qmux-01`, `qmux-00`, `webtransport`) behind a `withoutProtocol` flag that defaults to `false`. Before 0.1.0 those bare ALPNs were always offered/accepted, so a caller that opens a session **without** an application protocol (e.g. moq's WebSocket fallback, which constructs `new Session(url)` with no `protocols`) used to negotiate fine. Under 0.1.x the same call put an **empty subprotocol list** on the wire and the peer had nothing to negotiate.

The trap: the `Session` constructor signature never changed, only the default runtime behavior did, so downstream code (moq) still **compiled** while silently breaking the WebSocket fallback at runtime.

This PR replaces the double-negative `withoutProtocol` (default `false`) with **`requireProtocol`** (default `false`). Same default *value*, inverted *meaning*: bare ALPNs are now offered/accepted by default, and a caller opts into strict app-protocol negotiation with `requireProtocol: true` (JS) / `.require_protocol()` (Rust). This restores the original lenient behavior and keeps the JS and Rust implementations in lockstep.

## Changes

**JS (`@moq/qmux`)**
- `SessionOptions.withoutProtocol` → `requireProtocol`
- `InstallOptions.withoutProtocol` → `requireProtocol`
- Export `resolveSubprotocols` and cover it with a new `subprotocol.test.ts` (8 cases; the key regression: `resolveSubprotocols([], {}, false)` must yield `["qmux-01", "qmux-00", "webtransport"]`)

**Rust (`qmux`)**
- `ws::Client::without_protocol()` / `ws::Server::without_protocol()` → `require_protocol()`
- `tls::connect` and `alpn::build` params renamed and inverted
- `alpn` unit tests flipped/renamed to match

`withoutProtocol` only ever shipped in 0.1.0/0.1.1 and nothing depends on it, so it is removed outright rather than deprecated.

## Version

Both packages bumped to **0.1.2** (manual bump in `js/qmux/package.json` and `rs/qmux/Cargo.toml`).

## Behavior matrix

| | default | opt-out |
|---|---|---|
| JS `@moq/qmux` 0.1.2 | offers bare ALPNs | `requireProtocol: true` |
| Rust `qmux` 0.1.2 | offers/accepts bare ALPNs | `.require_protocol()` |

## Test plan

- [x] `cargo test -p qmux` (10 alpn + 4 lib + 20 wire-format) green via the pinned Nix toolchain
- [x] `cargo clippy -p qmux --all-targets --all-features` clean
- [x] `cargo fmt -p qmux --check` clean
- [x] `bun test js/qmux/src/` green (23 tests, 8 new)
- [x] `biome check` clean on changed JS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)