### PR TITLE
test: WebTransport browser regression harness + Firefox server-stream repro

### DIFF
--- a/js/web-demo/TESTING.md
+++ b/js/web-demo/TESTING.md
@@ -14,25 +14,34 @@ bugs — primarily:
   and CONNECT rejection (`/reject/<code>`). The "Aww, Snap! error 11" crash did
   **not** reproduce here — it likely needs a different reject/close shape or a
   different backend than `web-transport-quinn`.
-- **Firefox:** stalls after exactly **2 server-initiated streams** of any type
-  (`server-bi-5`, `server-uni-3`, `server-bi-concurrent-3` all fail;
-  concurrent also arrives **out of order**). Confirmed via server trace
-  (`RUST_LOG=info,quinn_proto=trace`):
-  - `open_bi() returned i=0, i=1` then the server **blocks** in `open_bi().await`
-    — Firefox grants an initial server-initiated stream credit of exactly **2**.
-  - `server-bi-serial/10` (open one, wait for the client to fully close it, then
-    open the next) **passes 10/10** — each open unblocks right after
-    `client closed bidi stream`. So **closing streams replenishes credit.**
-  - `got frame MaxStreams` is received as streams close, but not fast enough to
-    rescue a burst within the timeout.
-  - `client-bi-open-*` / `client-uni-open-*` pass — the limit is specifically on
-    **incoming** (server→client) streams, not client-opened ones.
-  - **Practical fix:** don't open server-initiated streams faster than the peer
-    drains them — cap concurrent server-opened streams to the negotiated
-    `initial_max_streams` (the `server-bi-serial` pattern).
-  - **Open question:** does a burst *eventually* recover or stay stuck forever?
-    Re-run `server-bi-5` in Firefox with the timeout box set to `30000` to tell
-    pacing (recovers) from a Firefox `MAX_STREAMS`-under-burst bug (stuck at 2).
+- **Firefox:** server-initiated streams stall at **2** — but it is **not** a
+  stream-credit problem. Root cause: **`incomingBidirectionalStreams` /
+  `incomingUnidirectionalStreams` backpressure that never resumes.** If the app
+  stops pulling the incoming-streams reader for a moment (e.g. while reading a
+  stream's body), Firefox fills the reader's queue (~2) and then **never delivers
+  any more streams, even after the app resumes pulling.**
+
+  Evidence:
+  - The decisive pair: `server-bi-probe-5` **passes** (it pulls all 5 stream
+    objects back-to-back, *then* reads their bodies), while `server-bi-5`
+    **fails** (it reads each body before pulling the next). Same server, same 5
+    streams — only the pull cadence differs.
+  - Server trace (`RUST_LOG=info,quinn_proto=trace`): Firefox grants
+    `MaxStreams { dir: Bi, count: 102 }`, the server opens **all 5** without
+    blocking (`open_bi() returned i=0..4 elapsed_ms=0`) and writes header+payload
+    to each — then **retransmits streams 2-4 repeatedly** because Firefox never
+    consumes them. The bytes are on the wire; Firefox just doesn't surface the
+    streams to JS.
+  - `server-uni-3` fails the same way with **no echo/writable involved** → rules
+    out the stream's send side; it's purely the incoming-stream reader.
+  - `server-bi-serial/10` passes (server opens one at a time → reader never backs
+    up); `server-mix` 2 uni + 2 bidi passes (per stream-type, ≤ queue);
+    `client-bi-open-*` pass (limit is only on **incoming** streams).
+  - **Workaround (works today):** drain the incoming-streams reader *promptly*
+    into your own queue and process bodies separately — never `await` per-stream
+    work inline between `reader.read()` calls. (This is exactly why the idiomatic
+    `for await (const s of incomingBidirectionalStreams) { await handle(s) }`
+    triggers the bug.)
 
 ## Layout
 

--- a/js/web-demo/TESTING.md
+++ b/js/web-demo/TESTING.md
@@ -1,0 +1,133 @@
+# Browser WebTransport test harness
+
+A reproducible battery of WebTransport scenarios for chasing browser-specific
+bugs — primarily:
+
+- **Firefox** breaking on **server-initiated bidirectional streams** (especially
+  the 2nd one).
+- **Chrome** "Aww, Snap! Error code 11" (a renderer **crash** = SIGSEGV) around
+  **explicit session close**, on connect or disconnect.
+
+## Findings so far
+
+- **Chrome (this quinn server):** 25/25 PASS, including every explicit-close path
+  and CONNECT rejection (`/reject/<code>`). The "Aww, Snap! error 11" crash did
+  **not** reproduce here — it likely needs a different reject/close shape or a
+  different backend than `web-transport-quinn`.
+- **Firefox:** stalls after exactly **2 server-initiated streams** of any type
+  (`server-bi-5`, `server-uni-3`, `server-bi-concurrent-3` all fail;
+  concurrent also arrives **out of order**). Confirmed via server trace
+  (`RUST_LOG=info,quinn_proto=trace`):
+  - `open_bi() returned i=0, i=1` then the server **blocks** in `open_bi().await`
+    — Firefox grants an initial server-initiated stream credit of exactly **2**.
+  - `server-bi-serial/10` (open one, wait for the client to fully close it, then
+    open the next) **passes 10/10** — each open unblocks right after
+    `client closed bidi stream`. So **closing streams replenishes credit.**
+  - `got frame MaxStreams` is received as streams close, but not fast enough to
+    rescue a burst within the timeout.
+  - `client-bi-open-*` / `client-uni-open-*` pass — the limit is specifically on
+    **incoming** (server→client) streams, not client-opened ones.
+  - **Practical fix:** don't open server-initiated streams faster than the peer
+    drains them — cap concurrent server-opened streams to the negotiated
+    `initial_max_streams` (the `server-bi-serial` pattern).
+  - **Open question:** does a burst *eventually* recover or stay stuck forever?
+    Re-run `server-bi-5` in Firefox with the timeout box set to `30000` to tell
+    pacing (recovers) from a Firefox `MAX_STREAMS`-under-burst bug (stuck at 2).
+
+## Layout
+
+It has two halves:
+
+- `rs/web-transport-quinn/examples/test-server.rs` — a server that picks its
+  behavior from the request **URL path** (e.g. `/server-bi/2`, `/server-close/42`).
+- `js/web-demo/test.html` + `test.js` — a page that runs each scenario, records
+  PASS / FAIL / TIMEOUT, and logs what happened.
+
+## 1. Generate a local certificate
+
+Browsers accept the self-signed cert via `serverCertificateHashes` (SHA-256
+pinning), so no CA is needed. The cert is only valid for 10 days — regenerate if
+connections start failing at `ready`.
+
+```bash
+bash dev/setup   # writes dev/localhost.{crt,key,hex}
+```
+
+## 2. Start the test server
+
+> Port 4443 may already be taken on this machine (e.g. by `moq-relay`). Pick a
+> free port and point the harness at it via the `server` box (or `?base=`).
+
+```bash
+cargo run --example test-server -p web-transport-quinn -- \
+    --tls-cert dev/localhost.crt --tls-key dev/localhost.key \
+    --addr 127.0.0.1:4444
+```
+
+The cert SAN covers `localhost` and `127.0.0.1`. Use `127.0.0.1` in the harness
+URL so it matches the bind address (plain `localhost` may resolve to IPv6 `::1`).
+
+## 3. Serve the harness
+
+```bash
+cd js/web-demo
+bun install
+npx parcel serve client.html test.html --port 1234
+```
+
+## 4. Run it in each browser
+
+Open <http://localhost:1234/test.html?base=https://127.0.0.1:4444> in **Firefox**
+and **Chrome**, then click **Run all** (or **Run** on a single row).
+
+- **Yellow rows close the session.** If the tab dies ("Aww, Snap!") while one of
+  these runs, *that scenario is the Chrome repro* — note its name.
+- ⭐ / ⚠ mark the prime suspects.
+- A hang shows up as **TIMEOUT** (default 8s, configurable) rather than freezing.
+
+### Deep links (handy for filing bugs / automation)
+
+- One scenario: `…/test.html?base=…&scenario=server-bi-2`
+- Auto-run everything: `…/test.html?base=…&run=all`
+
+## Scenarios
+
+**⭐ = reproduces the Firefox bug** (server-initiated streams stall at 2).
+
+| Scenario | URL path | What it exercises |
+|---|---|---|
+| `client-bi-echo` | `/client-bi-echo` | Baseline: client bidi → server echo |
+| `datagram-echo` | `/datagram-echo` | Baseline: client datagram → server echo |
+| `server-uni-1` | `/server-uni/1` | 1 server-initiated uni stream (passes) |
+| **`server-uni-3`** ⭐ | `/server-uni/3` | 3 server-initiated uni streams — **Firefox surfaces only 2** |
+| `server-bi-1` / `server-bi-2` | `/server-bi/N` | 1–2 server-initiated bidi streams (passes, at the limit) |
+| **`server-bi-5`** ⭐ | `/server-bi/5` | 5 server-initiated bidi streams — **Firefox surfaces only 2** |
+| **`server-bi-probe-5`** ⭐ | `/server-bi/5` | Probe: count stream OBJECTS delivered vs data flushed |
+| **`server-bi-concurrent-3`** ⭐ | `/server-bi-concurrent/3` | 3 bidi opened concurrently — **stalls at 2, out of order** |
+| `server-bi-serial-10` | `/server-bi-serial/10` | 10 bidi, drained one-at-a-time (passes → draining unblocks) |
+| `server-bi-no-finish-2` | `/server-bi-no-finish/2` | 2 server bidi streams, never FIN'd |
+| `server-mix-2uni-2bi` | `/server-mix/2` | 2 uni + 2 bidi (passes → limit is per-type, not shared) |
+| `server-datagram-3` | `/server-datagram/3` | Server-sent datagrams |
+| `client-bi-open-3/5/10` | `/echo` | **Client** opens N bidi streams (passes → direction matters) |
+| `client-bi-open-concurrent-5` | `/echo` | Client opens 5 bidi streams concurrently (passes) |
+| `client-uni-open-5/10` | `/echo` | **Client** opens N uni streams (passes) |
+| `server-close-0` ⚠ | `/server-close/0` | Server closes session, code 0 |
+| `server-close-42` ⚠ | `/server-close/42` | Server closes session, code 42 + reason |
+| `server-close-immediate` ⚠ | `/server-close-immediate/7` | Server closes the instant it's accepted |
+| `server-close-after-bi` ⚠ | `/server-close-after-bi/9` | Server opens a bidi stream, then closes |
+| `server-close-after-echo` ⚠ | `/server-close-after-echo/3` | Echo once, then server closes |
+| `client-close-immediate` ⚠ | `/echo` | Client closes right after connect |
+| `client-close-after-echo` | `/client-bi-echo` | Echo once, then client closes |
+| `reject-404/403/401/400/429/500/503` ⚠ | `/reject/<code>` | Server **rejects the CONNECT** with that HTTP status (`transport.ready` rejects) |
+| `mixed` | `/mixed/0` | uni + bidi + datagram + echo, then close |
+
+The `arg` (second path segment) is a **count** for the stream/datagram
+scenarios, a **close code** for the close scenarios, and the **HTTP status code**
+for `reject`.
+
+## Adding a scenario
+
+1. Add a `match` arm in `run_scenario()` in `test-server.rs`.
+2. Add an entry to `SCENARIOS` in `test.js` with the matching `path` and the
+   client steps. Set `noAutoClose: true` if the server (or the scenario itself)
+   closes the session.

--- a/js/web-demo/TESTING.md
+++ b/js/web-demo/TESTING.md
@@ -42,6 +42,11 @@ bugs — primarily:
     work inline between `reader.read()` calls. (This is exactly why the idiomatic
     `for await (const s of incomingBidirectionalStreams) { await handle(s) }`
     triggers the bug.)
+  - **Root cause (Firefox MOZ_LOG):** every layer delivers all 5 streams — neqo,
+    HTTP-3, and the parent→content IPC — but the content-process
+    `IncomingBidirectionalStreams` ReadableStream only enqueues 2: its `Pull`
+    callback fires twice and is never re-invoked from the backlog. Full trace in
+    [`firefox-bug/`](firefox-bug/README.md).
 
 ## Layout
 

--- a/js/web-demo/client.js
+++ b/js/web-demo/client.js
@@ -1,5 +1,5 @@
 // @ts-expect-error embed the certificate fingerprint using bundler
-import fingerprintHex from "bundle-text:../dev/localhost.hex";
+import fingerprintHex from "bundle-text:../../dev/localhost.hex";
 
 // Convert the hex to binary.
 const fingerprint = [];

--- a/js/web-demo/firefox-bug/README.md
+++ b/js/web-demo/firefox-bug/README.md
@@ -28,8 +28,17 @@ This explains the scenarios:
   being driven), then read them → **all 5** delivered.
 - `server-bi-serial-10` — server opens one at a time, never backlogs → **passes**.
 
+## Root cause
+
+Traced to the content-process pull algorithm in
+`dom/webtransport/api/WebTransportStreams.cpp`: the `length > 0` fast path of
+`PullCallbackImpl` returns a pull promise that is never resolved, wedging the
+ReadableStream's pull loop once a backlog forms. Full analysis + suggested fix:
+[`root-cause.md`](root-cause.md).
+
 ## Files
 
+- [`root-cause.md`](root-cause.md) — code-level analysis and proposed patch.
 - [`parent-process.log`](parent-process.log) — `MOZ_LOG=timestamp,nsHttp:5,WebTransport:5`,
   parent process. Shows neqo/HTTP-3 receiving all 5 and forwarding all 5 to content.
 - [`content-process.log`](content-process.log) — `MOZ_LOG=timestamp,WebTransport:5`,

--- a/js/web-demo/firefox-bug/README.md
+++ b/js/web-demo/firefox-bug/README.md
@@ -1,0 +1,38 @@
+# Firefox bug: incoming WebTransport streams stall at 2
+
+Firefox stops delivering **server-initiated** WebTransport streams to the page
+after **2**, when the application reads a stream's body before pulling the next
+stream from `incomingBidirectionalStreams` / `incomingUnidirectionalStreams`.
+Chrome is unaffected. Reproduce with the harness in this directory
+(`../test.html`, scenario `server-bi-5`); see [`../TESTING.md`](../TESTING.md).
+
+## Where it breaks (traced through every layer)
+
+| Layer | Streams handled | Evidence |
+|---|---|---|
+| neqo / HTTP-3 | 5 ✅ | `OnIncomingWebTransportStream` ×5 (parent log) |
+| Parent DOM → content IPC | 5 ✅ | `Sending BidirectionalStream pipe to content` ×5 (parent log) |
+| Content process receive | 5 ✅ | `NewBidirectionalStream()` ×5, `NotifyIncomingStream` → 4 (content log) |
+| **`IncomingBidirectionalStreams` ReadableStream** | **2 ❌** | `Pull` / `Enqueuing bidirectional stream` only ×2 (content log) |
+
+Every layer delivers all 5 streams. The JS-facing `IncomingBidirectionalStreams`
+ReadableStream only **enqueues 2**: its `Pull` callback fires twice and is never
+invoked again, even though 3+ streams sit in the internal backlog and the page
+keeps calling `reader.read()`. The incoming-streams source does not re-pull from
+its backlog once the ReadableStream's `desiredSize` drops after the initial fill.
+
+This explains the scenarios:
+
+- `server-bi-5` / `server-uni-3` — read each body, then pull next → **stall at 2**.
+- `server-bi-probe-5` — pull all 5 stream objects up front (while `Pull` is still
+  being driven), then read them → **all 5** delivered.
+- `server-bi-serial-10` — server opens one at a time, never backlogs → **passes**.
+
+## Files
+
+- [`parent-process.log`](parent-process.log) — `MOZ_LOG=timestamp,nsHttp:5,WebTransport:5`,
+  parent process. Shows neqo/HTTP-3 receiving all 5 and forwarding all 5 to content.
+- [`content-process.log`](content-process.log) — `MOZ_LOG=timestamp,WebTransport:5`,
+  content process. Shows all 5 arriving but only 2 enqueued to JS (`Pull` stops).
+
+Captured on Firefox, 2026-06-10, against the `test-server` example in this repo.

--- a/js/web-demo/firefox-bug/content-process.log
+++ b/js/web-demo/firefox-bug/content-process.log
@@ -1,0 +1,37 @@
+# Firefox MOZ_LOG excerpt (CONTENT process) — server-bi-5
+# MOZ_LOG=timestamp,WebTransport:5  /  file: wtlog.child-7.moz_log  /  2026-06-10 21:50 UTC
+#
+# DEFECT: all 5 incoming bidi streams reach the content process (NewBidirectionalStream x5)
+# and pile into the internal backlog (NotifyIncomingStream counter -> 4), but the
+# IncomingBidirectionalStreams ReadableStream 'Pull' callback fires only twice => only 2
+# streams enqueued to JS. Pull is never invoked again despite a non-empty backlog and the
+# app continuing to read. => incoming-streams ReadableStream does not re-pull from backlog.
+
+21:50:46.858875 Creating WebTransport for https://127.0.0.1:4444/server-bi/5
+21:50:46.858877 Creating WebTransport 112ab9120
+21:50:46.858908 Created datagram streams
+21:50:46.858922 Connecting WebTransport to parent for https://127.0.0.1:4444/server-bi/5
+21:50:46.869561 isreject: 0 nsresult <p>
+21:50:46.869563 Resolved Connection 112ab9120, reliability = 2
+21:50:46.869571 Setting child in datagrams
+21:50:46.869648 IncomingBiDirectionalStreams Pull waiting for a stream
+21:50:46.869676 NewBidirectionalStream()
+21:50:46.869677 NotifyIncomingStream
+21:50:46.869678 NotifyIncomingStream: 1 Bidirectional 
+21:50:46.869682 IncomingBiDirectionalStreams Pull building a stream
+21:50:46.869701 Enqueuing bidirectional stream
+21:50:46.869744 NewBidirectionalStream()
+21:50:46.869745 NotifyIncomingStream
+21:50:46.869746 NotifyIncomingStream: 1 Bidirectional 
+21:50:46.869757 NewBidirectionalStream()
+21:50:46.869758 NotifyIncomingStream
+21:50:46.869758 NotifyIncomingStream: 2 Bidirectional 
+21:50:46.869762 NewBidirectionalStream()
+21:50:46.869763 NotifyIncomingStream
+21:50:46.869763 NotifyIncomingStream: 3 Bidirectional 
+21:50:46.869810 NewBidirectionalStream()
+21:50:46.869814 NotifyIncomingStream
+21:50:46.869815 NotifyIncomingStream: 4 Bidirectional 
+21:50:46.870122 max datagram size for the session is 1224
+21:50:46.870238 IncomingBiDirectionalStreams Pull building a stream
+21:50:46.870253 Enqueuing bidirectional stream

--- a/js/web-demo/firefox-bug/parent-process.log
+++ b/js/web-demo/firefox-bug/parent-process.log
@@ -1,0 +1,116 @@
+# Firefox MOZ_LOG excerpt (Parent process) — server-bi-5 (server opens 5 server-initiated bidi streams)
+# Modules: nsHttp:5, WebTransport:5.  Run: 2026-06-10 21:46 UTC.
+#
+# CONCLUSION: the parent process receives all 5 incoming streams (neqo/HTTP-3),
+# the DOM WebTransportParent gets all 5 ('IncomingBidirectonalStream available' x5)
+# and forwards all 5 pipes to the content process ('Sending BidirectionalStream pipe to content' x5).
+# Only 2 are ever consumed by content (ReadSegments read=16 + SendFin x2); the other 3 idle
+# until the page's 8s timeout closes the session.  => the cap to 2 is in the CONTENT process
+#    (the JS-facing incomingBidirectionalStreams ReadableStream), downstream of all of this.
+
+21:46:02.221017 Created WebTransportParent 15ce0ba00 https://127.0.0.1:4444/server-bi/5 Dedicated  congestion=Default
+21:46:02.221452 Binding parent endpoint
+21:46:02.221485 WebTransport 15ce0ba00 AsyncConnect
+21:46:02.226829 Http3WebTransportSession ctor 173d7f0e0
+21:46:02.235823 Http3WebTransportSession::OnIncomingWebTransportStream this=173d7f0e0
+21:46:02.235828 Http3WebTransportStream incoming ctor 121428d60
+21:46:02.235840 Http3WebTransportStream::WriteSegments [this=121428d60]
+21:46:02.235846 Http3WebTransportStream::OnWriteSegment [this=121428d60, state=1
+21:46:02.235858 Http3WebTransportStream::WritePipeSegment 121428d60 written=11
+21:46:02.235859 Http3WebTransportStream::OnWriteSegment [this=121428d60, state=2
+21:46:02.235861 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=11 socketin=80470002 [this=121428d60]
+21:46:02.235864 Http3WebTransportSession::OnIncomingWebTransportStream this=173d7f0e0
+21:46:02.235865 Http3WebTransportStream incoming ctor 167768040
+21:46:02.235871 Http3WebTransportStream::WriteSegments [this=167768040]
+21:46:02.235875 Http3WebTransportStream::OnWriteSegment [this=167768040, state=1
+21:46:02.235883 Http3WebTransportStream::WritePipeSegment 167768040 written=11
+21:46:02.235884 Http3WebTransportStream::OnWriteSegment [this=167768040, state=2
+21:46:02.235886 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=11 socketin=80470002 [this=167768040]
+21:46:02.235888 Http3WebTransportSession::OnIncomingWebTransportStream this=173d7f0e0
+21:46:02.235889 Http3WebTransportStream incoming ctor 167768430
+21:46:02.235893 Http3WebTransportStream::WriteSegments [this=167768430]
+21:46:02.235895 Http3WebTransportStream::OnWriteSegment [this=167768430, state=1
+21:46:02.235908 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=0 socketin=80470007 [this=167768430]
+21:46:02.235910 Http3WebTransportStream::WriteSegments [this=167768040]
+21:46:02.235912 Http3WebTransportStream::WriteSegments rv=0x80470002 countWrittenSingle=0 socketin=0 [this=167768040]
+21:46:02.235983 Http3WebTransportSession::OnIncomingWebTransportStream this=173d7f0e0
+21:46:02.235985 Http3WebTransportStream incoming ctor 167768970
+21:46:02.235990 Http3WebTransportStream::WriteSegments [this=167768970]
+21:46:02.235994 Http3WebTransportStream::OnWriteSegment [this=167768970, state=1
+21:46:02.235997 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=0 socketin=80470007 [this=167768970]
+21:46:02.236000 Http3WebTransportStream::WriteSegments [this=167768430]
+21:46:02.236002 Http3WebTransportStream::OnWriteSegment [this=167768430, state=1
+21:46:02.236014 Http3WebTransportStream::WritePipeSegment 167768430 written=11
+21:46:02.236015 Http3WebTransportStream::OnWriteSegment [this=167768430, state=2
+21:46:02.236017 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=11 socketin=80470002 [this=167768430]
+21:46:02.236067 Http3WebTransportSession::OnIncomingWebTransportStream this=173d7f0e0
+21:46:02.236068 Http3WebTransportStream incoming ctor 167768580
+21:46:02.236073 Http3WebTransportStream::WriteSegments [this=167768580]
+21:46:02.236076 Http3WebTransportStream::OnWriteSegment [this=167768580, state=1
+21:46:02.236079 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=0 socketin=80470007 [this=167768580]
+21:46:02.236081 Http3WebTransportStream::WriteSegments [this=167768970]
+21:46:02.236082 Http3WebTransportStream::OnWriteSegment [this=167768970, state=1
+21:46:02.236085 Http3WebTransportStream::WritePipeSegment 167768970 written=11
+21:46:02.236086 Http3WebTransportStream::OnWriteSegment [this=167768970, state=2
+21:46:02.236087 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=11 socketin=80470002 [this=167768970]
+21:46:02.236266 Http3WebTransportStream::WriteSegments [this=167768580]
+21:46:02.236284 Http3WebTransportStream::OnWriteSegment [this=167768580, state=1
+21:46:02.236297 Http3WebTransportStream::WritePipeSegment 167768580 written=11
+21:46:02.236299 Http3WebTransportStream::OnWriteSegment [this=167768580, state=2
+21:46:02.236301 Http3WebTransportStream::WriteSegments rv=0x0 countWrittenSingle=11 socketin=80470002 [this=167768580]
+21:46:02.236613 Created web transport session, sessionID = 0, for 15ce0ba00
+21:46:02.236823 15ce0ba00 IncomingBidirectonalStream available
+21:46:02.236899 15ce0ba00 Sending BidirectionalStream pipe to content
+21:46:02.236954 15ce0ba00 IncomingBidirectonalStream available
+21:46:02.236988 15ce0ba00 Sending BidirectionalStream pipe to content
+21:46:02.237023 15ce0ba00 IncomingBidirectonalStream available
+21:46:02.237057 15ce0ba00 Sending BidirectionalStream pipe to content
+21:46:02.237082 15ce0ba00 IncomingBidirectonalStream available
+21:46:02.237136 15ce0ba00 Sending BidirectionalStream pipe to content
+21:46:02.237175 15ce0ba00 IncomingBidirectonalStream available
+21:46:02.237217 15ce0ba00 Sending BidirectionalStream pipe to content
+21:46:02.237304 WebTransportParent RecvGetMaxDatagramSize
+21:46:02.237317 Max datagram size is 1224
+21:46:02.237418 WebTransportParent Channel ID
+21:46:02.238886 Http3WebTransportStream::OnInputStreamReady [this=121428d60 stream=15cb9b430 state=1]
+21:46:02.238908 Http3WebTransportStream::ReadSegments [this=121428d60]
+21:46:02.238909 Http3WebTransportStream::ReadSegments state=2 [this=121428d60]
+21:46:02.238912 Http3WebTransportStream::OnReadSegment count=16 state=2 [this=121428d60]
+21:46:02.238921 Http3WebTransportStream::OnReadSegment 121428d60 sending body returns error=0x0.
+21:46:02.238922 Http3WebTransportStream::ReadRequestSegment 121428d60 read=16
+21:46:02.238924 Http3WebTransportStream::ReadSegments rv=0x0 read=16 sock-cond=0 again=1 mSendFin=0 [this=121428d60]
+21:46:02.238926 Http3WebTransportStream::ReadSegments state=2 [this=121428d60]
+21:46:02.238927 Http3WebTransportStream::ReadSegments rv=0x0 read=0 sock-cond=0 again=1 mSendFin=0 [this=121428d60]
+21:46:02.238928 Http3WebTransportStream::SendFin [this=121428d60 mSendState=3]
+21:46:02.238964 Http3WebTransportStream::ReadSegments [this=121428d60]
+21:46:02.238965 Http3WebTransportStream::ReadSegments state=3 [this=121428d60]
+21:46:02.239287 Http3WebTransportStream::OnInputStreamReady [this=167768040 stream=15cb9ba60 state=1]
+21:46:02.239298 Http3WebTransportStream::ReadSegments [this=167768040]
+21:46:02.239299 Http3WebTransportStream::ReadSegments state=2 [this=167768040]
+21:46:02.239301 Http3WebTransportStream::OnReadSegment count=16 state=2 [this=167768040]
+21:46:02.239305 Http3WebTransportStream::OnReadSegment 167768040 sending body returns error=0x0.
+21:46:02.239306 Http3WebTransportStream::ReadRequestSegment 167768040 read=16
+21:46:02.239307 Http3WebTransportStream::ReadSegments rv=0x0 read=16 sock-cond=0 again=1 mSendFin=0 [this=167768040]
+21:46:02.239308 Http3WebTransportStream::ReadSegments state=2 [this=167768040]
+21:46:02.239310 Http3WebTransportStream::ReadSegments rv=0x0 read=0 sock-cond=0 again=1 mSendFin=0 [this=167768040]
+21:46:02.239311 Http3WebTransportStream::SendFin [this=167768040 mSendState=3]
+21:46:02.239318 Http3WebTransportStream::ReadSegments [this=167768040]
+21:46:02.239341 Http3WebTransportStream::ReadSegments state=3 [this=167768040]
+21:46:10.239378 Close for 15ce0ba00 received, code = 0, reason = 
+21:46:10.239451 ActorDestroy WebTransportParent 3
+21:46:10.239460 Destroying WebTransportParent 15ce0ba00
+21:46:10.239561 Http3WebTransportSession::Close 173d7f0e0
+21:46:10.239564 Http3Session::CloseWebTransportConn 163296400
+21:46:10.239668 Http3Session::CloseWebTransportStream 163296400 167768430 0x804b00c8
+21:46:10.239671 Http3WebTransportStream::Close [this=167768430]
+21:46:10.239696 Http3WebTransportStream dtor 167768430
+21:46:10.239724 Http3Session::CloseWebTransportStream 163296400 167768970 0x804b00c8
+21:46:10.239726 Http3WebTransportStream::Close [this=167768970]
+21:46:10.239739 Http3WebTransportStream dtor 167768970
+21:46:10.239748 Http3Session::CloseWebTransportStream 163296400 167768580 0x804b00c8
+21:46:10.239750 Http3WebTransportStream::Close [this=167768580]
+21:46:10.239760 Http3WebTransportStream dtor 167768580
+21:46:10.240084 Http3WebTransportStream::Close [this=121428d60]
+21:46:10.240091 Http3WebTransportStream::Close [this=167768040]
+21:46:10.240096 Http3WebTransportStream dtor 121428d60
+21:46:10.240119 Http3WebTransportStream dtor 167768040

--- a/js/web-demo/firefox-bug/root-cause.md
+++ b/js/web-demo/firefox-bug/root-cause.md
@@ -1,0 +1,92 @@
+# Root cause: `IncomingBidirectionalStreams` pull promise is never resolved on the fast path
+
+**TL;DR** — Firefox stops delivering server-initiated WebTransport streams to the
+page after the first one whenever a backlog has formed, because
+`WebTransportIncomingStreamsAlgorithms::PullCallbackImpl` returns an **unresolved
+promise** on its synchronous (`length > 0`) path. A ReadableStream won't call
+`Pull` again until the previous pull promise settles, so the incoming-streams
+reader wedges permanently.
+
+## Location
+
+[`dom/webtransport/api/WebTransportStreams.cpp`](https://searchfox.org/mozilla-central/source/dom/webtransport/api/WebTransportStreams.cpp)
+— `WebTransportIncomingStreamsAlgorithms::PullCallbackImpl` / `BuildStream`.
+
+```cpp
+RefPtr<Promise> promise = Promise::CreateInfallible(...);   // the pull promise
+auto length = mTransport->mBidirectionalStreams.Length();
+if (length == 0) {
+  // SLOW PATH — wait for a stream, then BuildStream via a chained promise.
+  mCallback = promise;
+  Result<...> returnResult = promise->ThenWithCycleCollectedArgs(
+      [](...) { self->BuildStream(aCx, aRv); return nullptr; }, ...);
+  return returnResult.unwrap().forget();   // ← a promise that DOES resolve
+}
+self->BuildStream(aCx, aRv);
+return promise.forget();                    // ← FAST PATH: `promise` is NEVER resolved
+```
+
+`BuildStream()` enqueues the stream but never resolves `promise`, even though the
+spec step it implements is annotated in the code as *"Step 7.3: Resolve p with
+undefined."* (the comment is present; the resolve is not).
+
+## Why it wedges
+
+Per the Streams spec, `ReadableStreamDefaultControllerCallPullIfNeeded` sets
+`pulling = true`, calls the pull algorithm, and only clears `pulling` / honours a
+queued `pullAgain` **when the returned promise fulfills**. The `length > 0` path
+returns a promise that never fulfills, so after it runs once `pulling` stays
+`true` forever and `Pull` is never invoked again — no matter how many streams are
+backlogged or how many times the page calls `reader.read()`.
+
+The `length == 0` path returns a *chained* promise (`ThenWithCycleCollectedArgs`)
+that resolves once `BuildStream` runs, so it behaves correctly. The bug is the
+asymmetry between the two paths.
+
+## Why it reproduces exactly as observed
+
+`length > 0` means a stream is already in the backlog when `Pull` runs — i.e. the
+app let streams pile up. MOZ_LOG (content process, `WebTransport:5`) shows all 5
+streams arriving (`NewBidirectionalStream()` ×5, `NotifyIncomingStream` backlog
+→ 4) but only **2** `Enqueuing bidirectional stream` before `Pull` goes silent.
+
+| Scenario | What `Pull` sees | Path taken | Result |
+|---|---|---|---|
+| `server-bi-5` / `server-uni-3` (read body, *then* pull next) | backlog builds while reading bodies; 2nd pull finds `length > 0` | fast path → unresolved → **wedged** | stalls at 2 |
+| `server-bi-probe-5` (pull all stream objects first) | queue stays drained; every pull finds `length == 0` | slow path (resolves) | all 5 |
+| `server-bi-serial-10` (server opens one at a time) | backlog never forms; always `length == 0` | slow path | passes |
+
+It also explains the precise "stalls at **2**": stream 1 is delivered via the
+working `length == 0` path; by the second pull a backlog exists, the `length > 0`
+path runs, returns the dead promise, and pull never fires again.
+
+This is direction-agnostic (uni hits the same code), QUIC/HTTP-3 and the parent
+process deliver all N streams (see `parent-process.log`), and Chrome is
+unaffected — consistent with the defect being solely in this content-process
+pull algorithm.
+
+## Suggested fix
+
+Resolve the pull promise on the synchronous path (ideally make `BuildStream` own
+the resolve so both paths are consistent):
+
+```cpp
+  self->BuildStream(aCx, aRv);
+  if (aRv.Failed()) {
+    promise->MaybeReject(aRv.StealNSResult());
+    return promise.forget();
+  }
+  promise->MaybeResolveWithUndefined();   // the missing Step 7.3
+  return promise.forget();
+```
+
+## Repro
+
+Self-contained, no public server needed: <https://github.com/moq-dev/web-transport/pull/251>.
+Run the harness in Firefox and compare `server-bi-5` (stalls at 2) with
+`server-bi-probe-5` (all 5). Traces in this directory: `parent-process.log`,
+`content-process.log`.
+
+> Caveat: code/line references are from `mozilla-central` (GitHub `mozilla/gecko-dev`
+> mirror, read June 2026). The logic has clearly been in place a while, but
+> confirm against the exact Firefox build before filing.

--- a/js/web-demo/test.html
+++ b/js/web-demo/test.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>WebTransport Test Harness</title>
+	<style>
+		body { font-family: system-ui, sans-serif; margin: 1rem; color: #111; }
+		h1 { font-size: 1.3rem; }
+		#ua { font-size: 0.75rem; color: #666; word-break: break-all; }
+		.controls { display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0; flex-wrap: wrap; }
+		.controls label { font-size: 0.85rem; }
+		input { padding: 0.25rem 0.4rem; font: inherit; }
+		input#base { width: 22rem; }
+		input#timeout { width: 5rem; }
+		button { padding: 0.3rem 0.7rem; font: inherit; cursor: pointer; }
+		#run-all { font-weight: 600; }
+		#summary { font-weight: 600; margin-left: auto; }
+		table { border-collapse: collapse; width: 100%; }
+		th, td { border: 1px solid #ddd; padding: 0.35rem 0.5rem; vertical-align: top; text-align: left; }
+		th { background: #f5f5f5; font-size: 0.8rem; }
+		td.name { font-weight: 600; white-space: nowrap; }
+		.desc { font-weight: 400; color: #666; font-size: 0.78rem; white-space: normal; max-width: 28rem; }
+		pre.log { margin: 0; font-size: 0.72rem; white-space: pre-wrap; max-height: 9rem; overflow: auto; color: #333; }
+		.status { font-weight: 700; font-size: 0.78rem; text-align: center; white-space: nowrap; }
+		.status.pending { color: #999; }
+		.status.running { color: #b8860b; }
+		.status.pass { color: #fff; background: #2e7d32; }
+		.status.fail { color: #fff; background: #c62828; }
+		.status.timeout { color: #fff; background: #ef6c00; }
+		tr[data-kind="close"] { background: #fffaf0; }
+	</style>
+</head>
+<body>
+	<h1>WebTransport Test Harness</h1>
+	<div id="ua"></div>
+
+	<div class="controls">
+		<label>server <input id="base" value="https://localhost:4443"></label>
+		<label>timeout(ms) <input id="timeout" type="number" value="8000"></label>
+		<button id="run-all">Run all</button>
+		<span id="summary">PASS 0 · FAIL 0 · TIMEOUT 0</span>
+	</div>
+
+	<p style="font-size:0.8rem;color:#666">
+		<b>⭐ = reproduces the Firefox bug</b> (server-initiated streams stall at 2 — see TESTING.md).
+		Yellow rows explicitly close the session; ⚠ marks the Chrome "Aww, Snap! Error code 11" suspects.
+	</p>
+
+	<table>
+		<thead>
+			<tr><th></th><th>Status</th><th>Scenario</th><th>Log</th></tr>
+		</thead>
+		<tbody id="scenarios"></tbody>
+	</table>
+
+	<script src="test.js" type="module"></script>
+</body>
+</html>

--- a/js/web-demo/test.js
+++ b/js/web-demo/test.js
@@ -1,0 +1,717 @@
+// WebTransport browser regression harness.
+//
+// Pairs with `rs/web-transport-quinn/examples/test-server.rs`. Each scenario
+// picks a server behavior via the URL path and runs the matching client steps,
+// then reports PASS / FAIL / TIMEOUT. Open this in Firefox and Chrome and click
+// "Run all" — the goal is to pin down:
+//
+//   * Firefox breaking on server-initiated bidirectional streams (esp. the 2nd).
+//   * Chrome "Aww, Snap! Error code 11" (renderer crash) on explicit session close.
+//
+// A renderer crash kills the page, so those scenarios can't self-report — if the
+// tab dies while a "⚠ Chrome crash suspect" scenario is running, THAT is the repro.
+
+// @ts-expect-error embed the certificate fingerprint using bundler
+import fingerprintHex from "bundle-text:../../dev/localhost.hex";
+
+// Convert the hex fingerprint to bytes for serverCertificateHashes.
+const fingerprint = [];
+for (let c = 0; c < fingerprintHex.length - 1; c += 2) {
+	fingerprint.push(parseInt(fingerprintHex.substring(c, c + 2), 16));
+}
+
+const enc = (s) => new TextEncoder().encode(s);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function assert(cond, msg) {
+	if (!cond) throw new Error(msg || "assertion failed");
+}
+
+function options() {
+	return {
+		serverCertificateHashes: [{ algorithm: "sha-256", value: new Uint8Array(fingerprint) }],
+	};
+}
+
+// ----- low-level stream/datagram helpers -----------------------------------
+
+// Read a ReadableStream of Uint8Array to completion as text (waits for FIN).
+async function readAll(readable) {
+	const reader = readable.getReader();
+	const dec = new TextDecoder();
+	let out = "";
+	for (;;) {
+		const { value, done } = await reader.read();
+		if (done) break;
+		out += dec.decode(value, { stream: true });
+	}
+	out += dec.decode();
+	reader.releaseLock();
+	return out;
+}
+
+// Accept `count` server-initiated bidi streams, reading each to FIN.
+// Optionally echo the payload back so the server's recv side isn't reset.
+async function readIncomingBidi(transport, count, log, echo = true) {
+	const reader = transport.incomingBidirectionalStreams.getReader();
+	const got = [];
+	try {
+		for (let i = 0; i < count; i++) {
+			const { value: stream, done } = await reader.read();
+			if (done) throw new Error(`incomingBidirectionalStreams ended after ${i}/${count}`);
+			// Separate "stream object delivered" from "data flushed" so we can tell
+			// a delivery cap (reader.read never yields #i) from a flush stall
+			// (object arrives but readable never produces data).
+			log(`accepted server bidi #${i} (object delivered; awaiting data)`);
+			const text = await readAll(stream.readable);
+			log(`  flushed server bidi #${i}: "${text}"`);
+			got.push(text);
+			if (echo) {
+				const w = stream.writable.getWriter();
+				await w.write(enc(`echo:${text}`));
+				await w.close();
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return got;
+}
+
+// Like readIncomingBidi but the server never FINs — read only the first chunk.
+async function readIncomingBidiNoFin(transport, count, log) {
+	const reader = transport.incomingBidirectionalStreams.getReader();
+	const got = [];
+	try {
+		for (let i = 0; i < count; i++) {
+			const { value: stream, done } = await reader.read();
+			if (done) throw new Error(`incomingBidirectionalStreams ended after ${i}/${count}`);
+			const r = stream.readable.getReader();
+			const { value } = await r.read();
+			const text = new TextDecoder().decode(value);
+			log(`recv server bidi (no-fin) #${i}: "${text}"`);
+			got.push(text);
+			r.cancel().catch(() => {});
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return got;
+}
+
+// Accept `count` server-initiated unidirectional streams.
+async function readIncomingUni(transport, count, log) {
+	const reader = transport.incomingUnidirectionalStreams.getReader();
+	const got = [];
+	try {
+		for (let i = 0; i < count; i++) {
+			const { value: stream, done } = await reader.read();
+			if (done) throw new Error(`incomingUnidirectionalStreams ended after ${i}/${count}`);
+			log(`accepted server uni #${i} (object delivered; awaiting data)`);
+			const text = await readAll(stream);
+			log(`  flushed server uni #${i}: "${text}"`);
+			got.push(text);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return got;
+}
+
+// Read `count` datagrams from the server.
+async function readDatagrams(transport, count, log) {
+	const reader = transport.datagrams.readable.getReader();
+	const dec = new TextDecoder();
+	const got = [];
+	try {
+		for (let i = 0; i < count; i++) {
+			const { value, done } = await reader.read();
+			if (done) throw new Error(`datagrams ended after ${i}/${count}`);
+			const text = dec.decode(value);
+			log(`recv server datagram #${i}: "${text}"`);
+			got.push(text);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return got;
+}
+
+// Open `count` client-initiated bidi streams, echoing each. Tests whether the
+// stall is direction-specific: client->server vs server->client. The server
+// (echo loop) grants generous stream credit, so if Firefox stalls server-bi-N
+// at 2 but sails through client-bi-open-N, the limit is on *incoming* streams.
+async function openClientBidi(transport, count, log, concurrent = false) {
+	const one = async (i) => {
+		const s = await transport.createBidirectionalStream();
+		const w = s.writable.getWriter();
+		await w.write(enc(`client-bi-${i}`));
+		await w.close();
+		const text = await readAll(s.readable);
+		log(`opened+echoed client bidi #${i}: "${text}"`);
+		return text;
+	};
+	if (concurrent) return Promise.all(Array.from({ length: count }, (_, i) => one(i)));
+	const got = [];
+	for (let i = 0; i < count; i++) got.push(await one(i));
+	return got;
+}
+
+// Open `count` client-initiated unidirectional streams (server drains them).
+// `createUnidirectionalStream()` itself blocks if the peer's stream-count limit
+// is hit, so awaiting each open detects a credit stall on the client->server
+// direction.
+async function openClientUni(transport, count, log) {
+	const got = [];
+	for (let i = 0; i < count; i++) {
+		const stream = await transport.createUnidirectionalStream();
+		const w = stream.getWriter();
+		await w.write(enc(`client-uni-${i}`));
+		await w.close();
+		log(`opened client uni #${i}`);
+		got.push(i);
+	}
+	return got;
+}
+
+// Two-phase probe: first collect stream OBJECTS from incomingBidirectionalStreams
+// (without reading their data), then read each. Pinpoints the exact layer of the
+// Firefox stall — how many stream objects are delivered vs how many flush data.
+async function probeIncomingBidi(transport, count, log) {
+	const reader = transport.incomingBidirectionalStreams.getReader();
+	const streams = [];
+	// Phase 1 — accept stream objects only.
+	for (let i = 0; i < count; i++) {
+		let res;
+		try {
+			res = await withTimeout(reader.read(), 3000, `accept #${i}`);
+		} catch (e) {
+			log(`accept #${i}: ${e.message}`);
+			break;
+		}
+		if (res.done) {
+			log(`incoming ended after ${i}`);
+			break;
+		}
+		log(`accepted object #${i}`);
+		streams.push(res.value);
+	}
+	log(`==> ${streams.length}/${count} stream OBJECTS delivered`);
+	// Phase 2 — read data from each collected stream.
+	let flushed = 0;
+	for (let i = 0; i < streams.length; i++) {
+		try {
+			const text = await withTimeout(readAll(streams[i].readable), 3000, `read #${i}`);
+			log(`data #${i}: "${text}"`);
+			flushed++;
+		} catch (e) {
+			log(`data #${i}: ${e.message}`);
+		}
+	}
+	log(`==> ${flushed}/${streams.length} streams FLUSHED data`);
+	reader.releaseLock();
+	return { objects: streams.length, flushed };
+}
+
+// Wait for the session to close, surfacing the close code/reason either way.
+async function expectClosed(transport, log) {
+	try {
+		const info = await transport.closed;
+		log(`transport.closed RESOLVED: closeCode=${info?.closeCode}, reason="${info?.reason}"`);
+		return info ?? {};
+	} catch (e) {
+		log(`transport.closed REJECTED: ${e?.message ?? e}`);
+		return { closeCode: e?.closeCode, reason: String(e?.message ?? e), rejected: true };
+	}
+}
+
+// ----- scenarios -----------------------------------------------------------
+//
+// `kind`:
+//   "baseline"  — basic sanity
+//   "server"    — server-initiated streams/datagrams (Firefox suspects)
+//   "close"     — explicit session close (Chrome crash suspects)
+// `noAutoClose`: don't call transport.close() in cleanup (the scenario or server
+//   already closes it).
+
+const SCENARIOS = [
+	{
+		name: "client-bi-echo",
+		path: "client-bi-echo",
+		kind: "baseline",
+		desc: "Baseline: client opens a bidi stream, server echoes.",
+		async run(t, { log }) {
+			const s = await t.createBidirectionalStream();
+			const w = s.writable.getWriter();
+			await w.write(enc("hello"));
+			await w.close();
+			const text = await readAll(s.readable);
+			log(`echo: "${text}"`);
+			assert(text === "hello", `expected "hello", got "${text}"`);
+		},
+	},
+	{
+		name: "datagram-echo",
+		path: "datagram-echo",
+		kind: "baseline",
+		desc: "Baseline: client sends a datagram, server echoes.",
+		async run(t, { log }) {
+			const w = t.datagrams.writable.getWriter();
+			await w.write(enc("ping"));
+			w.releaseLock();
+			const [d] = await readDatagrams(t, 1, log);
+			assert(d === "ping", `expected "ping", got "${d}"`);
+		},
+	},
+	{
+		name: "server-uni-1",
+		path: "server-uni/1",
+		kind: "server",
+		desc: "Server opens 1 unidirectional stream.",
+		async run(t, { log }) {
+			const g = await readIncomingUni(t, 1, log);
+			assert(g[0] === "server-uni-0", `got "${g[0]}"`);
+		},
+	},
+	{
+		name: "server-uni-3",
+		path: "server-uni/3",
+		kind: "server",
+		desc: "⭐ FAILS IN FIREFOX: server opens 3 uni streams; Firefox surfaces only 2.",
+		async run(t, { log }) {
+			const g = await readIncomingUni(t, 3, log);
+			assert(g.length === 3, `got ${g.length}`);
+		},
+	},
+	{
+		name: "server-bi-1",
+		path: "server-bi/1",
+		kind: "server",
+		desc: "Server opens 1 bidi stream (client echoes back).",
+		async run(t, { log }) {
+			const g = await readIncomingBidi(t, 1, log);
+			assert(g[0] === "server-bi-0", `got "${g[0]}"`);
+		},
+	},
+	{
+		name: "server-bi-2",
+		path: "server-bi/2",
+		kind: "server",
+		desc: "Server opens 2 bidi streams sequentially (passes — right at the limit).",
+		async run(t, { log }) {
+			const g = await readIncomingBidi(t, 2, log);
+			assert(g.length === 2, `only got ${g.length}/2 streams`);
+		},
+	},
+	{
+		name: "server-bi-5",
+		path: "server-bi/5",
+		kind: "server",
+		desc: "⭐ FAILS IN FIREFOX: server opens 5 bidi streams; Firefox surfaces only 2.",
+		async run(t, { log }) {
+			const g = await readIncomingBidi(t, 5, log);
+			assert(g.length === 5, `only got ${g.length}/5 streams`);
+		},
+	},
+	{
+		name: "server-bi-probe-5",
+		path: "server-bi/5",
+		kind: "server",
+		desc: "⭐ FAILS IN FIREFOX: probe — accept all 5 stream OBJECTS first, then read each (separates delivery cap from flush stall).",
+		async run(t, { log }) {
+			const r = await probeIncomingBidi(t, 5, log);
+			assert(r.flushed === 5, `objects=${r.objects}/5, flushed=${r.flushed}/5`);
+		},
+	},
+	{
+		name: "server-mix-2uni-2bi",
+		path: "server-mix/2",
+		kind: "server",
+		desc: "Server opens 2 uni + 2 bidi (passes in Firefox → the limit is per-type, not shared across types).",
+		async run(t, { log }) {
+			const [u, b] = await Promise.all([readIncomingUni(t, 2, log), readIncomingBidi(t, 2, log)]);
+			assert(u.length === 2 && b.length === 2, `got uni=${u.length}/2 bi=${b.length}/2`);
+		},
+	},
+	{
+		name: "server-bi-serial-10",
+		path: "server-bi-serial/10",
+		kind: "server",
+		desc: "Server opens 10 bidi but waits for the client to fully close each before the next (passes in Firefox → draining unblocks delivery).",
+		async run(t, { log }) {
+			const g = await readIncomingBidi(t, 10, log);
+			assert(g.length === 10, `only got ${g.length}/10 streams`);
+		},
+	},
+	{
+		name: "server-bi-concurrent-3",
+		path: "server-bi-concurrent/3",
+		kind: "server",
+		desc: "⭐ FAILS IN FIREFOX: server opens 3 bidi concurrently; Firefox surfaces only 2 (and out of order).",
+		async run(t, { log }) {
+			const g = await readIncomingBidi(t, 3, log);
+			assert(g.length === 3, `only got ${g.length}/3 streams`);
+		},
+	},
+	{
+		name: "server-bi-no-finish-2",
+		path: "server-bi-no-finish/2",
+		kind: "server",
+		desc: "Server opens 2 bidi streams but never FINs them.",
+		async run(t, { log }) {
+			const g = await readIncomingBidiNoFin(t, 2, log);
+			assert(g.length === 2, `only got ${g.length}/2 streams`);
+		},
+	},
+	{
+		name: "server-datagram-3",
+		path: "server-datagram/3",
+		kind: "server",
+		desc: "Server sends 3 datagrams.",
+		async run(t, { log }) {
+			const g = await readDatagrams(t, 3, log);
+			assert(g.length === 3, `only got ${g.length}/3 datagrams`);
+		},
+	},
+	// ----- client-initiated streams (does direction/endpoint matter?) ------
+	//
+	// Compare against server-bi-N / server-uni-N. If Firefox stalls when the
+	// SERVER opens streams but not when the CLIENT does, the limit is on
+	// incoming (server->client) stream credit specifically.
+	{
+		name: "client-bi-open-3",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 3 bidi streams (server echoes each).",
+		async run(t, { log }) {
+			const g = await openClientBidi(t, 3, log);
+			assert(g.length === 3, `only ${g.length}/3`);
+		},
+	},
+	{
+		name: "client-bi-open-5",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 5 bidi streams (passes — client-initiated direction is unaffected).",
+		async run(t, { log }) {
+			const g = await openClientBidi(t, 5, log);
+			assert(g.length === 5, `only ${g.length}/5`);
+		},
+	},
+	{
+		name: "client-bi-open-10",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 10 bidi streams sequentially.",
+		async run(t, { log }) {
+			const g = await openClientBidi(t, 10, log);
+			assert(g.length === 10, `only ${g.length}/10`);
+		},
+	},
+	{
+		name: "client-bi-open-concurrent-5",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 5 bidi streams concurrently.",
+		async run(t, { log }) {
+			const g = await openClientBidi(t, 5, log, true);
+			assert(g.length === 5, `only ${g.length}/5`);
+		},
+	},
+	{
+		name: "client-uni-open-5",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 5 uni streams (server drains). Compare with server-uni-3.",
+		async run(t, { log }) {
+			const g = await openClientUni(t, 5, log);
+			assert(g.length === 5, `only ${g.length}/5`);
+			// Confirm the session is still usable afterwards.
+			const s = await t.createBidirectionalStream();
+			const w = s.writable.getWriter();
+			await w.write(enc("alive?"));
+			await w.close();
+			log(`alive check echo: "${await readAll(s.readable)}"`);
+		},
+	},
+	{
+		name: "client-uni-open-10",
+		path: "echo",
+		kind: "server",
+		desc: "Client opens 10 uni streams sequentially.",
+		async run(t, { log }) {
+			const g = await openClientUni(t, 10, log);
+			assert(g.length === 10, `only ${g.length}/10`);
+		},
+	},
+	{
+		name: "server-close-0",
+		path: "server-close/0",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Server closes the session with code 0. Chrome crash suspect.",
+		async run(t, { log }) {
+			const info = await expectClosed(t, log);
+			assert(info.closeCode === 0, `expected closeCode 0, got ${info.closeCode}`);
+		},
+	},
+	{
+		name: "server-close-42",
+		path: "server-close/42",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Server closes the session with code 42 + reason. Chrome crash suspect.",
+		async run(t, { log }) {
+			const info = await expectClosed(t, log);
+			assert(info.closeCode === 42, `expected closeCode 42, got ${info.closeCode}`);
+		},
+	},
+	{
+		name: "server-close-immediate",
+		path: "server-close-immediate/7",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Server closes the instant the session is accepted (races ready). Chrome crash suspect.",
+		async run(t, { log }) {
+			await expectClosed(t, log);
+		},
+	},
+	{
+		name: "server-close-after-bi",
+		path: "server-close-after-bi/9",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Server opens a bidi stream, then closes the session. Chrome crash suspect.",
+		async run(t, { log }) {
+			await readIncomingBidi(t, 1, log, false).catch((e) => log(`(stream read: ${e.message})`));
+			await expectClosed(t, log);
+		},
+	},
+	{
+		name: "server-close-after-echo",
+		path: "server-close-after-echo/3",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Client opens bidi, server echoes then closes the session. Chrome crash suspect.",
+		async run(t, { log }) {
+			const s = await t.createBidirectionalStream();
+			const w = s.writable.getWriter();
+			await w.write(enc("bye"));
+			await w.close();
+			const text = await readAll(s.readable);
+			log(`echo: "${text}"`);
+			await expectClosed(t, log);
+		},
+	},
+	{
+		name: "client-close-immediate",
+		path: "echo",
+		kind: "close",
+		noAutoClose: true,
+		desc: "⚠ Client connects then immediately closes. Chrome crash suspect (connect/disconnect).",
+		async run(t, { log }) {
+			t.close({ closeCode: 5, reason: "client-bye" });
+			log("client called close({closeCode:5})");
+			await sleep(200);
+		},
+	},
+	{
+		name: "client-close-after-echo",
+		path: "client-bi-echo",
+		kind: "close",
+		noAutoClose: true,
+		desc: "Client echoes once then closes (the original demo flow).",
+		async run(t, { log }) {
+			const s = await t.createBidirectionalStream();
+			const w = s.writable.getWriter();
+			await w.write(enc("hello"));
+			await w.close();
+			const text = await readAll(s.readable);
+			log(`echo: "${text}"`);
+			t.close();
+			log("client called close()");
+			await sleep(200);
+		},
+	},
+	// ----- rejected CONNECT (non-200 status) -------------------------------
+	//
+	// The server replies to the CONNECT with an HTTP error instead of accepting,
+	// so the session is never established and `transport.ready` rejects. This is
+	// a different code path from "accept then close" and a suspected Chrome crash
+	// trigger. `skipReady` tells the runner not to await ready itself — the
+	// scenario does it and expects a rejection.
+	...[
+		{ code: 404, name: "reject-404" },
+		{ code: 403, name: "reject-403" },
+		{ code: 401, name: "reject-401" },
+		{ code: 400, name: "reject-400" },
+		{ code: 429, name: "reject-429" },
+		{ code: 500, name: "reject-500" },
+		{ code: 503, name: "reject-503" },
+	].map(({ code, name }) => ({
+		name,
+		path: `reject/${code}`,
+		kind: "close",
+		noAutoClose: true,
+		skipReady: true,
+		desc: `⚠ Server rejects the CONNECT with HTTP ${code}. Suspected Chrome crash trigger.`,
+		async run(t, { log }) {
+			try {
+				await t.ready;
+				throw new Error("transport.ready RESOLVED but server should have rejected");
+			} catch (e) {
+				log(`ready REJECTED (expected): ${e?.name}: ${e?.message ?? e}`);
+			}
+			await t.closed
+				.then((i) => log(`closed RESOLVED: ${JSON.stringify(i)}`))
+				.catch((e) => log(`closed REJECTED: ${e?.name}: ${e?.message ?? e}`));
+		},
+	})),
+	{
+		name: "mixed",
+		path: "mixed/0",
+		kind: "close",
+		noAutoClose: true,
+		desc: "Kitchen sink: server uni + bidi + datagram + echo, then close.",
+		async run(t, { log }) {
+			const uni = readIncomingUni(t, 1, log).catch((e) => log(`uni: ${e.message}`));
+			const bi = readIncomingBidi(t, 1, log, false).catch((e) => log(`bidi: ${e.message}`));
+			const dg = readDatagrams(t, 1, log).catch((e) => log(`dgram: ${e.message}`));
+			const s = await t.createBidirectionalStream();
+			const w = s.writable.getWriter();
+			await w.write(enc("kitchen"));
+			await w.close();
+			await readAll(s.readable)
+				.then((x) => log(`echo: "${x}"`))
+				.catch((e) => log(`echo: ${e.message}`));
+			await Promise.allSettled([uni, bi, dg]);
+			await expectClosed(t, log);
+		},
+	},
+];
+
+// ----- runner --------------------------------------------------------------
+
+function withTimeout(p, ms, label) {
+	let timer;
+	const timeout = new Promise((_, reject) => {
+		timer = setTimeout(() => {
+			const e = new Error(`timeout after ${ms}ms (${label})`);
+			e.__timeout = true;
+			reject(e);
+		}, ms);
+	});
+	return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
+const ui = {
+	base: () => document.getElementById("base").value.replace(/\/$/, ""),
+	timeout: () => parseInt(document.getElementById("timeout").value, 10) || 8000,
+	row: (name) => document.getElementById(`row-${name}`),
+};
+
+function setStatus(name, status) {
+	const cell = ui.row(name).querySelector(".status");
+	cell.textContent = status;
+	cell.className = `status ${status.toLowerCase()}`;
+}
+
+function appendLog(name, msg) {
+	const pre = ui.row(name).querySelector(".log");
+	pre.textContent += (pre.textContent ? "\n" : "") + msg;
+	console.log(`[${name}] ${msg}`);
+}
+
+function clearLog(name) {
+	ui.row(name).querySelector(".log").textContent = "";
+}
+
+async function runScenario(sc) {
+	clearLog(sc.name);
+	setStatus(sc.name, "RUNNING");
+	const log = (m) => appendLog(sc.name, m);
+	const url = `${ui.base()}/${sc.path}`;
+	const ms = ui.timeout();
+	log(`connecting ${url}`);
+
+	let transport;
+	try {
+		transport = new WebTransport(url, options());
+	} catch (e) {
+		setStatus(sc.name, "FAIL");
+		log(`WebTransport constructor threw: ${e}`);
+		return "FAIL";
+	}
+
+	try {
+		if (!sc.skipReady) {
+			await withTimeout(transport.ready, ms, "ready");
+			log("ready");
+		}
+		await withTimeout(sc.run(transport, { log }), ms, sc.name);
+		setStatus(sc.name, "PASS");
+		return "PASS";
+	} catch (e) {
+		const kind = e?.__timeout ? "TIMEOUT" : "FAIL";
+		setStatus(sc.name, kind);
+		log(`${kind}: ${e?.message ?? e}`);
+		return kind;
+	} finally {
+		if (!sc.noAutoClose) {
+			try {
+				transport?.close();
+			} catch {}
+		}
+	}
+}
+
+async function runAll() {
+	const summary = { PASS: 0, FAIL: 0, TIMEOUT: 0 };
+	for (const sc of SCENARIOS) {
+		const result = await runScenario(sc);
+		summary[result] = (summary[result] || 0) + 1;
+		updateSummary(summary);
+		await sleep(300); // let the previous session fully tear down
+	}
+}
+
+function updateSummary(summary) {
+	document.getElementById("summary").textContent =
+		`PASS ${summary.PASS || 0} · FAIL ${summary.FAIL || 0} · TIMEOUT ${summary.TIMEOUT || 0}`;
+}
+
+// ----- DOM bootstrap -------------------------------------------------------
+
+function build() {
+	document.getElementById("ua").textContent = navigator.userAgent;
+
+	const tbody = document.getElementById("scenarios");
+	for (const sc of SCENARIOS) {
+		const tr = document.createElement("tr");
+		tr.id = `row-${sc.name}`;
+		tr.dataset.kind = sc.kind;
+		tr.innerHTML = `
+			<td><button class="run">Run</button></td>
+			<td class="status pending">PENDING</td>
+			<td class="name">${sc.name}<div class="desc">${sc.desc}</div></td>
+			<td><pre class="log"></pre></td>
+		`;
+		tr.querySelector(".run").addEventListener("click", () => runScenario(sc));
+		tbody.appendChild(tr);
+	}
+
+	document.getElementById("run-all").addEventListener("click", runAll);
+
+	// Optional deep-linking: ?run=all, or ?scenario=server-bi-2
+	const params = new URLSearchParams(window.location.search);
+	if (params.get("base")) document.getElementById("base").value = params.get("base");
+	const only = params.get("scenario");
+	if (only) {
+		const sc = SCENARIOS.find((s) => s.name === only);
+		if (sc) runScenario(sc);
+	} else if (params.get("run") === "all") {
+		runAll();
+	}
+}
+
+build();

--- a/rs/web-transport-quinn/examples/test-server.rs
+++ b/rs/web-transport-quinn/examples/test-server.rs
@@ -1,0 +1,402 @@
+//! Scenario-driven WebTransport server for browser interop / regression testing.
+//!
+//! The client selects a scenario via the URL *path*, e.g.
+//!
+//!   https://localhost:4443/server-bi/2
+//!   https://localhost:4443/server-close/42
+//!
+//! The first path segment is the scenario name, the (optional) second segment is
+//! a numeric argument (a count, or a close code). This pairs with the browser
+//! harness in `js/web-demo/test.html`, which knows the matching client behavior
+//! for each scenario.
+//!
+//! Run it with:
+//!
+//!   cargo run --example test-server -p web-transport-quinn -- \
+//!       --tls-cert dev/localhost.crt --tls-key dev/localhost.key
+//!
+//! Then open the harness (see js/web-demo) in Firefox and Chrome.
+
+use std::{
+    fs, io, path,
+    time::{Duration, Instant},
+};
+
+use anyhow::Context;
+use bytes::Bytes;
+use clap::Parser;
+use rustls::pki_types::CertificateDer;
+use web_transport_quinn::{http, Session};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long, default_value = "[::]:4443")]
+    addr: std::net::SocketAddr,
+
+    /// Use the certificates at this path, encoded as PEM.
+    #[arg(long)]
+    pub tls_cert: path::PathBuf,
+
+    /// Use the private key at this path, encoded as PEM.
+    #[arg(long)]
+    pub tls_key: path::PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    // Read the PEM certificate chain.
+    let chain = fs::File::open(&args.tls_cert).context("failed to open cert file")?;
+    let chain: Vec<CertificateDer> = rustls_pemfile::certs(&mut io::BufReader::new(chain))
+        .collect::<Result<_, _>>()
+        .context("failed to load certs")?;
+    anyhow::ensure!(!chain.is_empty(), "could not find certificate");
+
+    // Read the PEM private key.
+    let keys = fs::File::open(&args.tls_key).context("failed to open key file")?;
+    let key = rustls_pemfile::private_key(&mut io::BufReader::new(keys))
+        .context("failed to load private key")?
+        .context("missing private key")?;
+
+    let mut server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(args.addr)
+        .with_certificate(chain, key)?;
+
+    tracing::info!(addr = %args.addr, "listening; pick a scenario via the URL path");
+
+    while let Some(conn) = server.accept().await {
+        tokio::spawn(async move {
+            if let Err(err) = run_conn(conn).await {
+                tracing::error!(?err, "connection failed")
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn run_conn(request: web_transport_quinn::Request) -> anyhow::Result<()> {
+    // The scenario name is the first path segment, with an optional numeric arg.
+    let path = request.url.path().to_string();
+    let mut segments = path.split('/').filter(|s| !s.is_empty());
+    let scenario = segments.next().unwrap_or("echo").to_string();
+    let arg: u64 = segments.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+
+    tracing::info!(url = %request.url, %scenario, arg, "received WebTransport request");
+
+    // Reject the CONNECT with an HTTP status instead of accepting. `arg` is the
+    // status code (default 404). This is a distinct path from a 200 + later
+    // close — the session is never established, so the browser sees `ready`
+    // reject. Suspected Chrome crash trigger.
+    if scenario == "reject" {
+        let status = u16::try_from(arg)
+            .ok()
+            .and_then(|c| http::StatusCode::from_u16(c).ok())
+            .unwrap_or(http::StatusCode::NOT_FOUND);
+        tracing::info!(%status, "rejecting session");
+        request
+            .reject(status)
+            .await
+            .context("failed to reject session")?;
+        return Ok(());
+    }
+
+    let session = request.ok().await.context("failed to accept session")?;
+    tracing::info!(%scenario, "accepted session");
+
+    let res = run_scenario(&scenario, arg, session.clone()).await;
+    match &res {
+        Ok(()) => tracing::info!(%scenario, "scenario finished"),
+        Err(err) => tracing::info!(%scenario, ?err, "scenario ended with error"),
+    }
+
+    Ok(())
+}
+
+async fn run_scenario(scenario: &str, arg: u64, session: Session) -> anyhow::Result<()> {
+    match scenario {
+        // ---- Baselines (client-driven) --------------------------------------
+        //
+        // Echo whatever the client sends, forever. Used as a sanity check that
+        // the basic path works before blaming server-initiated streams.
+        "echo" | "client-bi-echo" | "datagram-echo" => echo_loop(session).await,
+
+        // ---- Server-initiated streams (Firefox suspects) --------------------
+        //
+        // Open N bidirectional streams from the server. `arg` is the count
+        // (default 1). This is the prime suspect: "the second server initiated
+        // bidirectional stream broke it last time" => /server-bi/2.
+        "server-bi" => server_bi(session, arg.max(1) as usize, true, false).await,
+
+        // Same, but never FIN the send side — some stacks treat an open-ended
+        // server stream differently.
+        "server-bi-no-finish" => server_bi(session, arg.max(1) as usize, false, false).await,
+
+        // Open N bidi streams but WAIT for each to fully close (client FIN on its
+        // send side) before opening the next. Tests whether closing a stream
+        // makes the peer replenish stream credit (MAX_STREAMS).
+        "server-bi-serial" => server_bi(session, arg.max(1) as usize, true, true).await,
+
+        // Open N bidirectional streams *concurrently* (all before any is drained)
+        // to stress ordering / flow-control on the client.
+        "server-bi-concurrent" => server_bi_concurrent(session, arg.max(1) as usize).await,
+
+        // Open N unidirectional streams from the server.
+        "server-uni" => server_uni(session, arg.max(1) as usize).await,
+
+        // Send N datagrams from the server.
+        "server-datagram" => server_datagram(session, arg.max(1) as usize).await,
+
+        // Open `arg` uni AND `arg` bidi streams, interleaved. Distinguishes a
+        // per-type stream-credit limit (2 uni + 2 bidi both succeed) from a
+        // shared one (stalls on the 3rd stream regardless of type).
+        "server-mix" => server_mix(session, arg.max(1) as usize).await,
+
+        // ---- Explicit session close (Chrome "Aww snap, code 11" suspects) ---
+        //
+        // Accept the session, then immediately close it with `arg` as the code.
+        "server-close" => {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            session.close(arg as u32, b"server-close");
+            session.closed().await;
+            Ok(())
+        }
+
+        // Open one bidi stream, send data, then close the session with `arg` as
+        // the code while the stream is still "live" on the client.
+        "server-close-after-bi" => {
+            let (mut send, _recv) = session.open_bi().await?;
+            send.write_all(b"server-bi-0").await.ok();
+            send.finish().ok();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            session.close(arg as u32, b"server-close-after-bi");
+            session.closed().await;
+            Ok(())
+        }
+
+        // Close the session the instant it's accepted, no delay — races the
+        // client's `ready`/first-stream against the close capsule.
+        "server-close-immediate" => {
+            session.close(arg as u32, b"server-close-immediate");
+            session.closed().await;
+            Ok(())
+        }
+
+        // Wait for the client to open a bidi stream, echo once, then the server
+        // closes the session explicitly. Mirrors "closes during a live stream".
+        "server-close-after-echo" => {
+            if let Ok((mut send, mut recv)) = session.accept_bi().await {
+                let msg = recv.read_to_end(1024).await.unwrap_or_default();
+                send.write_all(&msg).await.ok();
+                send.finish().ok();
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            session.close(arg as u32, b"server-close-after-echo");
+            session.closed().await;
+            Ok(())
+        }
+
+        // ---- Kitchen sink ---------------------------------------------------
+        //
+        // Server opens a uni, a bidi, sends a datagram, echoes a client stream,
+        // then closes. Exercises everything in one session.
+        "mixed" => {
+            let mut uni = session.open_uni().await?;
+            uni.write_all(b"server-uni-0").await.ok();
+            uni.finish().ok();
+
+            let (mut send, recv) = session.open_bi().await?;
+            send.write_all(b"server-bi-0").await.ok();
+            send.finish().ok();
+            tokio::spawn(drain(recv));
+
+            session
+                .send_datagram(Bytes::from_static(b"server-dgram-0"))
+                .ok();
+
+            if let Ok((mut s, mut r)) = session.accept_bi().await {
+                let msg = r.read_to_end(1024).await.unwrap_or_default();
+                s.write_all(&msg).await.ok();
+                s.finish().ok();
+            }
+
+            session.close(arg as u32, b"mixed-done");
+            session.closed().await;
+            Ok(())
+        }
+
+        // Unknown scenario: log and fall back to echo so the client still gets
+        // *something* rather than a silent hang.
+        other => {
+            tracing::warn!(scenario = %other, "unknown scenario, falling back to echo");
+            echo_loop(session).await
+        }
+    }
+}
+
+/// Echo client-initiated streams (bidi echoed, uni drained) and datagrams until
+/// the session closes. Used by both the baseline and the client-opens-N
+/// scenarios, so it must accept all stream types the client might open.
+async fn echo_loop(session: Session) -> anyhow::Result<()> {
+    loop {
+        tokio::select! {
+            res = session.accept_bi() => {
+                let (mut send, mut recv) = res?;
+                let msg = recv.read_to_end(1024).await?;
+                tracing::info!(msg = %String::from_utf8_lossy(&msg), "echo bidi");
+                send.write_all(&msg).await.ok();
+                send.finish().ok();
+            },
+            res = session.accept_uni() => {
+                let mut recv = res?;
+                let msg = recv.read_to_end(1024).await?;
+                tracing::info!(msg = %String::from_utf8_lossy(&msg), "drain uni");
+            },
+            res = session.read_datagram() => {
+                let msg = res?;
+                tracing::info!(msg = %String::from_utf8_lossy(&msg), "echo datagram");
+                session.send_datagram(msg).ok();
+            },
+        }
+    }
+}
+
+/// Open `count` server-initiated bidi streams, one after another.
+///
+/// `wait_close`: wait for the client to fully close each stream (FIN on its send
+/// side) before opening the next. The per-open timing log makes a stream-credit
+/// stall obvious — a blocked `open_bi()` shows up as a multi-second `elapsed_ms`.
+async fn server_bi(
+    session: Session,
+    count: usize,
+    finish: bool,
+    wait_close: bool,
+) -> anyhow::Result<()> {
+    for i in 0..count {
+        let start = Instant::now();
+        let (mut send, mut recv) = session.open_bi().await?;
+        tracing::info!(
+            i,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "open_bi() returned"
+        );
+
+        let msg = format!("server-bi-{i}");
+        send.write_all(msg.as_bytes()).await?;
+        if finish {
+            send.finish().ok();
+        }
+
+        if wait_close {
+            // Block until the client finishes its send side = stream fully closed.
+            let echo = recv.read_to_end(1024).await;
+            tracing::info!(i, ok = echo.is_ok(), "client closed bidi stream");
+        } else {
+            // Drain the client's echo (if any) so the recv side isn't reset.
+            tokio::spawn(drain(recv));
+        }
+    }
+
+    // Keep the session alive so the client controls teardown.
+    session.closed().await;
+    Ok(())
+}
+
+/// Open `count` server-initiated bidi streams without awaiting between them.
+async fn server_bi_concurrent(session: Session, count: usize) -> anyhow::Result<()> {
+    let mut tasks = Vec::new();
+    for i in 0..count {
+        let session = session.clone();
+        tasks.push(tokio::spawn(async move {
+            let (mut send, recv) = session.open_bi().await?;
+            let msg = format!("server-bi-{i}");
+            send.write_all(msg.as_bytes()).await?;
+            send.finish().ok();
+            tracing::info!(i, "opened concurrent server bidi stream");
+            drain(recv).await;
+            Ok::<_, anyhow::Error>(())
+        }));
+    }
+    for task in tasks {
+        let _ = task.await;
+    }
+    session.closed().await;
+    Ok(())
+}
+
+/// Open `count` uni and `count` bidi streams, interleaved (uni, bidi, uni, …).
+/// The per-open timing log shows exactly which stream (and type) blocks.
+async fn server_mix(session: Session, count: usize) -> anyhow::Result<()> {
+    for i in 0..count {
+        let start = Instant::now();
+        let mut uni = session.open_uni().await?;
+        tracing::info!(
+            i,
+            kind = "uni",
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "open returned"
+        );
+        uni.write_all(format!("server-uni-{i}").as_bytes()).await?;
+        uni.finish().ok();
+
+        let start = Instant::now();
+        let (mut send, recv) = session.open_bi().await?;
+        tracing::info!(
+            i,
+            kind = "bi",
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "open returned"
+        );
+        send.write_all(format!("server-bi-{i}").as_bytes()).await?;
+        send.finish().ok();
+        tokio::spawn(drain(recv));
+    }
+
+    session.closed().await;
+    Ok(())
+}
+
+/// Open `count` server-initiated unidirectional streams.
+async fn server_uni(session: Session, count: usize) -> anyhow::Result<()> {
+    for i in 0..count {
+        let start = Instant::now();
+        let mut send = session.open_uni().await?;
+        tracing::info!(
+            i,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "open_uni() returned"
+        );
+        let msg = format!("server-uni-{i}");
+        send.write_all(msg.as_bytes()).await?;
+        send.finish().ok();
+    }
+    session.closed().await;
+    Ok(())
+}
+
+/// Send `count` datagrams from the server.
+async fn server_datagram(session: Session, count: usize) -> anyhow::Result<()> {
+    for i in 0..count {
+        let msg = format!("server-dgram-{i}");
+        session.send_datagram(Bytes::from(msg)).ok();
+        tracing::info!(i, "sent server datagram");
+        // Space them out slightly so they aren't coalesced/dropped.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    session.closed().await;
+    Ok(())
+}
+
+/// Read and discard a recv stream to completion, ignoring errors.
+async fn drain(mut recv: web_transport_quinn::RecvStream) {
+    let _ = recv.read_to_end(64 * 1024).await;
+}


### PR DESCRIPTION
## Summary

Adds a scenario-driven WebTransport test server and a browser harness for chasing browser-specific bugs, and uses it to produce a minimal, isolated reproduction of a **Firefox bug**: **incoming server-initiated streams stall at ~2 because `incomingBidirectionalStreams` / `incomingUnidirectionalStreams` backpressure never resumes.**

- **`rs/web-transport-quinn/examples/test-server.rs`** — a server that selects its behavior from the request URL *path* (`/server-bi/5`, `/server-uni/3`, `/server-mix/2`, `/server-bi-serial/10`, `/reject/404`, `/server-close/42`, …). Per-open timing logs.
- **`js/web-demo/test.html` + `test.js`** — a harness that runs each scenario, reports PASS/FAIL/TIMEOUT, and logs per-stream delivery. ⭐ rows reproduce the Firefox bug.
- **`js/web-demo/TESTING.md`** — run instructions + findings.
- **`js/web-demo/client.js`** — fix the cert-hash path (`../dev` → `../../dev`); certs live at repo-root `dev/`, so the existing demo didn't build.

## The Firefox bug

When the **server** opens several server-initiated streams and the page reads each stream's body *before* pulling the next stream from the incoming-streams reader, **Firefox delivers only ~2 streams and then permanently stops** — even though it granted plenty of stream credit and the bytes are on the wire. **Chrome passes every scenario.**

### Decisive evidence: probe vs inline (same server, same 5 streams)
| Scenario | Client pull pattern | Firefox | Chrome |
|---|---|---|---|
| `server-bi-probe-5` | `read()` all 5 stream objects **back-to-back**, *then* read bodies | **PASS** (5/5) ✅ | 5/5 ✅ |
| `server-bi-5` | `read()` one, read its body, *then* `read()` next | **FAIL** — stalls at 2 ❌ | 5/5 ✅ |
| `server-uni-3` | same inline pattern, uni (no writable/echo) | **FAIL** — stalls at 2 ❌ | 3/3 ✅ |
| `server-bi-concurrent-3` | inline | **FAIL** — 2, out of order ❌ | 3/3 ✅ |

The only difference between the passing probe and the failing case is **how promptly the app pulls the incoming-streams reader.** `server-uni-3` failing (no echo, no writable) rules out the stream's send side — it's purely the incoming-stream reader.

### It is NOT `MAX_STREAMS` / stream-count credit
Server-side QUIC trace (`RUST_LOG=info,quinn_proto=trace`) shows Firefox granting generous credit and the server opening + writing data to all 5 streams without blocking, then **retransmitting the undelivered streams** because Firefox never consumes them:

```
got frame MaxStreams { dir: Bi, count: 102 }
test_server: open_bi() returned i=0..4 elapsed_ms=0
... wrote 3/11 bytes stream=server bidirectional stream 0..4   (streams 2-4 retransmitted many times)
```

So the bytes are on the wire for all 5 streams; Firefox simply stops surfacing streams to JS once the incoming-streams reader queue fills and isn't drained promptly, and never resumes.

### Boundaries (what passes in Firefox)
- **`server-bi-serial-10`** — server opens one, waits for the client to fully drain+close it, then opens the next: **10/10.** Reader never backs up.
- **`server-mix-2uni-2bi`** — 2 uni + 2 bidi: **passes.** Queue limit is per stream-type.
- **`client-bi-open-*` / `client-uni-open-*`** — the *client* opening many streams: **passes.** Limited to **incoming** (server→client) streams.

### Practical impact / workaround
The idiomatic `for await (const s of transport.incomingBidirectionalStreams) { await handle(s) }` is exactly the failing pattern (it pulls the next stream only after `handle` completes). **Workaround:** drain the incoming-streams reader promptly into your own queue and process bodies separately, so you never `await` per-stream work between `reader.read()` calls.

## How to run

```bash
# 1. self-signed cert (serverCertificateHashes, no CA); valid ~10 days
bash dev/setup

# 2. test server (4443 may be taken locally; any free port works)
cargo run --example test-server -p web-transport-quinn -- \
    --tls-cert dev/localhost.crt --tls-key dev/localhost.key --addr 127.0.0.1:4444

# 3. harness
cd js/web-demo && bun install && npx parcel serve client.html test.html --port 1234
```

Open `http://localhost:1234/test.html?base=https://127.0.0.1:4444` in Firefox and Chrome and click **Run all**, or deep-link a single case: `…&scenario=server-bi-5`. Compare `server-bi-5` (fails) with `server-bi-probe-5` (passes) to see the backpressure dependence directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)