### PR TITLE
feat(wasm): advertise subprotocols for negotiation

### DIFF
--- a/rs/web-transport-wasm/src/client.rs
+++ b/rs/web-transport-wasm/src/client.rs
@@ -1,5 +1,6 @@
-use js_sys::Uint8Array;
+use js_sys::{Array, Reflect, Uint8Array};
 use url::Url;
+use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{WebTransport, WebTransportHash, WebTransportOptions};
 
@@ -34,6 +35,25 @@ impl ClientBuilder {
     /// Hint at the required congestion control algorithm
     pub fn with_congestion_control(self, control: CongestionControl) -> Self {
         self.options.set_congestion_control(control);
+        self
+    }
+
+    /// Advertise the application protocols (subprotocols) offered for negotiation.
+    ///
+    /// The server selects one of these, available afterwards via [`Session::protocol`].
+    pub fn with_protocols<I, S>(self, protocols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let array = Array::new();
+        for protocol in protocols {
+            array.push(&JsValue::from_str(protocol.as_ref()));
+        }
+
+        // web-sys 0.3 has no binding for `WebTransportOptions.protocols`, so set it via Reflect.
+        // This mirrors how `Session` reads the negotiated `protocol` field.
+        let _ = Reflect::set(&self.options, &JsValue::from_str("protocols"), &array);
         self
     }
 

--- a/rs/web-transport/src/quinn.rs
+++ b/rs/web-transport/src/quinn.rs
@@ -10,6 +10,7 @@ pub use web_transport_quinn::CongestionControl;
 #[derive(Default, Clone)]
 pub struct ClientBuilder {
     inner: quinn::ClientBuilder,
+    protocols: Vec<String>,
 }
 
 impl ClientBuilder {
@@ -21,13 +22,30 @@ impl ClientBuilder {
     pub fn with_congestion_control(self, cc: CongestionControl) -> Self {
         Self {
             inner: self.inner.with_congestion_control(cc),
+            ..self
         }
+    }
+
+    /// Advertise the application protocols (subprotocols) offered for negotiation.
+    ///
+    /// The server selects one of these, available afterwards via [`Session::protocol`].
+    pub fn with_protocols<I, S>(mut self, protocols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.protocols = protocols
+            .into_iter()
+            .map(|p| p.as_ref().to_string())
+            .collect();
+        self
     }
 
     /// Accept the server's certificate hashes (sha256) instead of using a root CA.
     pub fn with_server_certificate_hashes(self, hashes: Vec<Vec<u8>>) -> Result<Client, Error> {
         Ok(Client {
             inner: self.inner.with_server_certificate_hashes(hashes)?,
+            protocols: self.protocols,
         })
     }
 
@@ -35,6 +53,7 @@ impl ClientBuilder {
     pub fn with_system_roots(self) -> Result<Client, Error> {
         Ok(Client {
             inner: self.inner.with_system_roots()?,
+            protocols: self.protocols,
         })
     }
 }
@@ -43,12 +62,15 @@ impl ClientBuilder {
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: quinn::Client,
+    protocols: Vec<String>,
 }
 
 impl Client {
     /// Connect to the server.
     pub async fn connect(&self, url: Url) -> Result<Session, Error> {
-        Ok(self.inner.connect(url).await?.into())
+        let request =
+            quinn::proto::ConnectRequest::new(url).with_protocols(self.protocols.iter().cloned());
+        Ok(self.inner.connect(request).await?.into())
     }
 }
 

--- a/rs/web-transport/src/wasm.rs
+++ b/rs/web-transport/src/wasm.rs
@@ -29,6 +29,19 @@ impl ClientBuilder {
         }
     }
 
+    /// Advertise the application protocols (subprotocols) offered for negotiation.
+    ///
+    /// The server selects one of these, available afterwards via [`Session::protocol`].
+    pub fn with_protocols<I, S>(self, protocols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            inner: self.inner.with_protocols(protocols),
+        }
+    }
+
     pub fn with_server_certificate_hashes(self, hashes: Vec<Vec<u8>>) -> Result<Client, Error> {
         Ok(Client {
             inner: self.inner.with_server_certificate_hashes(hashes),


### PR DESCRIPTION
## What

Adds `ClientBuilder::with_protocols(...)` to advertise WebTransport application protocols (subprotocols) for negotiation.

- **`web-transport-wasm`** — new `ClientBuilder::with_protocols`. Sets `WebTransportOptions.protocols` via `Reflect` (web-sys 0.3 has no binding for the field), mirroring how `Session` already reads the negotiated `protocol` via `Reflect`.
- **`web-transport`** (unified crate) — threads it through both platforms: the wasm wrapper delegates, and the quinn wrapper builds a `ConnectRequest` with the protocols. Closes the existing `// TODO add sub-protocol support`.

## Why

`web-transport-wasm` could *read* the negotiated subprotocol (`Session::protocol()`) but had no way to *advertise* the offered list. Without setting `WebTransportOptions.protocols`, the browser sends no `WT-Available-Protocols` header, the server selects nothing, and `protocol()` comes back empty — which moq-net rejected as `unknown ALPN: (empty)`.

The wire-level support already existed in `web-transport-proto` and `web-transport-quinn` (`ConnectRequest.protocols`); the only gap was the missing builder method on the client side.

## Usage

Identical API on native and wasm:

```rust
web_transport::ClientBuilder::new()
    .with_protocols(["moq-00", "moq-01"])
    .with_system_roots()?
    .connect(url).await?;
// session.protocol()  ->  Some("moq-01")
```

Generic over `IntoIterator<Item: AsRef<str>>`, so `&str` slices, `Vec<String>`, etc. all work.

## Notes for reviewers

- Public-API additions to `web-transport-wasm` and `web-transport` — these warrant minor version bumps on release.
- Verified: `cargo check`/`clippy`/`fmt` clean on both native and `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)