### PR TITLE
feat(qmux): preserve typed error sources and surface HTTP status

### DIFF
--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use web_transport_proto::{VarInt, VarIntBoundsExceeded, VarIntUnexpectedEnd};
 
 /// Errors that can occur during QMux session and stream operations.
@@ -45,8 +47,26 @@ pub enum Error {
     #[error("invalid protocol token: {0:?}")]
     InvalidProtocol(String),
 
-    #[error("io error: {0}")]
-    Io(String),
+    #[error("invalid server name")]
+    InvalidServerName,
+
+    /// The server rejected the handshake with a non-success HTTP status.
+    ///
+    /// Surfaced from the WebSocket upgrade response so callers can distinguish
+    /// terminal failures (e.g. 401/403 auth rejections) from transient I/O
+    /// errors worth retrying.
+    #[error("http error status: {0}")]
+    Http(u16),
+
+    // Foreign error sources aren't `Clone`, but `Error` must be (the session
+    // fans one terminal error out to every waiter). `Arc` bridges the two while
+    // keeping the original error — source chain and all — instead of a string.
+    #[error(transparent)]
+    Io(Arc<std::io::Error>),
+
+    #[cfg(feature = "ws")]
+    #[error(transparent)]
+    WebSocket(Arc<tokio_tungstenite::tungstenite::Error>),
 
     #[error("datagrams not supported")]
     DatagramsUnsupported,
@@ -64,16 +84,25 @@ impl From<VarIntBoundsExceeded> for Error {
     }
 }
 
+// Hand-written rather than `#[from]`: thiserror's `#[from]` would generate
+// `From<Arc<std::io::Error>>`, but `?` call sites yield a bare `std::io::Error`.
+// These wrap it so `?` stays ergonomic.
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
-        Self::Io(err.to_string())
+        Self::Io(Arc::new(err))
     }
 }
 
 #[cfg(feature = "ws")]
 impl From<tokio_tungstenite::tungstenite::Error> for Error {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
-        Self::Io(err.to_string())
+        // A non-101 upgrade response carries the HTTP status; surface it as a
+        // distinct, transport-agnostic variant so callers can act on terminal
+        // rejections (e.g. auth) without downcasting tungstenite.
+        if let tokio_tungstenite::tungstenite::Error::Http(response) = &err {
+            return Self::Http(response.status().as_u16());
+        }
+        Self::WebSocket(Arc::new(err))
     }
 }
 
@@ -93,5 +122,27 @@ impl web_transport_trait::Error for Error {
             Error::StreamReset(code) | Error::StreamStop(code) => code.into_inner().try_into().ok(),
             _ => None,
         }
+    }
+}
+
+#[cfg(all(test, feature = "ws"))]
+mod tests {
+    use super::*;
+    use tokio_tungstenite::tungstenite::{self, http};
+
+    #[test]
+    fn preserves_http_status() {
+        let response = http::Response::builder()
+            .status(http::StatusCode::UNAUTHORIZED)
+            .body(None::<Vec<u8>>)
+            .unwrap();
+        let err: Error = tungstenite::Error::Http(Box::new(response)).into();
+        assert!(matches!(err, Error::Http(401)));
+    }
+
+    #[test]
+    fn non_http_preserves_source() {
+        let err: Error = tungstenite::Error::ConnectionClosed.into();
+        assert!(matches!(err, Error::WebSocket(_)));
     }
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -27,7 +27,7 @@ pub async fn connect<'a>(
     let stream = TcpStream::connect(&addr).await?;
 
     let server_name = rustls::pki_types::ServerName::try_from(server_name)
-        .map_err(|e| Error::Io(e.to_string()))?
+        .map_err(|_| Error::InvalidServerName)?
         .to_owned();
 
     let prefixed = alpn::build(entries, require_protocol);

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -189,9 +189,7 @@ impl Client {
             validate_protocol(a)?;
         }
 
-        let mut request = url
-            .into_client_request()
-            .map_err(|e| Error::Io(e.to_string()))?;
+        let mut request = url.into_client_request().map_err(Error::from)?;
 
         let entries = self
             .protocols
@@ -214,14 +212,14 @@ impl Client {
                 self.connector.clone(),
             )
             .await
-            .map_err(|e| Error::Io(e.to_string()))?
+            .map_err(Error::from)?
         };
 
         #[cfg(not(feature = "wss"))]
         let (ws_stream, response) =
             tokio_tungstenite::connect_async_with_config(request, self.config, false)
                 .await
-                .map_err(|e| Error::Io(e.to_string()))?;
+                .map_err(Error::from)?;
 
         let negotiated = response
             .headers()


### PR DESCRIPTION
## Problem

The qmux WebSocket `Client::connect` path collapsed **every** failure into `Error::Io(String)`, throwing away two things:

1. The **HTTP status** from a non-101 upgrade response — so consumers (e.g. moq-native's reconnect loop) couldn't tell a terminal auth rejection (401/403) from a transient I/O error, and an unauthorized client would back off and retry forever.
2. The **underlying error type and source chain** — `std::io::Error`, `tungstenite::Error`, and a DNS-name parse error all became opaque strings.

The QUIC path already surfaces status via `ConnectError::ErrorStatus(StatusCode)`.

## Root cause

The stringification only existed to satisfy `#[derive(Clone)]` on `qmux::Error`. `Clone` is genuinely required — a session stores one terminal error and fans it out to every waiter (`watch::Sender<Option<Error>>` + ~10 `error.clone()` sites in `session.rs`) — but `std::io::Error` / `tungstenite::Error` aren't `Clone`, so `#[from]` storing them was impossible and `.to_string()` was the escape hatch.

## Change

Wrap non-`Clone` sources in `Arc` (which is `Clone`) and keep the real error:

- `Io(String)` → `Io(Arc<std::io::Error>)`, `#[error(transparent)]`.
- New `WebSocket(Arc<tungstenite::Error>)` for non-HTTP WebSocket failures (preserves source chain, downcastable).
- New `Http(u16)` extracted from a rejected upgrade response — a transport-agnostic variant so callers act on the status without depending on tungstenite's error type.
- New `InvalidServerName` replacing the stringified DNS-name parse error (the source is a dataless unit struct, so no `Arc` needed).

`?` stays ergonomic via hand-written `From` impls — thiserror's `#[from]` can't auto-wrap in `Arc`. This mirrors the `Arc<Source>` + transparent pattern moq-native already uses one layer up.

## Notes

- This is the qmux half. The consuming side in moq (classifying `Error::Http(401/403)` as terminal in the reconnect loop) is a separate follow-up.
- `Io`'s payload changing from `String` to `Arc<std::io::Error>` is technically breaking, but qmux is pre-1.0 and nothing pattern-matches the variant outside the crate.
- Version bump left to release-plz.

## Test

`cargo clippy -p qmux` clean across feature combos (all-features, no-default, tls-only). `cargo test -p qmux --all-features` passes, including new unit tests: a rejected upgrade (`Http(401)`) maps to `Error::Http(401)`, and a non-HTTP tungstenite error preserves its source as `Error::WebSocket`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)