### PR TITLE
Bump qmux to 0.1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "js/qmux": {
       "name": "@moq/qmux",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "@moq/web-socket-stream": "workspace:*",
       },

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]


### PR DESCRIPTION
Manually bumps the qmux version from 0.1.2 to 0.1.3.

- `rs/qmux/Cargo.toml`: `0.1.2` → `0.1.3`
- `js/qmux/package.json` (`@moq/qmux`): `0.1.2` → `0.1.3`
- `bun.lock`: workspace version field updated to `0.1.3` (was stale at `0.1.1`)

https://claude.ai/code/session_019nZQpLvmftLPuTfnUH5vL4

---
_Generated by [Claude Code](https://claude.ai/code/session_019nZQpLvmftLPuTfnUH5vL4)_