### PR TITLE
feat(quiche): live stats, server cert verification, and Linux client GSO

### DIFF
--- a/rs/web-transport-quiche/Cargo.toml
+++ b/rs/web-transport-quiche/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rcgen = "0.13"
 rustls-pemfile = "2"
+sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"

--- a/rs/web-transport-quiche/src/client.rs
+++ b/rs/web-transport-quiche/src/client.rs
@@ -83,6 +83,21 @@ impl<M: Metrics> ClientBuilder<M> {
         Self(self.0.with_single_cert(chain, key))
     }
 
+    /// Verify the server certificate against an explicit set of root
+    /// certificates instead of the system trust store.
+    pub fn with_root_certificates(self, roots: Vec<ez::CertificateDer<'static>>) -> Self {
+        Self(self.0.with_root_certificates(roots))
+    }
+
+    /// Accept the server certificate only if the SHA-256 of its DER encoding
+    /// matches one of the provided hashes, bypassing CA verification.
+    ///
+    /// This mirrors the browser's `serverCertificateHashes` option and is the
+    /// usual way to reach a relay using a short-lived self-signed certificate.
+    pub fn with_server_certificate_hashes(self, hashes: Vec<[u8; 32]>) -> Self {
+        Self(self.0.with_server_certificate_hashes(hashes))
+    }
+
     /// Connect to the WebTransport server at the given URL.
     ///
     /// DNS resolution and socket setup happen eagerly. The returned [Connecting]

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -335,6 +335,45 @@ impl Connection {
     pub fn response(&self) -> &ConnectResponse {
         &self.response
     }
+
+    /// Returns the most recent connection statistics snapshot.
+    pub fn stats(&self) -> ez::ConnectionStats {
+        self.conn.stats()
+    }
+}
+
+impl web_transport_trait::Stats for ez::ConnectionStats {
+    fn bytes_sent(&self) -> Option<u64> {
+        Some(self.bytes_sent)
+    }
+
+    fn bytes_received(&self) -> Option<u64> {
+        Some(self.bytes_received)
+    }
+
+    fn bytes_lost(&self) -> Option<u64> {
+        Some(self.bytes_lost)
+    }
+
+    fn packets_sent(&self) -> Option<u64> {
+        Some(self.packets_sent)
+    }
+
+    fn packets_received(&self) -> Option<u64> {
+        Some(self.packets_received)
+    }
+
+    fn packets_lost(&self) -> Option<u64> {
+        Some(self.packets_lost)
+    }
+
+    fn rtt(&self) -> Option<std::time::Duration> {
+        self.rtt
+    }
+
+    fn estimated_send_rate(&self) -> Option<u64> {
+        self.send_rate
+    }
 }
 
 impl web_transport_trait::Session for Connection {
@@ -380,6 +419,10 @@ impl web_transport_trait::Session for Connection {
 
     async fn closed(&self) -> SessionError {
         self.closed().await
+    }
+
+    fn stats(&self) -> impl web_transport_trait::Stats {
+        self.conn.stats()
     }
 }
 

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -167,14 +167,14 @@ impl<M: Metrics> ClientBuilder<M> {
         }
 
         // Install a TLS hook whenever we present a client certificate or need a
-        // non-default verification policy. ALPN is left to tokio-quiche, which
-        // applies it at the config level after the hook runs.
+        // non-default verification policy. The SSL context is built (and the
+        // certificate material validated) here so a bad cert/key/root fails the
+        // connection rather than silently dropping the policy inside the hook.
+        // ALPN is left to tokio-quiche, which applies it after the hook runs.
         let needs_hook = self.tls.is_some() || !matches!(self.verify, ClientVerify::Default);
         let (tls_cert, hooks) = if needs_hook {
-            let hook = ClientHook {
-                cert: self.tls,
-                verify: self.verify,
-            };
+            let ctx = crate::ez::tls::build_client_context(self.tls.as_ref(), &self.verify)?;
+            let hook = ClientHook::new(ctx);
             // ConnectionHook is only invoked when tls_cert is set, so we provide a dummy.
             let dummy_tls = TlsCertificatePaths {
                 cert: "",

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -4,7 +4,7 @@ use tokio_quiche::settings::{CertificateKind, Hooks, TlsCertificatePaths};
 
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 
-use crate::ez::tls::StaticCertHook;
+use crate::ez::tls::{ClientHook, ClientVerify};
 use crate::ez::DriverState;
 
 use super::{Connection, ConnectionError, DefaultMetrics, Driver, Lock, Metrics, Settings};
@@ -23,6 +23,7 @@ pub struct ClientBuilder<M: Metrics = DefaultMetrics> {
     settings: Settings,
     socket: Option<tokio::net::UdpSocket>,
     tls: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
+    verify: ClientVerify,
     metrics: M,
 }
 
@@ -43,6 +44,7 @@ impl<M: Metrics> ClientBuilder<M> {
             metrics: m,
             socket: None,
             tls: None,
+            verify: ClientVerify::Default,
         }
     }
 
@@ -53,19 +55,12 @@ impl<M: Metrics> ClientBuilder<M> {
         socket.set_nonblocking(true)?;
         let socket = tokio::net::UdpSocket::from_std(socket)?;
 
-        /*
-        // TODO Modify quiche to add other platform support.
-        #[cfg(target_os = "linux")]
-        let capabilities = SocketCapabilities::apply_all_and_get_compatibility(&socket);
-        #[cfg(not(target_os = "linux"))]
-        let capabilities = SocketCapabilities::default();
-        */
-
         Ok(Self {
             socket: Some(socket),
             settings: self.settings,
             metrics: self.metrics,
             tls: self.tls,
+            verify: self.verify,
         })
     }
 
@@ -98,7 +93,25 @@ impl<M: Metrics> ClientBuilder<M> {
             settings: self.settings,
             metrics: self.metrics,
             socket: self.socket,
+            verify: self.verify,
         }
+    }
+
+    /// Verify the server certificate against an explicit set of root
+    /// certificates instead of the system trust store.
+    pub fn with_root_certificates(mut self, roots: Vec<CertificateDer<'static>>) -> Self {
+        self.verify = ClientVerify::Roots(roots);
+        self
+    }
+
+    /// Accept the server certificate only if the SHA-256 of its DER encoding
+    /// matches one of the provided hashes, bypassing CA verification.
+    ///
+    /// This mirrors the browser's `serverCertificateHashes` option and is the
+    /// usual way to reach a relay using a short-lived self-signed certificate.
+    pub fn with_server_certificate_hashes(mut self, hashes: Vec<[u8; 32]>) -> Self {
+        self.verify = ClientVerify::Hashes(hashes);
+        self
     }
 
     /// Connect to the QUIC server at the given host and port.
@@ -135,35 +148,45 @@ impl<M: Metrics> ClientBuilder<M> {
         socket.connect(remote).await?;
 
         // Connect to the server using the addr we just resolved.
-        let socket = tokio_quiche::socket::Socket::<
+        #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
+        let mut socket = tokio_quiche::socket::Socket::<
             Arc<tokio::net::UdpSocket>,
             Arc<tokio::net::UdpSocket>,
         >::from_udp(socket)?;
 
-        if !self.settings.verify_peer {
+        // Enable UDP GSO/GRO offload where the kernel supports it (Linux only).
+        // This mirrors the server listener and cuts syscall overhead at high
+        // throughput; it's a no-op if send/recv don't share one FD.
+        #[cfg(target_os = "linux")]
+        socket.apply_max_capabilities();
+
+        // Only the fully-insecure path (no verification of any kind) deserves a
+        // warning; hash- and root-based verification still authenticate the peer.
+        if !self.settings.verify_peer && matches!(self.verify, ClientVerify::Default) {
             tracing::warn!("TLS certificate verification is disabled, a MITM attack is possible");
         }
 
-        let (tls_cert, hooks) = match self.tls {
-            Some((chain, key)) => {
-                // ALPN is left empty; tokio-quiche sets h3 at the config level after the hook.
-                let hook = StaticCertHook {
-                    chain,
-                    key,
-                    alpn: Vec::new(),
-                };
-                // ConnectionHook is only invoked when tls_cert is set, so we provide a dummy.
-                let dummy_tls = TlsCertificatePaths {
-                    cert: "",
-                    private_key: "",
-                    kind: CertificateKind::X509,
-                };
-                let hooks = Hooks {
-                    connection_hook: Some(Arc::new(hook)),
-                };
-                (Some(dummy_tls), hooks)
-            }
-            None => (None, Hooks::default()),
+        // Install a TLS hook whenever we present a client certificate or need a
+        // non-default verification policy. ALPN is left to tokio-quiche, which
+        // applies it at the config level after the hook runs.
+        let needs_hook = self.tls.is_some() || !matches!(self.verify, ClientVerify::Default);
+        let (tls_cert, hooks) = if needs_hook {
+            let hook = ClientHook {
+                cert: self.tls,
+                verify: self.verify,
+            };
+            // ConnectionHook is only invoked when tls_cert is set, so we provide a dummy.
+            let dummy_tls = TlsCertificatePaths {
+                cert: "",
+                private_key: "",
+                kind: CertificateKind::X509,
+            };
+            let hooks = Hooks {
+                connection_hook: Some(Arc::new(hook)),
+            };
+            (Some(dummy_tls), hooks)
+        } else {
+            (None, Hooks::default())
         };
 
         let params = tokio_quiche::ConnectionParams::new_client(self.settings, tls_cert, hooks);

--- a/rs/web-transport-quiche/src/ez/connection.rs
+++ b/rs/web-transport-quiche/src/ez/connection.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{
     future::poll_fn,
     ops::Deref,
@@ -15,6 +16,51 @@ use tokio_quiche::quiche;
 use crate::ez::DriverState;
 
 use super::{Lock, RecvStream, SendStream};
+
+/// A point-in-time snapshot of QUIC connection statistics.
+///
+/// The driver refreshes this each event loop iteration once the connection is
+/// established, so reads are cheap and lock-free of quiche internals.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ConnectionStats {
+    /// Total bytes sent, including retransmissions and overhead.
+    pub bytes_sent: u64,
+    /// Total bytes received, including duplicates and overhead.
+    pub bytes_received: u64,
+    /// Total bytes detected as lost.
+    pub bytes_lost: u64,
+    /// Total QUIC packets sent.
+    pub packets_sent: u64,
+    /// Total QUIC packets received.
+    pub packets_received: u64,
+    /// Total QUIC packets detected as lost.
+    pub packets_lost: u64,
+    /// Smoothed round-trip time for the active path, if one is established.
+    pub rtt: Option<Duration>,
+    /// Estimated send rate in bits per second (from the congestion controller),
+    /// if a path is established.
+    pub send_rate: Option<u64>,
+}
+
+impl ConnectionStats {
+    /// Snapshot the current stats from a live quiche connection.
+    pub(super) fn from_quiche(conn: &tokio_quiche::quic::QuicheConnection) -> Self {
+        let stats = conn.stats();
+        // The first (active) path carries RTT and the delivery-rate estimate.
+        let path = conn.path_stats().next();
+        Self {
+            bytes_sent: stats.sent_bytes,
+            bytes_received: stats.recv_bytes,
+            bytes_lost: stats.lost_bytes,
+            packets_sent: stats.sent as u64,
+            packets_received: stats.recv as u64,
+            packets_lost: stats.lost as u64,
+            rtt: path.as_ref().map(|p| p.rtt),
+            // quiche reports the delivery rate in bytes/sec; the trait wants bits/sec.
+            send_rate: path.as_ref().map(|p| p.delivery_rate.saturating_mul(8)),
+        }
+    }
+}
 
 /// An errors returned by [Connection].
 #[derive(Clone, Error, Debug)]
@@ -284,6 +330,11 @@ impl Connection {
     /// Returns the SNI server name from the TLS ClientHello, if the handshake has completed.
     pub fn server_name(&self) -> Option<String> {
         self.driver.lock().server_name().map(|s| s.to_string())
+    }
+
+    /// Returns the most recent connection statistics snapshot.
+    pub fn stats(&self) -> ConnectionStats {
+        self.driver.lock().stats()
     }
 }
 

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -17,8 +17,8 @@ use tokio_quiche::{
 use crate::ez::Lock;
 
 use super::{
-    ConnectionClosed, ConnectionError, Metrics, RecvState, RecvStream, SendState, SendStream,
-    StreamId,
+    ConnectionClosed, ConnectionError, ConnectionStats, Metrics, RecvState, RecvStream, SendState,
+    SendStream, StreamId,
 };
 
 // "drop" in ascii; if you see this then close(code)
@@ -47,6 +47,9 @@ pub(super) struct DriverState {
 
     /// Wakers waiting for the handshake to complete.
     handshake_wakers: Vec<Waker>,
+
+    /// Latest connection statistics, refreshed by the driver each poll.
+    stats: ConnectionStats,
 }
 
 impl DriverState {
@@ -71,7 +74,13 @@ impl DriverState {
             alpn: None,
             server_name: None,
             handshake_wakers: Vec::new(),
+            stats: ConnectionStats::default(),
         }
+    }
+
+    /// Returns the most recent connection statistics snapshot.
+    pub fn stats(&self) -> ConnectionStats {
+        self.stats
     }
 
     pub fn close(&mut self, err: ConnectionError) -> Vec<Waker> {
@@ -431,8 +440,12 @@ impl Driver {
             return Poll::Pending;
         }
 
+        // Snapshot stats while we hold an immutable view; stored under the lock below.
+        let stats = ConnectionStats::from_quiche(qconn);
+
         let (sleep, send, recv, bi_wakers, uni_wakers) = {
             let mut driver = self.state.lock();
+            driver.stats = stats;
             // Park the waker before checking for work. `send_datagram` pushes
             // to the channel first, then takes this waker — observing the
             // queue after we publish the waker means any racing producer is

--- a/rs/web-transport-quiche/src/ez/tls.rs
+++ b/rs/web-transport-quiche/src/ez/tls.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::sync::Arc;
 
 use boring::ec::EcKey;
@@ -216,11 +217,57 @@ pub(crate) enum ClientVerify {
     Hashes(Vec<[u8; 32]>),
 }
 
-/// Client-side TLS hook: optionally presents a client certificate (mTLS) and
-/// installs the requested server-verification policy.
-pub(crate) struct ClientHook {
-    pub cert: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
-    pub verify: ClientVerify,
+/// Build the client SSL context: optionally present a client certificate
+/// (mTLS) and install the requested server-verification policy.
+///
+/// Fallible up front (at connect time) so a malformed certificate, key, or
+/// root surfaces as a connection error. The [ConnectionHook] returns
+/// `Option<SslContextBuilder>` and `None` silently falls back to tokio-quiche's
+/// default (unverified) config, so the policy must never be dropped there.
+pub(crate) fn build_client_context(
+    cert: Option<&(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
+    verify: &ClientVerify,
+) -> io::Result<SslContextBuilder> {
+    let mut builder = SslContextBuilder::new(SslMethod::tls()).map_err(io::Error::other)?;
+
+    if let Some((chain, key)) = cert {
+        apply_client_cert(&mut builder, chain, key)?;
+    }
+
+    match verify {
+        ClientVerify::Default => {}
+        ClientVerify::Roots(roots) => {
+            let mut store = X509StoreBuilder::new().map_err(io::Error::other)?;
+            for der in roots {
+                let cert = X509::from_der(der.as_ref()).map_err(io::Error::other)?;
+                store.add_cert(cert).map_err(io::Error::other)?;
+            }
+            builder.set_cert_store_builder(store);
+            builder.set_verify(SslVerifyMode::PEER);
+        }
+        ClientVerify::Hashes(hashes) => {
+            let hashes = hashes.clone();
+            // Fully replaces standard verification: accept the peer iff the
+            // SHA-256 of its leaf DER is in the allow-list.
+            builder.set_custom_verify_callback(SslVerifyMode::PEER, move |ssl| {
+                let cert = ssl
+                    .peer_certificate()
+                    .ok_or(SslVerifyError::Invalid(SslAlert::CERTIFICATE_UNKNOWN))?;
+                let digest = cert
+                    .digest(MessageDigest::sha256())
+                    .map_err(|_| SslVerifyError::Invalid(SslAlert::BAD_CERTIFICATE))?;
+                if hashes.iter().any(|h| h.as_slice() == digest.as_ref()) {
+                    Ok(())
+                } else {
+                    Err(SslVerifyError::Invalid(
+                        SslAlert::BAD_CERTIFICATE_HASH_VALUE,
+                    ))
+                }
+            });
+        }
+    }
+
+    Ok(builder)
 }
 
 /// Set the leaf, intermediates, and private key on the builder for mTLS.
@@ -228,42 +275,43 @@ fn apply_client_cert(
     builder: &mut SslContextBuilder,
     chain: &[CertificateDer<'static>],
     key: &PrivateKeyDer<'static>,
-) -> Option<()> {
-    let leaf = X509::from_der(
-        chain
-            .first()
-            .or_else(|| {
-                tracing::warn!("empty client certificate chain");
-                None
-            })?
-            .as_ref(),
-    )
-    .inspect_err(|err| tracing::warn!(%err, "failed to parse client leaf certificate DER"))
-    .ok()?;
-    builder
-        .set_certificate(&leaf)
-        .inspect_err(|err| tracing::warn!(%err, "failed to set client leaf certificate"))
-        .ok()?;
+) -> io::Result<()> {
+    let leaf_der = chain.first().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "empty client certificate chain",
+        )
+    })?;
+    let leaf = X509::from_der(leaf_der.as_ref()).map_err(io::Error::other)?;
+    builder.set_certificate(&leaf).map_err(io::Error::other)?;
 
     for cert_der in chain.iter().skip(1) {
-        let cert = X509::from_der(cert_der.as_ref())
-            .inspect_err(|err| tracing::warn!(%err, "failed to parse client intermediate DER"))
-            .ok()?;
+        let cert = X509::from_der(cert_der.as_ref()).map_err(io::Error::other)?;
         builder
             .add_extra_chain_cert(cert)
-            .inspect_err(|err| tracing::warn!(%err, "failed to add client intermediate"))
-            .ok()?;
+            .map_err(io::Error::other)?;
     }
 
-    let key = der_to_boring_key(key)
-        .inspect_err(|err| tracing::warn!(%err, "failed to parse client private key"))
-        .ok()?;
-    builder
-        .set_private_key(&key)
-        .inspect_err(|err| tracing::warn!(%err, "failed to set client private key"))
-        .ok()?;
+    let key = der_to_boring_key(key).map_err(io::Error::other)?;
+    builder.set_private_key(&key).map_err(io::Error::other)?;
 
-    Some(())
+    Ok(())
+}
+
+/// Client-side TLS hook holding a pre-built, pre-validated SSL context.
+///
+/// The context is built once at connect time (see [build_client_context]); the
+/// hook just hands it over. tokio-quiche calls this once per socket.
+pub(crate) struct ClientHook {
+    builder: std::sync::Mutex<Option<SslContextBuilder>>,
+}
+
+impl ClientHook {
+    pub fn new(builder: SslContextBuilder) -> Self {
+        Self {
+            builder: std::sync::Mutex::new(Some(builder)),
+        }
+    }
 }
 
 impl ConnectionHook for ClientHook {
@@ -271,56 +319,13 @@ impl ConnectionHook for ClientHook {
         &self,
         _settings: TlsCertificatePaths<'_>,
     ) -> Option<SslContextBuilder> {
-        let mut builder = SslContextBuilder::new(SslMethod::tls())
-            .inspect_err(|err| tracing::warn!(%err, "failed to create SSL context"))
-            .ok()?;
-
-        if let Some((chain, key)) = &self.cert {
-            apply_client_cert(&mut builder, chain, key)?;
+        let builder = self.builder.lock().unwrap().take();
+        if builder.is_none() {
+            // Should be unreachable: the hook is invoked once per socket. Falling
+            // back to the default config would drop the verification policy, so
+            // refuse loudly rather than silently downgrading.
+            tracing::error!("client SSL context requested more than once; refusing to reuse");
         }
-
-        match &self.verify {
-            ClientVerify::Default => {}
-            ClientVerify::Roots(roots) => {
-                let mut store = X509StoreBuilder::new()
-                    .inspect_err(|err| tracing::warn!(%err, "failed to create cert store"))
-                    .ok()?;
-                for der in roots {
-                    let cert = X509::from_der(der.as_ref())
-                        .inspect_err(
-                            |err| tracing::warn!(%err, "failed to parse root certificate DER"),
-                        )
-                        .ok()?;
-                    store
-                        .add_cert(cert)
-                        .inspect_err(|err| tracing::warn!(%err, "failed to add root certificate"))
-                        .ok()?;
-                }
-                builder.set_cert_store_builder(store);
-                builder.set_verify(SslVerifyMode::PEER);
-            }
-            ClientVerify::Hashes(hashes) => {
-                let hashes = hashes.clone();
-                // Fully replaces standard verification: accept the peer iff the
-                // SHA-256 of its leaf DER is in the allow-list.
-                builder.set_custom_verify_callback(SslVerifyMode::PEER, move |ssl| {
-                    let cert = ssl
-                        .peer_certificate()
-                        .ok_or(SslVerifyError::Invalid(SslAlert::CERTIFICATE_UNKNOWN))?;
-                    let digest = cert
-                        .digest(MessageDigest::sha256())
-                        .map_err(|_| SslVerifyError::Invalid(SslAlert::BAD_CERTIFICATE))?;
-                    if hashes.iter().any(|h| h.as_slice() == digest.as_ref()) {
-                        Ok(())
-                    } else {
-                        Err(SslVerifyError::Invalid(
-                            SslAlert::BAD_CERTIFICATE_HASH_VALUE,
-                        ))
-                    }
-                });
-            }
-        }
-
-        Some(builder)
+        builder
     }
 }

--- a/rs/web-transport-quiche/src/ez/tls.rs
+++ b/rs/web-transport-quiche/src/ez/tls.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
 use boring::ec::EcKey;
+use boring::hash::MessageDigest;
 use boring::pkey::{PKey, Private};
 use boring::rsa::Rsa;
 use boring::ssl::{
-    AlpnError, ClientHello, NameType, SelectCertError, SslContextBuilder, SslMethod,
+    AlpnError, ClientHello, NameType, SelectCertError, SslAlert, SslContextBuilder, SslMethod,
+    SslVerifyError, SslVerifyMode,
 };
+use boring::x509::store::X509StoreBuilder;
 use boring::x509::X509;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_quiche::quic::ConnectionHook;
@@ -191,6 +194,131 @@ impl ConnectionHook for DynamicCertHook {
             builder.set_alpn_select_callback(move |_, client| {
                 alpn_select(alpn.as_slice(), client).ok_or(AlpnError::ALERT_FATAL)
             });
+        }
+
+        Some(builder)
+    }
+}
+
+/// How a client verifies the server's certificate.
+pub(crate) enum ClientVerify {
+    /// Standard verification against the SSL context's default trust store.
+    /// The driver layers `verify_peer` from [super::Settings] on top.
+    Default,
+
+    /// Standard verification against an explicit set of root certificates,
+    /// replacing the default trust store.
+    Roots(Vec<CertificateDer<'static>>),
+
+    /// Accept the server certificate if (and only if) the SHA-256 of its DER
+    /// encoding matches one of these. This bypasses CA verification entirely,
+    /// mirroring the browser's `serverCertificateHashes` mechanism.
+    Hashes(Vec<[u8; 32]>),
+}
+
+/// Client-side TLS hook: optionally presents a client certificate (mTLS) and
+/// installs the requested server-verification policy.
+pub(crate) struct ClientHook {
+    pub cert: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
+    pub verify: ClientVerify,
+}
+
+/// Set the leaf, intermediates, and private key on the builder for mTLS.
+fn apply_client_cert(
+    builder: &mut SslContextBuilder,
+    chain: &[CertificateDer<'static>],
+    key: &PrivateKeyDer<'static>,
+) -> Option<()> {
+    let leaf = X509::from_der(
+        chain
+            .first()
+            .or_else(|| {
+                tracing::warn!("empty client certificate chain");
+                None
+            })?
+            .as_ref(),
+    )
+    .inspect_err(|err| tracing::warn!(%err, "failed to parse client leaf certificate DER"))
+    .ok()?;
+    builder
+        .set_certificate(&leaf)
+        .inspect_err(|err| tracing::warn!(%err, "failed to set client leaf certificate"))
+        .ok()?;
+
+    for cert_der in chain.iter().skip(1) {
+        let cert = X509::from_der(cert_der.as_ref())
+            .inspect_err(|err| tracing::warn!(%err, "failed to parse client intermediate DER"))
+            .ok()?;
+        builder
+            .add_extra_chain_cert(cert)
+            .inspect_err(|err| tracing::warn!(%err, "failed to add client intermediate"))
+            .ok()?;
+    }
+
+    let key = der_to_boring_key(key)
+        .inspect_err(|err| tracing::warn!(%err, "failed to parse client private key"))
+        .ok()?;
+    builder
+        .set_private_key(&key)
+        .inspect_err(|err| tracing::warn!(%err, "failed to set client private key"))
+        .ok()?;
+
+    Some(())
+}
+
+impl ConnectionHook for ClientHook {
+    fn create_custom_ssl_context_builder(
+        &self,
+        _settings: TlsCertificatePaths<'_>,
+    ) -> Option<SslContextBuilder> {
+        let mut builder = SslContextBuilder::new(SslMethod::tls())
+            .inspect_err(|err| tracing::warn!(%err, "failed to create SSL context"))
+            .ok()?;
+
+        if let Some((chain, key)) = &self.cert {
+            apply_client_cert(&mut builder, chain, key)?;
+        }
+
+        match &self.verify {
+            ClientVerify::Default => {}
+            ClientVerify::Roots(roots) => {
+                let mut store = X509StoreBuilder::new()
+                    .inspect_err(|err| tracing::warn!(%err, "failed to create cert store"))
+                    .ok()?;
+                for der in roots {
+                    let cert = X509::from_der(der.as_ref())
+                        .inspect_err(
+                            |err| tracing::warn!(%err, "failed to parse root certificate DER"),
+                        )
+                        .ok()?;
+                    store
+                        .add_cert(cert)
+                        .inspect_err(|err| tracing::warn!(%err, "failed to add root certificate"))
+                        .ok()?;
+                }
+                builder.set_cert_store_builder(store);
+                builder.set_verify(SslVerifyMode::PEER);
+            }
+            ClientVerify::Hashes(hashes) => {
+                let hashes = hashes.clone();
+                // Fully replaces standard verification: accept the peer iff the
+                // SHA-256 of its leaf DER is in the allow-list.
+                builder.set_custom_verify_callback(SslVerifyMode::PEER, move |ssl| {
+                    let cert = ssl
+                        .peer_certificate()
+                        .ok_or(SslVerifyError::Invalid(SslAlert::CERTIFICATE_UNKNOWN))?;
+                    let digest = cert
+                        .digest(MessageDigest::sha256())
+                        .map_err(|_| SslVerifyError::Invalid(SslAlert::BAD_CERTIFICATE))?;
+                    if hashes.iter().any(|h| h.as_slice() == digest.as_ref()) {
+                        Ok(())
+                    } else {
+                        Err(SslVerifyError::Invalid(
+                            SslAlert::BAD_CERTIFICATE_HASH_VALUE,
+                        ))
+                    }
+                });
+            }
         }
 
         Some(builder)

--- a/rs/web-transport-quiche/tests/verify.rs
+++ b/rs/web-transport-quiche/tests/verify.rs
@@ -1,0 +1,205 @@
+//! Server-certificate verification: SHA-256 hash pinning (the browser's
+//! `serverCertificateHashes` equivalent) and explicit root certificates.
+//!
+//! The security-critical assertion is the negative one: a wrong hash must
+//! *fail* the handshake, not silently connect.
+
+use std::{
+    net::{Ipv6Addr, SocketAddr},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertifiedKey, DnType, ExtendedKeyUsagePurpose, IsCa,
+    KeyPair, KeyUsagePurpose,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use sha2::{Digest, Sha256};
+use url::Url;
+use web_transport_quiche::{ClientBuilder, ServerBuilder};
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, key_pair } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&key_pair);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+/// A CA certificate plus a leaf signed by it. Returns `(ca_root, leaf_chain, leaf_key)`.
+#[allow(clippy::type_complexity)]
+fn make_ca_chain() -> Result<(
+    CertificateDer<'static>,
+    Vec<CertificateDer<'static>>,
+    PrivateKeyDer<'static>,
+)> {
+    let ca_key = KeyPair::generate().context("ca key")?;
+    let mut ca_params = CertificateParams::new(Vec::new()).context("ca params")?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "web-transport test CA");
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_cert = ca_params.self_signed(&ca_key).context("self-sign ca")?;
+
+    let leaf_key = KeyPair::generate().context("leaf key")?;
+    let mut leaf_params = CertificateParams::new(vec!["localhost".into(), "127.0.0.1".into()])
+        .context("leaf params")?;
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, "localhost");
+    leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &ca_cert, &ca_key)
+        .context("sign leaf")?;
+
+    let ca_der = CertificateDer::from(ca_cert.der().to_vec());
+    let leaf_der = CertificateDer::from(leaf_cert.der().to_vec());
+    let leaf_key_der =
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(&leaf_key)));
+
+    Ok((ca_der, vec![leaf_der], leaf_key_der))
+}
+
+fn cert_sha256(chain: &[CertificateDer<'static>]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(chain[0].as_ref());
+    hasher.finalize().into()
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+/// Bind a server with the given cert and spawn a task that accepts (and holds)
+/// a single session. Returns the bound address and the task handle.
+async fn spawn_server(
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    let bind: SocketAddr = (Ipv6Addr::LOCALHOST, 0).into();
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let handle = tokio::spawn(async move {
+        if let Some(request) = server.accept().await {
+            if let Ok(session) = request.ok().await {
+                let _ = session.closed().await;
+            }
+        }
+    });
+
+    Ok((addr, handle))
+}
+
+// Connect by hostname so root-based verification sees a matching DNS SAN.
+// `localhost` resolves to `::1` first on the test hosts, matching the IPv6 bind.
+fn url_for(addr: SocketAddr) -> Result<Url> {
+    Ok(Url::parse(&format!("https://localhost:{}/", addr.port()))?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cert_hash_accept() -> Result<()> {
+    init_tracing();
+
+    let (chain, key) = make_self_signed()?;
+    let hash = cert_sha256(&chain);
+    let (addr, server) = spawn_server(chain, key).await?;
+
+    let session = ClientBuilder::default()
+        .with_bind((Ipv6Addr::LOCALHOST, 0))?
+        .with_server_certificate_hashes(vec![hash])
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed with the correct hash")?;
+
+    // Stats should be populated once a path is established (covers the live
+    // stats plumbing, not just `StatsUnavailable`).
+    let stats = session.stats();
+    assert!(
+        stats.bytes_sent > 0 && stats.packets_sent > 0,
+        "expected non-zero send counters, got {stats:?}"
+    );
+    assert!(
+        stats.rtt.is_some(),
+        "expected an RTT estimate once a path is established, got {stats:?}"
+    );
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cert_hash_reject() -> Result<()> {
+    init_tracing();
+
+    let (chain, key) = make_self_signed()?;
+    let (addr, server) = spawn_server(chain, key).await?;
+
+    // A hash that does not match any certificate.
+    let wrong = [0xAB; 32];
+    let url = url_for(addr)?;
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind((Ipv6Addr::LOCALHOST, 0))?
+            .with_server_certificate_hashes(vec![wrong])
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "handshake must fail when the certificate hash does not match"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_roots_accept() -> Result<()> {
+    init_tracing();
+
+    let (ca_root, chain, key) = make_ca_chain()?;
+    let (addr, server) = spawn_server(chain, key).await?;
+
+    let session = ClientBuilder::default()
+        .with_bind((Ipv6Addr::LOCALHOST, 0))?
+        .with_root_certificates(vec![ca_root])
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed when the cert is a trusted root")?;
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/verify.rs
+++ b/rs/web-transport-quiche/tests/verify.rs
@@ -5,7 +5,7 @@
 //! *fail* the handshake, not silently connect.
 
 use std::{
-    net::{Ipv6Addr, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
     time::Duration,
 };
 
@@ -88,7 +88,13 @@ async fn spawn_server(
     chain: Vec<CertificateDer<'static>>,
     key: PrivateKeyDer<'static>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
-    let bind: SocketAddr = (Ipv6Addr::LOCALHOST, 0).into();
+    // Bind to whatever `localhost` resolves to first. The client connects to the
+    // same name, so server and client agree on the address family regardless of
+    // the host's v4/v6 ordering (otherwise CI flakes when ::1 vs 127.0.0.1 differ).
+    let bind = ("localhost", 0)
+        .to_socket_addrs()?
+        .next()
+        .context("localhost did not resolve")?;
     let mut server = ServerBuilder::default()
         .with_bind(bind)?
         .with_single_cert(chain, key)?;
@@ -109,10 +115,19 @@ async fn spawn_server(
     Ok((addr, handle))
 }
 
-// Connect by hostname so root-based verification sees a matching DNS SAN.
-// `localhost` resolves to `::1` first on the test hosts, matching the IPv6 bind.
+// Connect by hostname so root-based verification sees a matching DNS SAN. Both
+// the server bind and this connect resolve `localhost`, so they pick the same
+// address; only the port from the bound socket is needed here.
 fn url_for(addr: SocketAddr) -> Result<Url> {
     Ok(Url::parse(&format!("https://localhost:{}/", addr.port()))?)
+}
+
+/// Loopback bind address matching the family of `addr`, for the client socket.
+fn loopback_for(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V4(_) => (Ipv4Addr::LOCALHOST, 0).into(),
+        SocketAddr::V6(_) => (Ipv6Addr::LOCALHOST, 0).into(),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -124,7 +139,7 @@ async fn cert_hash_accept() -> Result<()> {
     let (addr, server) = spawn_server(chain, key).await?;
 
     let session = ClientBuilder::default()
-        .with_bind((Ipv6Addr::LOCALHOST, 0))?
+        .with_bind(loopback_for(addr))?
         .with_server_certificate_hashes(vec![hash])
         .connect(url_for(addr)?)
         .await?
@@ -160,10 +175,11 @@ async fn cert_hash_reject() -> Result<()> {
     // A hash that does not match any certificate.
     let wrong = [0xAB; 32];
     let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
 
     let result = tokio::time::timeout(Duration::from_secs(5), async move {
         ClientBuilder::default()
-            .with_bind((Ipv6Addr::LOCALHOST, 0))?
+            .with_bind(client_bind)?
             .with_server_certificate_hashes(vec![wrong])
             .connect(url)
             .await?
@@ -190,7 +206,7 @@ async fn custom_roots_accept() -> Result<()> {
     let (addr, server) = spawn_server(chain, key).await?;
 
     let session = ClientBuilder::default()
-        .with_bind((Ipv6Addr::LOCALHOST, 0))?
+        .with_bind(loopback_for(addr))?
         .with_root_certificates(vec![ca_root])
         .connect(url_for(addr)?)
         .await?
@@ -200,6 +216,40 @@ async fn custom_roots_accept() -> Result<()> {
 
     session.close(0, "bye");
     session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_roots_reject() -> Result<()> {
+    init_tracing();
+
+    // Server presents a leaf from one CA; the client trusts a *different* CA.
+    // Verification must fail rather than fall back to accepting the peer.
+    let (_server_ca, chain, key) = make_ca_chain()?;
+    let (other_ca, _other_chain, _other_key) = make_ca_chain()?;
+    let (addr, server) = spawn_server(chain, key).await?;
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![other_ca])
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "handshake must fail when the server cert chains to an untrusted root"
+    );
+
     server.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes three gaps that kept the **quiche** backend from being a drop-in alternative to quinn.

### 1. Live connection stats
`Session::stats()` was inheriting the `StatsUnavailable` default, so every metric returned `None` — which silently disables any consumer that drives off RTT or the congestion-controller bitrate (e.g. moq-net's send-rate probe). tokio-quiche's own `QuicConnection::stats()` handle only refreshes *on close*, so it's useless for live reads. The driver now snapshots `quiche::Connection::stats()` + `path_stats()` each poll into a new `ez::ConnectionStats`, exposed via `Connection::stats()` and an `impl web_transport_trait::Stats`. (delivery rate is converted bytes/s → bits/s for the trait.)

### 2. Server certificate verification
New client builder methods (on both the top-level and `ez` builders):
- `with_server_certificate_hashes(Vec<[u8; 32]>)` — pin the leaf by SHA-256 via a BoringSSL custom-verify callback, bypassing the CA chain. This is the native equivalent of the browser's `serverCertificateHashes` and the usual way to reach a relay with a short-lived self-signed cert.
- `with_root_certificates(Vec<CertificateDer>)` — verify against an explicit trust store instead of BoringSSL's empty default.

Implemented as a unified client `ConnectionHook` (`ClientHook` + `ClientVerify`) that also keeps the existing mTLS client-cert path.

### 3. Linux client GSO/GRO
The client connect path now calls `socket.apply_max_capabilities()` (Linux only), matching what the server listener already did. The old `// TODO modify quiche` comment was stale — tokio-quiche 0.19 threads the capabilities through `Socket`. No-op on non-Linux.

## Public API (all additive, non-breaking)
- `ez::ConnectionStats` (new struct) + `Connection::stats()` (top-level and `ez`)
- `ClientBuilder::with_server_certificate_hashes` / `with_root_certificates` (top-level and `ez`)
- `impl web_transport_trait::Stats for ez::ConnectionStats`, `Session::stats()` now returns real data

## Test plan
- [x] `tests/verify.rs`: `cert_hash_accept`, **`cert_hash_reject`** (a non-matching hash must fail the handshake — the security-critical negative), `custom_roots_accept` (proper CA→leaf chain), plus a live-stats assertion on the established session.
- [x] Existing `datagram` / `reset` tests still pass.
- [x] clippy clean, `cargo fmt --check` clean (via `nix develop`).

Branched off the latest `origin/main`. The motivating consumer is the moq quiche backend ([moq-dev/moq#1902](https://github.com/moq-dev/moq/pull/1902)), which wires `--tls-fingerprint` / `--tls-root` / `http://` through to these methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)