### PR TITLE
feat(qmux): resolve protocol/path during establishment; sync getters

### DIFF
--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -28,7 +28,13 @@ pub enum Protocol {
 }
 
 /// Configuration for a QMux session.
+///
+/// Construct with [`Config::new`] (or [`Config::negotiated`]) and set the public
+/// fields you need; the struct is `#[non_exhaustive]` so new fields can be added
+/// without breaking callers. For the common transports, prefer the higher-level
+/// [`tcp`](crate::tcp) / [`uds`](crate::uds) builders, which wrap this.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Config {
     /// Wire format version.
     pub version: Version,

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -5,6 +5,7 @@ use crate::Version;
 
 /// How the application-level protocol is determined for a session.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub enum Protocol {
     /// No application protocol.
     #[default]

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::proto::{TransportParams, DEFAULT_MAX_RECORD_SIZE};
 use crate::Version;
 
@@ -14,8 +16,8 @@ pub enum Protocol {
     /// For transports without ALPN (TCP, Unix sockets). Both peers must opt in:
     /// receiving the parameter while *not* in this mode is a protocol error.
     /// The agreed protocol is surfaced by
-    /// [`Session::protocol`](web_transport_trait::Session::protocol) /
-    /// [`Session::negotiated`](crate::Session::negotiated) once params arrive.
+    /// [`Session::protocol`](web_transport_trait::Session::protocol), resolved
+    /// by the time [`Session::established`](crate::Session::established) completes.
     Negotiate(Vec<String>),
 
     /// Already negotiated out of band (TLS / WebSocket ALPN). Reported as-is;
@@ -57,6 +59,13 @@ pub struct Config {
     pub max_idle_timeout: u64,
     /// Maximum QMux Record size in bytes (draft-01). Default: 16382.
     pub max_record_size: u64,
+
+    /// How long [`Session::established`](crate::Session::established) waits for
+    /// the peer's transport parameters before giving up. Bounds the handshake so
+    /// a peer that completes the transport connection but never sends its
+    /// parameters can't hang `connect`/`accept` forever. Default: 10s; a zero
+    /// duration disables the timeout (wait indefinitely).
+    pub handshake_timeout: Duration,
 }
 
 impl Default for Config {
@@ -73,6 +82,7 @@ impl Default for Config {
             max_stream_data_uni: 262_144,         // 256 KB
             max_idle_timeout: 30_000,             // 30 seconds
             max_record_size: DEFAULT_MAX_RECORD_SIZE,
+            handshake_timeout: Duration::from_secs(10),
         }
     }
 }

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -17,7 +17,8 @@ pub enum Protocol {
     /// receiving the parameter while *not* in this mode is a protocol error.
     /// The agreed protocol is surfaced by
     /// [`Session::protocol`](web_transport_trait::Session::protocol), resolved
-    /// by the time [`Session::established`](crate::Session::established) completes.
+    /// by the time [`Session::connect`](crate::Session::connect) /
+    /// [`accept`](crate::Session::accept) returns.
     Negotiate(Vec<String>),
 
     /// Already negotiated out of band (TLS / WebSocket ALPN). Reported as-is;
@@ -60,11 +61,12 @@ pub struct Config {
     /// Maximum QMux Record size in bytes (draft-01). Default: 16382.
     pub max_record_size: u64,
 
-    /// How long [`Session::established`](crate::Session::established) waits for
-    /// the peer's transport parameters before giving up. Bounds the handshake so
-    /// a peer that completes the transport connection but never sends its
-    /// parameters can't hang `connect`/`accept` forever. Default: 10s; a zero
-    /// duration disables the timeout (wait indefinitely).
+    /// How long [`Session::connect`](crate::Session::connect) /
+    /// [`accept`](crate::Session::accept) waits for the peer's transport
+    /// parameters before giving up. Bounds the handshake so a peer that completes
+    /// the transport connection but never sends its parameters can't hang
+    /// establishment forever. Default: 10s; a zero duration disables the timeout
+    /// (wait indefinitely).
     pub handshake_timeout: Duration,
 }
 

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error("idle timeout")]
     IdleTimeout,
 
+    #[error("handshake timeout: peer never sent transport parameters")]
+    HandshakeTimeout,
+
     #[error("invalid protocol token: {0:?}")]
     InvalidProtocol(String),
 

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -4,6 +4,7 @@ use web_transport_proto::{VarInt, VarIntBoundsExceeded, VarIntUnexpectedEnd};
 
 /// Errors that can occur during QMux session and stream operations.
 #[derive(Debug, thiserror::Error, Clone)]
+#[non_exhaustive]
 pub enum Error {
     #[error("invalid frame type: {0}")]
     InvalidFrameType(u64),

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -558,38 +558,37 @@ impl<T: Transport> SessionState<T> {
 }
 
 impl Session {
-    /// Create a client-side session over the given transport.
-    pub fn connect<T: Transport>(transport: T, config: Config) -> Self {
-        Self::new(transport, false, config)
-    }
-
-    /// Create a server-side session over the given transport.
-    pub fn accept<T: Transport>(transport: T, config: Config) -> Self {
-        Self::new(transport, true, config)
-    }
-
-    /// Wait until the session is established — the peer's transport parameters
-    /// have been received and applied, so [`protocol`] and [`path`] return their
-    /// final values.
+    /// Open a client-side session over the given transport, waiting until it is
+    /// established before returning.
     ///
-    /// The transport builders ([`tcp`], [`uds`], [`tls`]) await this internally,
-    /// so a session they hand back is already established. Call it yourself only
-    /// when you built the [`Session`] directly via [`Session::connect`] /
-    /// [`Session::accept`]. For the legacy `webtransport` wire format — which
-    /// exchanges no parameters — it resolves immediately.
+    /// "Established" means the peer's transport parameters have been received and
+    /// applied, so [`protocol`](web_transport_trait::Session::protocol) and
+    /// [`path`](Session::path) return their final values. The legacy
+    /// `webtransport` wire format exchanges no parameters, so it is established
+    /// immediately.
     ///
     /// Bounded by [`Config::handshake_timeout`](crate::Config::handshake_timeout):
     /// if the peer completes the transport handshake but never sends its
-    /// parameters, this closes the session and returns [`Error::HandshakeTimeout`]
-    /// rather than hanging. If the connection drops mid-handshake, the close
-    /// reason is returned instead.
-    ///
-    /// [`protocol`]: web_transport_trait::Session::protocol
-    /// [`path`]: Session::path
-    /// [`tcp`]: crate::tcp
-    /// [`uds`]: crate::uds
-    /// [`tls`]: crate::tls
-    pub async fn established(&self) -> Result<(), Error> {
+    /// parameters, this returns [`Error::HandshakeTimeout`] rather than hanging;
+    /// a mid-handshake disconnect returns the close reason.
+    pub async fn connect<T: Transport>(transport: T, config: Config) -> Result<Session, Error> {
+        let session = Self::new(transport, false, config);
+        session.established().await?;
+        Ok(session)
+    }
+
+    /// Open a server-side session over the given transport, waiting until it is
+    /// established before returning. See [`Session::connect`] for the semantics.
+    pub async fn accept<T: Transport>(transport: T, config: Config) -> Result<Session, Error> {
+        let session = Self::new(transport, true, config);
+        session.established().await?;
+        Ok(session)
+    }
+
+    /// Wait until the peer's transport parameters have been received and applied.
+    /// Folded into [`connect`](Session::connect) / [`accept`](Session::accept);
+    /// see those for the timeout and error semantics.
+    async fn established(&self) -> Result<(), Error> {
         let mut established = self.established.clone();
         if *established.borrow() {
             return Ok(());
@@ -630,13 +629,18 @@ impl Session {
     /// For a server this is the resource path the client requested; for a client
     /// it's whatever the server advertised (usually `None`). Mirrors
     /// [`protocol`](web_transport_trait::Session::protocol): a synchronous getter
-    /// that returns the resolved value, since a session is only handed back once
-    /// [`established`](Session::established) has completed.
+    /// that returns the resolved value, since [`connect`](Session::connect) /
+    /// [`accept`](Session::accept) only return once the handshake has completed.
     pub fn path(&self) -> Option<&str> {
         self.peer_path.get().and_then(|p| p.as_deref())
     }
 
-    fn new<T: Transport>(transport: T, is_server: bool, config: Config) -> Self {
+    /// Construct a session over the transport and start its run loop, without
+    /// waiting for the handshake. The public entry points are the async
+    /// [`connect`](Session::connect) / [`accept`](Session::accept), which await
+    /// establishment; this is for callers that resolve their protocol out of band
+    /// (e.g. the WebSocket transport, which negotiates via the subprotocol).
+    pub(crate) fn new<T: Transport>(transport: T, is_server: bool, config: Config) -> Self {
         let version = config.version;
         let our_params = config.to_transport_params();
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -34,20 +34,20 @@ pub struct Session {
     closed: watch::Sender<Option<Error>>,
 
     // Negotiated application protocol (via the application_protocols transport
-    // parameter). `None` inside the OnceLock means "no protocol"; the OnceLock
-    // being unset means negotiation is still pending. `negotiated_ready` flips
-    // to `true` once it's set, so `negotiated()` can await it.
+    // parameter) and the path the peer advertised (via the `path` parameter).
+    // Both are resolved exactly once, before the session is handed to the caller
+    // (see `established()`), so `protocol()` / `path()` are plain synchronous
+    // getters. `None` inside an OnceLock means "no value"; unset means the peer's
+    // params haven't arrived yet (only observable on a session you constructed
+    // without awaiting `established()`). OnceLocks give the resolved values a
+    // stable address so the getters can hand out `&str` borrows.
     negotiated: Arc<OnceLock<Option<String>>>,
-    negotiated_ready: watch::Receiver<bool>,
-
-    // Path the peer advertised via the `path` transport parameter. `None` inside
-    // the OnceLock means "no path"; the OnceLock being unset means the peer's
-    // params haven't arrived yet. `peer_path_ready` flips to `true` once it's
-    // set, so `path()` can await it. Kept as an OnceLock rather than folded into
-    // a watch so the resolved value has a stable address and `path()` can hand
-    // out a `&str` borrow (as `protocol()` does), instead of cloning.
     peer_path: Arc<OnceLock<Option<String>>>,
-    peer_path_ready: watch::Receiver<bool>,
+
+    // Flips to `true` once the peer's transport parameters have been received and
+    // applied (or eagerly for the param-less `webtransport` format). `established()`
+    // awaits this; if the sender drops first, the connection closed mid-handshake.
+    established: watch::Receiver<bool>,
 
     // Flow control: stream count credits (claim_index returns stream sequence number)
     open_bi_credit: Credit,
@@ -79,13 +79,11 @@ struct SessionState<T: Transport> {
 
     closed: watch::Sender<Option<Error>>,
 
-    // Negotiated application protocol — see the matching fields on `Session`.
+    // Negotiated protocol, peer path, and handshake-complete signal — see the
+    // matching fields on `Session`.
     negotiated: Arc<OnceLock<Option<String>>>,
-    negotiated_ready: watch::Sender<bool>,
-
-    // Peer's advertised path — see the matching fields on `Session`.
     peer_path: Arc<OnceLock<Option<String>>>,
-    peer_path_ready: watch::Sender<bool>,
+    established: watch::Sender<bool>,
 
     // Flow control state
     conn_send_credit: Credit,
@@ -487,23 +485,6 @@ impl<T: Transport> SessionState<T> {
         Ok(())
     }
 
-    /// Record the negotiated application protocol exactly once and wake any
-    /// `Session::negotiated()` waiters. Later calls are no-ops.
-    fn resolve_negotiated(&self, protocol: Option<String>) {
-        if self.negotiated.set(protocol).is_ok() {
-            self.negotiated_ready.send_replace(true);
-        }
-    }
-
-    /// Record the peer's advertised path exactly once and wake any
-    /// `Session::path()` waiters. The first resolution — the peer's params or
-    /// the connection closing — wins; later calls are no-ops.
-    fn resolve_peer_path(&self, path: Option<String>) {
-        if self.peer_path.set(path).is_ok() {
-            self.peer_path_ready.send_replace(true);
-        }
-    }
-
     fn recv_transport_parameters(&mut self, params: TransportParams) -> Result<(), Error> {
         if self.params_received {
             // Duplicate transport parameters
@@ -517,7 +498,7 @@ impl<T: Transport> SessionState<T> {
             // wins, matching RFC 7301). The OnceLock is still pending here.
             crate::Protocol::Negotiate(ours) => {
                 let agreed = negotiate_protocol(self.is_server, ours, &params.protocols);
-                self.resolve_negotiated(agreed);
+                self.negotiated.set(agreed).ok();
             }
             // Not negotiating in-band: the peer MUST NOT send the parameter.
             // TLS/WebSocket already chose a protocol via ALPN, and a session
@@ -532,7 +513,7 @@ impl<T: Transport> SessionState<T> {
 
         // Surface the peer's path (if any). Unlike protocols this isn't gated on
         // opt-in: it's optional routing metadata, so an absent param is just None.
-        self.resolve_peer_path(params.path.clone());
+        self.peer_path.set(params.path.clone()).ok();
 
         // Set connection-level send credit from peer's initial_max_data
         self.conn_send_credit
@@ -568,6 +549,10 @@ impl<T: Transport> SessionState<T> {
 
         self.peer_params = params;
 
+        // Handshake complete: `negotiated` and `peer_path` are now set, so unblock
+        // `established()` and let the synchronous getters return their final values.
+        self.established.send_replace(true);
+
         Ok(())
     }
 }
@@ -583,46 +568,71 @@ impl Session {
         Self::new(transport, true, config)
     }
 
-    /// Wait for the negotiated application protocol.
+    /// Wait until the session is established — the peer's transport parameters
+    /// have been received and applied, so [`protocol`] and [`path`] return their
+    /// final values.
     ///
-    /// For [`Protocol::Negotiated`](crate::Protocol::Negotiated) /
-    /// [`Protocol::None`](crate::Protocol::None) (e.g. TLS/WS ALPN) this resolves
-    /// immediately. For [`Protocol::Negotiate`](crate::Protocol::Negotiate) — the
-    /// in-band path over TCP, Unix sockets, or any
-    /// [`Stream`](crate::transport::Stream)-based session — it resolves once the
-    /// peer's transport parameters arrive, or to `None` if the connection closes
-    /// first.
+    /// The transport builders ([`tcp`], [`uds`], [`tls`]) await this internally,
+    /// so a session they hand back is already established. Call it yourself only
+    /// when you built the [`Session`] directly via [`Session::connect`] /
+    /// [`Session::accept`]. For the legacy `webtransport` wire format — which
+    /// exchanges no parameters — it resolves immediately.
     ///
-    /// [`Session::protocol`](web_transport_trait::Session::protocol) returns the
-    /// same value synchronously, but yields `None` until negotiation completes.
-    pub async fn negotiated(&self) -> Option<String> {
-        if self.negotiated.get().is_none() {
-            // `wait_for` checks the current value first, so this can't miss the
-            // transition even if it already happened.
-            let mut ready = self.negotiated_ready.clone();
-            ready.wait_for(|&done| done).await.ok();
+    /// Bounded by [`Config::handshake_timeout`](crate::Config::handshake_timeout):
+    /// if the peer completes the transport handshake but never sends its
+    /// parameters, this closes the session and returns [`Error::HandshakeTimeout`]
+    /// rather than hanging. If the connection drops mid-handshake, the close
+    /// reason is returned instead.
+    ///
+    /// [`protocol`]: web_transport_trait::Session::protocol
+    /// [`path`]: Session::path
+    /// [`tcp`]: crate::tcp
+    /// [`uds`]: crate::uds
+    /// [`tls`]: crate::tls
+    pub async fn established(&self) -> Result<(), Error> {
+        let mut established = self.established.clone();
+        if *established.borrow() {
+            return Ok(());
         }
-        self.negotiated.get().cloned().flatten()
+
+        let wait = established.wait_for(|&done| done);
+        let timeout = self.config.handshake_timeout;
+        // A zero timeout disables the bound (wait indefinitely).
+        let outcome = if timeout.is_zero() {
+            Some(wait.await)
+        } else {
+            tokio::time::timeout(timeout, wait).await.ok()
+        };
+
+        match outcome {
+            // Established.
+            Some(Ok(_)) => Ok(()),
+            // The backend task ended before establishing — surface the close reason.
+            Some(Err(_)) => Err(self.closed.borrow().clone().unwrap_or(Error::Closed)),
+            // Timed out waiting for the peer's parameters: abort the half-open
+            // handshake, notifying the peer, and fail rather than hang.
+            None => {
+                let _ = self.outbound_priority.send(
+                    ConnectionClose {
+                        code: VarInt::from(0u32),
+                        reason: "handshake timeout".to_string(),
+                    }
+                    .into(),
+                );
+                self.closed.send_replace(Some(Error::HandshakeTimeout));
+                Err(Error::HandshakeTimeout)
+            }
+        }
     }
 
     /// The path the peer advertised via the `path` transport parameter.
     ///
     /// For a server this is the resource path the client requested; for a client
-    /// it's whatever the server advertised (usually `None`).
-    ///
-    /// This is async because the value rides in the peer's transport parameters,
-    /// which arrive after the connection is established. It resolves once those
-    /// params arrive (carrying a path or nothing), or to `None` if the connection
-    /// closes first. For the legacy `webtransport` wire format — which exchanges
-    /// no parameters — it resolves to `None` immediately. The returned `&str`
-    /// borrows from the session, mirroring [`protocol`](generic::Session::protocol).
-    pub async fn path(&self) -> Option<&str> {
-        if self.peer_path.get().is_none() {
-            // `wait_for` checks the current value first, so this can't miss the
-            // transition even if it already happened.
-            let mut ready = self.peer_path_ready.clone();
-            ready.wait_for(|&done| done).await.ok();
-        }
+    /// it's whatever the server advertised (usually `None`). Mirrors
+    /// [`protocol`](web_transport_trait::Session::protocol): a synchronous getter
+    /// that returns the resolved value, since a session is only handed back once
+    /// [`established`](Session::established) has completed.
+    pub fn path(&self) -> Option<&str> {
         self.peer_path.get().and_then(|p| p.as_deref())
     }
 
@@ -644,28 +654,25 @@ impl Session {
         // Protocol negotiation. Only `Negotiate` resolves in-band (once the
         // peer's params arrive); the out-of-band cases resolve immediately.
         let negotiated: Arc<OnceLock<Option<String>>> = Arc::new(OnceLock::new());
-        let (negotiated_ready_tx, negotiated_ready_rx) = watch::channel(false);
         match &config.protocol {
             crate::Protocol::Negotiate(_) => {} // pending
             crate::Protocol::Negotiated(name) => {
                 negotiated.set(Some(name.clone())).ok();
-                negotiated_ready_tx.send_replace(true);
             }
             crate::Protocol::None => {
                 negotiated.set(None).ok();
-                negotiated_ready_tx.send_replace(true);
             }
         }
 
-        // Peer path. Resolved once the peer's transport parameters arrive (or the
-        // connection closes). Only QMux versions exchange params; the legacy
-        // `webtransport` format never does, so resolve it to `None` eagerly to
-        // keep `path()` from hanging.
+        // Peer path. Resolved once the peer's transport parameters arrive.
         let peer_path: Arc<OnceLock<Option<String>>> = Arc::new(OnceLock::new());
-        let (peer_path_ready_tx, peer_path_ready_rx) = watch::channel(false);
+
+        // Handshake-complete signal. QMux versions flip it once the peer's params
+        // arrive; the legacy `webtransport` format exchanges none, so it (and the
+        // resolved getters) are established eagerly.
+        let (established_tx, established_rx) = watch::channel(!version.is_qmux());
         if !version.is_qmux() {
             peer_path.set(None).ok();
-            peer_path_ready_tx.send_replace(true);
         }
 
         let open_bi_credit = Credit::new(if version.is_qmux() { 0 } else { u64::MAX });
@@ -705,9 +712,8 @@ impl Session {
             recv_streams: HashMap::new(),
             closed: closed.clone(),
             negotiated: negotiated.clone(),
-            negotiated_ready: negotiated_ready_tx,
             peer_path: peer_path.clone(),
-            peer_path_ready: peer_path_ready_tx,
+            established: established_tx,
             conn_send_credit: conn_send_credit.clone(),
             conn_recv_credit: conn_recv_credit.clone(),
             our_params: our_params.clone(),
@@ -723,10 +729,10 @@ impl Session {
         };
         tokio::spawn(async move {
             let err = backend.run().await.err().unwrap_or(Error::Closed);
-            // Unblock any `negotiated()` / `path()` waiter if the connection
-            // died before the peer's params arrived. No-op for already-resolved cases.
-            backend.resolve_negotiated(None);
-            backend.resolve_peer_path(None);
+            // Dropping `backend` drops the `established` sender; an `established()`
+            // waiter that was still pending then observes the channel close and
+            // reports this terminal error. The OnceLocks stay unset, so the
+            // synchronous getters report `None` on a never-established session.
             // Close all credits so blocked claim()/claim_index() calls unblock
             backend.open_bi_credit.close();
             backend.open_uni_credit.close();
@@ -757,9 +763,8 @@ impl Session {
             create_bi: create_bi_tx,
             closed,
             negotiated,
-            negotiated_ready: negotiated_ready_rx,
             peer_path,
-            peer_path_ready: peer_path_ready_rx,
+            established: established_rx,
             open_bi_credit,
             open_uni_credit,
             conn_send_credit,

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -59,11 +59,21 @@ impl Config {
         self
     }
 
+    /// Override how long establishment waits for the peer's transport
+    /// parameters before failing with [`Error::HandshakeTimeout`]. Defaults to
+    /// 10s; a zero duration waits indefinitely. See
+    /// [`Config::handshake_timeout`](crate::Config::handshake_timeout).
+    pub fn handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.inner.handshake_timeout = timeout;
+        self
+    }
+
     /// Connect to `addr` and start a client session.
     ///
-    /// When negotiating, this awaits the peer's transport parameters so
-    /// [`Session::protocol`](web_transport_trait::Session::protocol) is populated
-    /// on return.
+    /// Awaits the peer's transport parameters before returning, so
+    /// [`Session::protocol`](web_transport_trait::Session::protocol) and
+    /// [`Session::path`](crate::Session::path) are populated on the returned
+    /// session (bounded by [`handshake_timeout`](Self::handshake_timeout)).
     pub async fn connect(self, addr: impl ToSocketAddrs) -> Result<Session, Error> {
         let stream = TcpStream::connect(addr).await?;
         finish(stream, self.inner, false).await
@@ -81,8 +91,9 @@ async fn finish(
     is_server: bool,
 ) -> Result<Session, Error> {
     let session = build_stream_session(stream, config, is_server)?;
-    // Resolve the protocol before returning (instant unless negotiating). The
-    // peer's path, if any, is awaited lazily by the caller via `Session::path`.
-    session.negotiated().await;
+    // Await the peer's transport parameters before returning, so `protocol()` and
+    // `path()` are resolved on the session we hand back. Bounded by the config's
+    // handshake timeout.
+    session.established().await?;
     Ok(session)
 }

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -80,6 +80,11 @@ impl Config {
     }
 
     /// Start a server session over an accepted TCP stream.
+    ///
+    /// This awaits the QMux handshake (the peer's transport parameters), bounded
+    /// by [`handshake_timeout`](Self::handshake_timeout). Drive each connection
+    /// with `tokio::spawn` so a slow or non-cooperative peer can't stall your
+    /// `listener.accept()` loop.
     pub async fn accept(self, stream: TcpStream) -> Result<Session, Error> {
         finish(stream, self.inner, true).await
     }

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -90,10 +90,8 @@ async fn finish(
     config: crate::Config,
     is_server: bool,
 ) -> Result<Session, Error> {
-    let session = build_stream_session(stream, config, is_server)?;
-    // Await the peer's transport parameters before returning, so `protocol()` and
-    // `path()` are resolved on the session we hand back. Bounded by the config's
-    // handshake timeout.
-    session.established().await?;
-    Ok(session)
+    // `build_stream_session` awaits the peer's transport parameters before
+    // returning, so `protocol()` and `path()` are resolved on the session we hand
+    // back (bounded by the config's handshake timeout).
+    build_stream_session(stream, config, is_server).await
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -143,6 +143,12 @@ impl Server {
     }
 
     /// Accept a TLS connection over an established TCP stream.
+    ///
+    /// This awaits both the TLS handshake and the QMux handshake (the peer's
+    /// transport parameters, bounded by the session's
+    /// [`handshake_timeout`](crate::Config::handshake_timeout)). Drive each
+    /// connection with `tokio::spawn` so a slow or non-cooperative peer can't
+    /// stall your `listener.accept()` loop.
     pub async fn accept(&self, stream: TcpStream) -> Result<Session, Error> {
         let acceptor = TlsAcceptor::from(self.config.clone());
         let tls_stream = acceptor.accept(stream).await?;

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -6,92 +6,157 @@ use tokio_rustls::TlsConnector;
 use crate::transport::Stream;
 use crate::{alpn, Config, Error, Session, Version};
 
-/// Connect over TLS, advertising the given `(alpn, versions)` entries.
+/// A QMux client over TLS that advertises `(alpn, versions)` entries.
 ///
 /// Each entry's `versions` slice is expanded into the TLS ALPN list as
-/// `{v.prefix()}{alpn}` per version (empty = every QMux draft this crate
-/// knows about). The bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`)
-/// are appended as well unless `require_protocol` is set, in which case only
-/// the prefixed pairs are offered. The peer's chosen ALPN determines the QMux
-/// wire-format version; the `alpn_protocols` field on the supplied
-/// `rustls::ClientConfig` is ignored and rebuilt from `entries`.
-///
-/// `server_name` is used for SNI and certificate verification.
-///
-/// `path` is an optional requested resource path. TLS has no request line of
-/// its own, so when set it is sent in-band via the QMux `path` transport
-/// parameter; the server reads it via [`Session::path`]. Pass `None` to send no
-/// path.
-pub async fn connect<'a>(
-    addr: impl ToSocketAddrs,
-    server_name: &str,
+/// `{v.prefix()}{alpn}` per version (empty = every QMux draft this crate knows
+/// about). The bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`) are
+/// appended as well unless [`require_protocol`](Client::require_protocol) is
+/// set, in which case only the prefixed pairs are offered. The peer's chosen
+/// ALPN determines the QMux wire-format version; the `alpn_protocols` field on
+/// the supplied `rustls::ClientConfig` is ignored and rebuilt from the entries.
+#[derive(Clone)]
+pub struct Client {
     config: Arc<rustls::ClientConfig>,
-    entries: impl IntoIterator<Item = (&'a str, &'a [Version])>,
+    protocols: Vec<(String, Vec<Version>)>,
     require_protocol: bool,
-    path: Option<&str>,
-) -> Result<Session, Error> {
-    let stream = TcpStream::connect(&addr).await?;
-
-    let server_name = rustls::pki_types::ServerName::try_from(server_name)
-        .map_err(|_| Error::InvalidServerName)?
-        .to_owned();
-
-    let prefixed = alpn::build(entries, require_protocol);
-
-    let mut config = (*config).clone();
-    config.alpn_protocols = prefixed.iter().map(|s| s.as_bytes().to_vec()).collect();
-
-    tracing::debug!(?prefixed, "TLS connecting");
-
-    let connector = TlsConnector::from(Arc::new(config));
-    let tls_stream = connector.connect(server_name, stream).await?;
-
-    let negotiated = tls_stream.get_ref().1.alpn_protocol();
-    let negotiated_str = negotiated.and_then(|a| std::str::from_utf8(a).ok());
-    tracing::debug!(?negotiated_str, "TLS negotiated ALPN");
-
-    let (version, protocol) = alpn::parse(negotiated_str);
-    tracing::debug!(?version, ?protocol, "parsed ALPN");
-
-    // In strict mode an unrecognized or absent ALPN would otherwise fall
-    // through to the legacy `webtransport` wire format with no app protocol,
-    // silently downgrading the negotiation we promised to enforce.
-    if require_protocol && protocol.is_none() {
-        return Err(Error::InvalidProtocol(
-            negotiated_str.unwrap_or("<none>").to_string(),
-        ));
-    }
-
-    let mut session_config = Config::negotiated(version, protocol);
-    session_config.path = path.map(str::to_string);
-    let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    // `connect` awaits the peer's transport parameters so `path()` is resolved.
-    Session::connect(transport, session_config).await
+    path: Option<String>,
 }
 
-/// Accept a TLS connection.
+impl Client {
+    /// Start building a TLS client with the given `rustls::ClientConfig`.
+    pub fn new(config: Arc<rustls::ClientConfig>) -> Self {
+        Self {
+            config,
+            protocols: Vec::new(),
+            require_protocol: false,
+            path: None,
+        }
+    }
+
+    /// Advertise `alpn` under the listed QMux wire-format versions.
+    ///
+    /// Pass `&[v]` to pin to one version, `&[v1, v2]` to enumerate, or `&[]`
+    /// to expand to every QMux draft this crate knows about.
+    pub fn with_protocol(mut self, alpn: &str, versions: &[Version]) -> Self {
+        self.protocols.push((alpn.to_string(), versions.to_vec()));
+        self
+    }
+
+    /// Advertise multiple `(alpn, versions)` entries in preference order.
+    pub fn with_protocols<'a>(
+        mut self,
+        entries: impl IntoIterator<Item = (&'a str, &'a [Version])>,
+    ) -> Self {
+        self.protocols.extend(
+            entries
+                .into_iter()
+                .map(|(a, vs)| (a.to_string(), vs.to_vec())),
+        );
+        self
+    }
+
+    /// Offer only the prefixed `(alpn, version)` pairs, suppressing the bare
+    /// version ALPNs (`qmux-01`, `qmux-00`, `webtransport`) offered by default.
+    pub fn require_protocol(mut self) -> Self {
+        self.require_protocol = true;
+        self
+    }
+
+    /// Advertise a requested resource `path`.
+    ///
+    /// TLS has no request line of its own, so when set the path is sent in-band
+    /// via the QMux `path` transport parameter; the server reads it via
+    /// [`Session::path`]. Omit to send no path.
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Connect to `addr` and start a client session. `server_name` is used for
+    /// SNI and certificate verification.
+    pub async fn connect(
+        &self,
+        addr: impl ToSocketAddrs,
+        server_name: &str,
+    ) -> Result<Session, Error> {
+        let stream = TcpStream::connect(&addr).await?;
+
+        let server_name = rustls::pki_types::ServerName::try_from(server_name)
+            .map_err(|_| Error::InvalidServerName)?
+            .to_owned();
+
+        let entries = self
+            .protocols
+            .iter()
+            .map(|(a, vs)| (a.as_str(), vs.as_slice()));
+        let prefixed = alpn::build(entries, self.require_protocol);
+
+        let mut config = (*self.config).clone();
+        config.alpn_protocols = prefixed.iter().map(|s| s.as_bytes().to_vec()).collect();
+
+        tracing::debug!(?prefixed, "TLS connecting");
+
+        let connector = TlsConnector::from(Arc::new(config));
+        let tls_stream = connector.connect(server_name, stream).await?;
+
+        let negotiated = tls_stream.get_ref().1.alpn_protocol();
+        let negotiated_str = negotiated.and_then(|a| std::str::from_utf8(a).ok());
+        tracing::debug!(?negotiated_str, "TLS negotiated ALPN");
+
+        let (version, protocol) = alpn::parse(negotiated_str);
+        tracing::debug!(?version, ?protocol, "parsed ALPN");
+
+        // In strict mode an unrecognized or absent ALPN would otherwise fall
+        // through to the legacy `webtransport` wire format with no app protocol,
+        // silently downgrading the negotiation we promised to enforce.
+        if self.require_protocol && protocol.is_none() {
+            return Err(Error::InvalidProtocol(
+                negotiated_str.unwrap_or("<none>").to_string(),
+            ));
+        }
+
+        let mut session_config = Config::negotiated(version, protocol);
+        session_config.path = self.path.clone();
+        let transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        // `connect` awaits the peer's transport parameters so `path()` is resolved.
+        Session::connect(transport, session_config).await
+    }
+}
+
+/// A QMux server that accepts TLS connections.
 ///
 /// Selection of an offered ALPN happens inside rustls based on the
-/// `alpn_protocols` already set on the supplied `rustls::ServerConfig`; the
-/// QMux wire-format version is then derived from the negotiated ALPN.
-/// Callers building that ALPN list should use `{version.prefix()}{alpn}` for
-/// each supported pair (e.g. `"qmux-01.moq-lite-04"`).
-pub async fn accept(
-    stream: TcpStream,
+/// `alpn_protocols` already set on the supplied `rustls::ServerConfig`; the QMux
+/// wire-format version is then derived from the negotiated ALPN. Callers
+/// building that ALPN list should use `{version.prefix()}{alpn}` for each
+/// supported pair (e.g. `"qmux-01.moq-lite-04"`).
+#[derive(Clone)]
+pub struct Server {
     config: Arc<rustls::ServerConfig>,
-) -> Result<Session, Error> {
-    let acceptor = TlsAcceptor::from(config);
-    let tls_stream = acceptor.accept(stream).await?;
+}
 
-    let negotiated = tls_stream.get_ref().1.alpn_protocol();
-    let negotiated_str = negotiated.and_then(|a| std::str::from_utf8(a).ok());
-    tracing::debug!(?negotiated_str, "TLS accepted, negotiated ALPN");
+impl Server {
+    /// Create a TLS server from the given `rustls::ServerConfig`.
+    pub fn new(config: Arc<rustls::ServerConfig>) -> Self {
+        Self { config }
+    }
 
-    let (version, protocol) = alpn::parse(negotiated_str);
-    tracing::debug!(?version, ?protocol, "parsed ALPN");
+    /// Accept a TLS connection over an established TCP stream.
+    pub async fn accept(&self, stream: TcpStream) -> Result<Session, Error> {
+        let acceptor = TlsAcceptor::from(self.config.clone());
+        let tls_stream = acceptor.accept(stream).await?;
 
-    let session_config = Config::negotiated(version, protocol);
-    let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    // `accept` awaits the peer's transport parameters so `path()` is resolved.
-    Session::accept(transport, session_config).await
+        let negotiated = tls_stream.get_ref().1.alpn_protocol();
+        let negotiated_str = negotiated.and_then(|a| std::str::from_utf8(a).ok());
+        tracing::debug!(?negotiated_str, "TLS accepted, negotiated ALPN");
+
+        let (version, protocol) = alpn::parse(negotiated_str);
+        tracing::debug!(?version, ?protocol, "parsed ALPN");
+
+        let session_config = Config::negotiated(version, protocol);
+        let transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        // `accept` awaits the peer's transport parameters so `path()` is resolved.
+        Session::accept(transport, session_config).await
+    }
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -65,10 +65,8 @@ pub async fn connect<'a>(
     let mut session_config = Config::negotiated(version, protocol);
     session_config.path = path.map(str::to_string);
     let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    let session = Session::connect(transport, session_config);
-    // Await the peer's transport parameters so `path()` is resolved on return.
-    session.established().await?;
-    Ok(session)
+    // `connect` awaits the peer's transport parameters so `path()` is resolved.
+    Session::connect(transport, session_config).await
 }
 
 /// Accept a TLS connection.
@@ -94,8 +92,6 @@ pub async fn accept(
 
     let session_config = Config::negotiated(version, protocol);
     let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    let session = Session::accept(transport, session_config);
-    // Await the peer's transport parameters so `path()` is resolved on return.
-    session.established().await?;
-    Ok(session)
+    // `accept` awaits the peer's transport parameters so `path()` is resolved.
+    Session::accept(transport, session_config).await
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -65,7 +65,10 @@ pub async fn connect<'a>(
     let mut session_config = Config::negotiated(version, protocol);
     session_config.path = path.map(str::to_string);
     let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    Ok(Session::connect(transport, session_config))
+    let session = Session::connect(transport, session_config);
+    // Await the peer's transport parameters so `path()` is resolved on return.
+    session.established().await?;
+    Ok(session)
 }
 
 /// Accept a TLS connection.
@@ -91,5 +94,8 @@ pub async fn accept(
 
     let session_config = Config::negotiated(version, protocol);
     let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-    Ok(Session::accept(transport, session_config))
+    let session = Session::accept(transport, session_config);
+    // Await the peer's transport parameters so `path()` is resolved on return.
+    session.established().await?;
+    Ok(session)
 }

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -59,7 +59,7 @@ mod stream_transport {
     ///
     /// let config = Config::new(Version::QMux01);
     /// let transport = Stream::new(stream, config.version, config.max_record_size);
-    /// let session = Session::connect(transport, config);
+    /// let session = Session::connect(transport, config).await?;
     /// # let _ = session; Ok(())
     /// # }
     /// ```
@@ -482,7 +482,7 @@ mod stream_session {
 
     /// Wrap a byte stream in a [`Stream`] and start a session, validating any
     /// advertised protocol names first. Used by the `tcp`/`uds` builders.
-    pub(crate) fn build<T: AsyncRead + AsyncWrite + Send + 'static>(
+    pub(crate) async fn build<T: AsyncRead + AsyncWrite + Send + 'static>(
         stream: T,
         config: Config,
         is_server: bool,
@@ -493,11 +493,11 @@ mod stream_session {
             }
         }
         let transport = Stream::new(stream, config.version, config.max_record_size);
-        Ok(if is_server {
-            Session::accept(transport, config)
+        if is_server {
+            Session::accept(transport, config).await
         } else {
-            Session::connect(transport, config)
-        })
+            Session::connect(transport, config).await
+        }
     }
 }
 

--- a/rs/qmux/src/uds.rs
+++ b/rs/qmux/src/uds.rs
@@ -73,6 +73,11 @@ impl Config {
     }
 
     /// Start a server session over an accepted Unix-socket stream.
+    ///
+    /// This awaits the QMux handshake (the peer's transport parameters), bounded
+    /// by [`handshake_timeout`](Self::handshake_timeout). Drive each connection
+    /// with `tokio::spawn` so a slow or non-cooperative peer can't stall your
+    /// `listener.accept()` loop.
     pub async fn accept(self, stream: UnixStream) -> Result<Session, Error> {
         finish(stream, self.inner, true).await
     }

--- a/rs/qmux/src/uds.rs
+++ b/rs/qmux/src/uds.rs
@@ -57,6 +57,15 @@ impl Config {
         self
     }
 
+    /// Override how long establishment waits for the peer's transport
+    /// parameters before failing with [`Error::HandshakeTimeout`]. Defaults to
+    /// 10s; a zero duration waits indefinitely. See
+    /// [`Config::handshake_timeout`](crate::Config::handshake_timeout).
+    pub fn handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.inner.handshake_timeout = timeout;
+        self
+    }
+
     /// Connect to the socket at `path` and start a client session.
     pub async fn connect(self, path: impl AsRef<Path>) -> Result<Session, Error> {
         let stream = UnixStream::connect(path).await?;
@@ -75,8 +84,9 @@ async fn finish(
     is_server: bool,
 ) -> Result<Session, Error> {
     let session = build_stream_session(stream, config, is_server)?;
-    // Resolve the protocol before returning (instant unless negotiating). The
-    // peer's path, if any, is awaited lazily by the caller via `Session::path`.
-    session.negotiated().await;
+    // Await the peer's transport parameters before returning, so `protocol()` and
+    // `path()` are resolved on the session we hand back. Bounded by the config's
+    // handshake timeout.
+    session.established().await?;
     Ok(session)
 }

--- a/rs/qmux/src/uds.rs
+++ b/rs/qmux/src/uds.rs
@@ -83,10 +83,8 @@ async fn finish(
     config: crate::Config,
     is_server: bool,
 ) -> Result<Session, Error> {
-    let session = build_stream_session(stream, config, is_server)?;
-    // Await the peer's transport parameters before returning, so `protocol()` and
-    // `path()` are resolved on the session we hand back. Bounded by the config's
-    // handshake timeout.
-    session.established().await?;
-    Ok(session)
+    // `build_stream_session` awaits the peer's transport parameters before
+    // returning, so `protocol()` and `path()` are resolved on the session we hand
+    // back (bounded by the config's handshake timeout).
+    build_stream_session(stream, config, is_server).await
 }

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -83,15 +83,29 @@ where
     }
 
     /// Wrap as a client-side session.
+    ///
+    /// The protocol is already known from the negotiated subprotocol (ALPN), so
+    /// this returns synchronously without awaiting in-band parameters.
     pub fn connect(self) -> Session {
         let (version, protocol) = alpn::parse(self.alpn.as_deref());
-        Session::connect(self.into_transport(), Config::negotiated(version, protocol))
+        Session::new(
+            self.into_transport(),
+            false,
+            Config::negotiated(version, protocol),
+        )
     }
 
     /// Wrap as a server-side session.
+    ///
+    /// As with [`connect`](Self::connect), the protocol is known from the
+    /// negotiated subprotocol, so this returns synchronously.
     pub fn accept(self) -> Session {
         let (version, protocol) = alpn::parse(self.alpn.as_deref());
-        Session::accept(self.into_transport(), Config::negotiated(version, protocol))
+        Session::new(
+            self.into_transport(),
+            true,
+            Config::negotiated(version, protocol),
+        )
     }
 
     fn into_transport(self) -> WsTransport<T> {
@@ -241,8 +255,10 @@ impl Client {
             Some(ka) => WsTransport::new(ws_stream).with_keep_alive(ka),
             None => WsTransport::new(ws_stream),
         };
-        Ok(Session::connect(
+        // Protocol came from the negotiated subprotocol, so no in-band wait.
+        Ok(Session::new(
             transport,
+            false,
             Config::negotiated(version, protocol),
         ))
     }
@@ -396,8 +412,10 @@ impl Server {
             Some(ka) => WsTransport::new(ws).with_keep_alive(ka),
             None => WsTransport::new(ws),
         };
-        Ok(Session::accept(
+        // Protocol came from the negotiated subprotocol, so no in-band wait.
+        Ok(Session::new(
             transport,
+            true,
             Config::negotiated(version, protocol),
         ))
     }

--- a/rs/qmux/tests/negotiation.rs
+++ b/rs/qmux/tests/negotiation.rs
@@ -98,11 +98,12 @@ mod tcp {
 
         let server = tokio::spawn(async move {
             let (sock, _) = listener.accept().await.unwrap();
-            let session = qmux::tcp::Config::new(Version::QMux01)
-                .accept(sock)
-                .await
-                .unwrap();
-            session.closed().await
+            // The client's unexpected `application_protocols` param fails the
+            // handshake, so establishment (awaited inside `accept`) returns it.
+            match qmux::tcp::Config::new(Version::QMux01).accept(sock).await {
+                Err(e) => e,
+                Ok(_) => panic!("expected establishment to fail"),
+            }
         });
 
         // Keep the client alive so its parameters actually reach the server.
@@ -128,9 +129,9 @@ mod tcp {
                 .accept(sock)
                 .await
                 .unwrap();
-            // Await the client's params to read the path it advertised. Own it
-            // so the borrow doesn't escape this task.
-            session.path().await.map(str::to_string)
+            // `accept` already awaited the client's params, so `path()` is
+            // resolved here. Own it so the borrow doesn't escape this task.
+            session.path().map(str::to_string)
         });
 
         let client = qmux::tcp::Config::new(Version::QMux01)
@@ -142,7 +143,7 @@ mod tcp {
 
         assert_eq!(server_saw.as_deref(), Some("/broadcast/room-42"));
         // The server set no path of its own, so the client sees none.
-        assert_eq!(client.path().await, None);
+        assert_eq!(client.path(), None);
     }
 
     /// Path and protocol negotiation are independent and can be used together.
@@ -160,7 +161,7 @@ mod tcp {
                 .unwrap();
             (
                 session.protocol().map(str::to_string),
-                session.path().await.map(str::to_string),
+                session.path().map(str::to_string),
             )
         });
 
@@ -189,7 +190,7 @@ mod tcp {
                 .accept(sock)
                 .await
                 .unwrap();
-            session.path().await.map(str::to_string)
+            session.path().map(str::to_string)
         });
 
         let client = qmux::tcp::Config::new(Version::QMux01)
@@ -199,7 +200,36 @@ mod tcp {
         let server_saw = server.await.unwrap();
 
         assert_eq!(server_saw, None);
-        assert_eq!(client.path().await, None);
+        assert_eq!(client.path(), None);
+    }
+
+    /// A peer that completes the TCP handshake but never sends its transport
+    /// parameters fails establishment with `HandshakeTimeout` instead of hanging.
+    #[tokio::test]
+    async fn handshake_timeout_fires() {
+        use std::time::Duration;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Accept the connection but never speak QMux, holding the socket open so
+        // the client can't short-circuit on an EOF — it must hit the timeout.
+        let server = tokio::spawn(async move {
+            let (_sock, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let result = qmux::tcp::Config::new(Version::QMux01)
+            .handshake_timeout(Duration::from_millis(100))
+            .connect(addr)
+            .await;
+
+        match result {
+            Err(Error::HandshakeTimeout) => {}
+            Err(other) => panic!("expected HandshakeTimeout, got {other:?}"),
+            Ok(_) => panic!("expected HandshakeTimeout, got an established session"),
+        }
+        server.abort();
     }
 
     /// Advertised protocol names are validated before the session starts.

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -39,7 +39,7 @@ impl Transport for ThrottledTransport {
 }
 
 /// Build a connected client/server session pair over throttled in-memory pipes.
-fn pair(delay: Duration) -> (Session, Session) {
+async fn pair(delay: Duration) -> (Session, Session) {
     let (c2s_tx, c2s_rx) = mpsc::channel(64);
     let (s2c_tx, s2c_rx) = mpsc::channel(64);
 
@@ -55,9 +55,13 @@ fn pair(delay: Duration) -> (Session, Session) {
     };
 
     let config = Config::new(Version::QMux01);
-    let client = Session::connect(client_transport, config.clone());
-    let server = Session::accept(server_transport, config);
-    (client, server)
+    // `connect`/`accept` await establishment, so drive both ends concurrently —
+    // each side's handshake needs the other's transport parameters.
+    let (client, server) = tokio::join!(
+        Session::connect(client_transport, config.clone()),
+        Session::accept(server_transport, config),
+    );
+    (client.unwrap(), server.unwrap())
 }
 
 /// Higher-priority stream data jumps ahead of a low-priority backlog.
@@ -68,7 +72,7 @@ fn pair(delay: Duration) -> (Session, Session) {
 /// trickling through.
 #[tokio::test]
 async fn higher_priority_completes_first() {
-    let (client, server) = pair(Duration::from_millis(5));
+    let (client, server) = pair(Duration::from_millis(5)).await;
 
     const LO_LEN: usize = 200 * 1024;
     const HI_LEN: usize = 4 * 1024;
@@ -136,7 +140,7 @@ async fn higher_priority_completes_first() {
 /// fully before the other starts.
 #[tokio::test]
 async fn equal_priority_interleaves() {
-    let (client, server) = pair(Duration::from_millis(2));
+    let (client, server) = pair(Duration::from_millis(2)).await;
 
     const LEN: usize = 128 * 1024;
 
@@ -196,7 +200,7 @@ async fn equal_priority_interleaves() {
 /// large data backlog queued on another stream.
 #[tokio::test]
 async fn control_precedes_data_backlog() {
-    let (client, server) = pair(Duration::from_millis(5));
+    let (client, server) = pair(Duration::from_millis(5)).await;
 
     const LO_LEN: usize = 200 * 1024;
 
@@ -240,7 +244,7 @@ async fn control_precedes_data_backlog() {
 /// the receiver reassembles exactly what was written, in order.
 #[tokio::test]
 async fn mid_stream_set_priority_preserves_order() {
-    let (client, server) = pair(Duration::from_millis(2));
+    let (client, server) = pair(Duration::from_millis(2)).await;
 
     // A distinctive, position-encoded payload so any reorder/loss is detectable.
     let payload: Vec<u8> = (0..200 * 1024).map(|i| (i % 251) as u8).collect();
@@ -289,7 +293,7 @@ async fn mid_stream_set_priority_preserves_order() {
 #[tokio::test]
 async fn teardown_unblocks_blocked_writer() {
     // Long delay so the queue stays full and `write` blocks.
-    let (client, server) = pair(Duration::from_millis(500));
+    let (client, server) = pair(Duration::from_millis(500)).await;
 
     let mut s = client.open_uni().await.unwrap();
 

--- a/rs/qmux/tests/qmux01.rs
+++ b/rs/qmux/tests/qmux01.rs
@@ -41,7 +41,9 @@ async fn wire_format_size_prefix_qmux01_only() {
             buf
         });
         // The session sends TRANSPORT_PARAMETERS as its first frame on connect.
-        let _client = qmux::tcp::Config::new(version).connect(addr).await.unwrap();
+        // We only need that first frame on the wire; this bare server never sends
+        // its own params back, so establishment fails (EOF) — ignore the result.
+        let _ = qmux::tcp::Config::new(version).connect(addr).await;
         server.await.unwrap()
     }
 


### PR DESCRIPTION
Follow-up to #263. Makes `Session::protocol()` and `Session::path()` plain **synchronous** getters by waiting for the peer's transport parameters (its "settings") during establishment — so by the time you hold a `Session`, both are resolved. Also hardens the public API surface so future additions stay non-breaking (flagged by cargo-semver-checks).

## Why

qmux was the odd backend out: for quinn/quiche/wasm the TLS handshake completes *before* you ever get a `Session`, so `protocol()` (ALPN) is already known synchronously. qmux's settings arrive as the first frame *after* the byte stream is up, which is why `protocol()` could transiently be `None` and why `path()`/`negotiated()` had to be async. Awaiting those settings during establishment removes that quirk and the async-getter footgun.

## What changed

### Establishment / sync getters
- **`Session::connect`/`accept` are now `async fn -> Result<Session, Error>`** and wait for the peer's `TRANSPORT_PARAMETERS` before returning. A `Session` you hold is always established. No `Connecting`-style handle: qmux flow control starts every stream credit at zero, so nothing useful can happen before the peer's params arrive anyway.
- **Handshake timeout**: new **`Config::handshake_timeout`** (default 10s; `0` = wait forever). A peer that completes the transport handshake but never sends params fails with **`Error::HandshakeTimeout`** instead of hanging; a mid-handshake disconnect returns the close reason. `tcp`/`uds` builders gained `handshake_timeout(..)` setters.
- **Getters are sync**: `protocol()` stays the sync trait getter; `path()` becomes a sync getter returning `Option<&str>`. The async `negotiated()` and async `path()` are **removed**.
- **`Session::new`** is now `pub(crate)` — the non-awaiting constructor for callers that resolve their protocol out of band. WebSocket uses it (protocol from the subprotocol), so **WS behavior is unchanged**.

### API hardening (cargo-semver-checks)
- **`Config` and `Error` are now `#[non_exhaustive]`** — adding fields (`path`, `handshake_timeout`) / variants (`InvalidPath`) was technically breaking on the previously-exhaustive types. Future additions stay non-breaking.
- **`tls::connect`/`accept` free functions → `tls::Client`/`tls::Server` builders** (mirroring `ws::Client`/`ws::Server`). Positional params meant adding `path` changed `connect`'s arity; now per-connection inputs (addr, server_name, stream) are call args and everything else is a chained setter, so future options don't change arity.

These are intentional one-time breaks — this is the release that takes them so the surface is forward-compatible afterward.

### Before / after

```rust
// before
let session = qmux::tcp::Config::new(v).connect(addr).await?;
let proto = session.negotiated().await;   // async
let path  = session.path().await;          // async

// after — connect() already waited for settings
let session = qmux::tcp::Config::new(v).connect(addr).await?;
let proto = session.protocol();            // sync, resolved
let path  = session.path();                // sync, resolved

// tls
let session = qmux::tls::Client::new(rustls_config)
    .with_protocol("moq-lite-04", &[Version::QMux01])
    .path("/live")
    .connect(addr, "example.com").await?;
```

## Testing

- New test `handshake_timeout_fires` — a half-open peer fails with `HandshakeTimeout` (not a hang).
- Updated `unexpected_protocols_is_fatal`: the unexpected `application_protocols` param surfaces as an establishment error from `accept`.
- Updated path tests for sync `path()`; `priority`'s `pair()` drives both ends with `join!`.
- `cargo test -p qmux --all-features` green; clippy/doc/fmt clean; builds across every transport feature combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)