### PR TITLE
feat(qmux): remove the in-band path transport parameter

### DIFF
--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -75,40 +75,6 @@ describe("QMux01 record framing", () => {
 		expect(() => Frame.decode(record, "qmux-00")).toThrow();
 	});
 
-	test("path parameter is rejected (WebSocket carries the path in its URL)", () => {
-		// A QX_TRANSPORT_PARAMETERS frame carrying only the `path` parameter
-		// (id 0x2b9a4c1f6e3d8052, value "/x"). WebSocket addresses the resource
-		// via its URL, so this parameter must never appear and decoding must throw.
-		const bytes = (...vals: number[]) => new Uint8Array(vals);
-		const record = bytes(
-			// frame type 0x3f5153300d0a0d0a — the "\xffQS0\r\n\r\n" magic.
-			0xff,
-			0x51,
-			0x53,
-			0x30,
-			0x0d,
-			0x0a,
-			0x0d,
-			0x0a,
-			// length = 11 (param id 8 bytes + len 1 byte + value 2 bytes)
-			0x0b,
-			// param id 0x2b9a4c1f6e3d8052 — 8-byte varint, first wire byte 0xeb.
-			0xeb,
-			0x9a,
-			0x4c,
-			0x1f,
-			0x6e,
-			0x3d,
-			0x80,
-			0x52,
-			// param length = 2, value = "/x"
-			0x02,
-			0x2f,
-			0x78,
-		);
-		expect(() => Frame.decode(record, "qmux-00")).toThrow();
-	});
-
 	test("ping_request and ping_response round-trip preserves the sequence number", () => {
 		const req: Frame.Any = { type: "ping_request", sequence: 0xdeadbeefn };
 		const reqBytes = Frame.encode(req, "qmux-01");

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -176,11 +176,6 @@ const MAX_RECORD_SIZE_ID = 0x0571c59429cd0845n;
 // This implementation only runs over WebSocket, which negotiates the protocol
 // via its subprotocol (ALPN), so receiving this parameter is a protocol error.
 const APPLICATION_PROTOCOLS_ID = 0x3d4f9c2a8b1e6075n;
-// path transport parameter ID (QMux-specific). Carries the requested resource
-// path on transports without a request line of their own (TCP, TLS, Unix
-// sockets). This implementation only runs over WebSocket, which carries the
-// path in its URL, so receiving this parameter is a protocol error.
-const PATH_ID = 0x2b9a4c1f6e3d8052n;
 
 function encodeWebTransport(frame: Any): Uint8Array {
 	switch (frame.type) {
@@ -429,12 +424,6 @@ function decodeTransportParams(buffer: Uint8Array): TransportParams {
 		// negotiates via its subprotocol, so the parameter must never appear.
 		if (id === APPLICATION_PROTOCOLS_ID) {
 			throw new Error("unexpected application_protocols parameter over WebSocket");
-		}
-
-		// WebSocket carries the path in its URL, so the in-band `path` parameter
-		// (used by TCP/TLS/Unix-socket peers) must never appear here.
-		if (id === PATH_ID) {
-			throw new Error("unexpected path parameter over WebSocket");
 		}
 
 		if (paramData.byteLength < 1) {

--- a/rs/qmux/CHANGELOG.md
+++ b/rs/qmux/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0](https://github.com/moq-dev/web-transport/compare/qmux-v0.2.0...qmux-v0.3.0) - 2026-06-24
+## [0.3.1](https://github.com/moq-dev/web-transport/compare/qmux-v0.2.0...qmux-v0.3.1) - 2026-06-25
 
 ### Added
 
-- *(qmux)* resolve protocol/path during establishment; sync getters ([#265](https://github.com/moq-dev/web-transport/pull/265))
-- *(qmux)* optional in-band path for TCP, TLS, and Unix sockets ([#263](https://github.com/moq-dev/web-transport/pull/263))
+- *(qmux)* resolve the application protocol during establishment so `Session::protocol` is a synchronous getter; fold establishment into async `connect`/`accept` and add `Config::handshake_timeout` ([#265](https://github.com/moq-dev/web-transport/pull/265))
+- *(qmux)* mark `Config`, `Error`, and `Protocol` `#[non_exhaustive]`; replace the `tls` free functions with `tls::Client`/`tls::Server` builders ([#265](https://github.com/moq-dev/web-transport/pull/265))
 
 ## [0.2.0](https://github.com/moq-dev/web-transport/compare/qmux-v0.1.3...qmux-v0.2.0) - 2026-06-19
 

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -42,14 +42,6 @@ pub struct Config {
     /// How the application protocol is determined. See [`Protocol`].
     pub protocol: Protocol,
 
-    /// Requested resource path, sent in-band for transports without a URL of
-    /// their own (TCP, TLS, Unix sockets). `None` omits it from the wire.
-    ///
-    /// The peer's value is surfaced by [`Session::path`](crate::Session::path)
-    /// once its transport parameters arrive. WebTransport / WebSocket sessions
-    /// carry the path in the request line instead and ignore this field.
-    pub path: Option<String>,
-
     /// Max concurrent bidirectional streams the peer can open.
     pub max_streams_bidi: u64,
     /// Max concurrent unidirectional streams the peer can open.
@@ -82,7 +74,6 @@ impl Default for Config {
         Self {
             version: Version::QMux01,
             protocol: Protocol::None,
-            path: None,
             max_streams_bidi: 100,
             max_streams_uni: 100,
             max_data: 1_048_576,                  // 1 MB
@@ -135,7 +126,6 @@ impl Config {
                 Protocol::Negotiate(list) => list.clone(),
                 Protocol::None | Protocol::Negotiated(_) => Vec::new(),
             },
-            path: self.path.clone(),
         }
     }
 }

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -51,9 +51,6 @@ pub enum Error {
     #[error("invalid protocol token: {0:?}")]
     InvalidProtocol(String),
 
-    #[error("invalid path: {0:?}")]
-    InvalidPath(String),
-
     /// Peer sent the `application_protocols` transport parameter, but this
     /// session isn't negotiating in-band (e.g. it's a TLS/WebSocket session that
     /// already negotiated via ALPN, or a stream session that didn't opt in).

--- a/rs/qmux/src/proto/params.rs
+++ b/rs/qmux/src/proto/params.rs
@@ -28,15 +28,6 @@ pub struct TransportParams {
     /// the application protocol was negotiated out of band (e.g. via TLS/WS
     /// ALPN) or not negotiated at all; the parameter is then omitted entirely.
     pub protocols: Vec<String>,
-
-    /// Requested resource path, for transports without a URL of their own.
-    ///
-    /// QMux-specific (ID 0x2b9a4c1f6e3d8052). WebTransport over HTTP/3 and
-    /// WebSocket carry the path in the request line (`:path` / the WS URL);
-    /// TCP, TLS, and Unix sockets have no such field, so a client that needs to
-    /// address a specific resource sends it here. `None` (the default) omits the
-    /// parameter entirely, keeping peers that never set a path byte-identical.
-    pub path: Option<String>,
 }
 
 /// Default max_record_size per draft-01.
@@ -61,13 +52,6 @@ const _: () = assert!(
     APPLICATION_PROTOCOLS_ID < (1 << 62),
     "APPLICATION_PROTOCOLS_ID must fit in VarInt"
 );
-
-// path parameter ID (QMux-specific). Carries the requested resource path on
-// transports that lack a request line of their own (TCP, TLS, Unix sockets).
-const PATH_ID: u64 = 0x2b9a4c1f6e3d8052;
-// SAFETY: 0x2b9a4c1f6e3d8052 < 2^62 (VarInt max)
-const PATH_ID_VI: VarInt = unsafe { VarInt::from_u64_unchecked(PATH_ID) };
-const _: () = assert!(PATH_ID < (1 << 62), "PATH_ID must fit in VarInt");
 
 impl TransportParams {
     // Transport parameter IDs
@@ -138,15 +122,6 @@ impl TransportParams {
             buf.put_slice(&value);
         }
 
-        // path: a single UTF-8 string. Omitted entirely when unset so peers that
-        // don't address a resource stay byte-identical to the old format. An
-        // explicitly empty path is a distinct, valid value and is still sent.
-        if let Some(path) = &self.path {
-            PATH_ID_VI.encode(&mut buf);
-            VarInt::try_from(path.len())?.encode(&mut buf);
-            buf.put_slice(path.as_bytes());
-        }
-
         Ok(buf.freeze())
     }
 
@@ -176,18 +151,6 @@ impl TransportParams {
                         return Err(Error::DuplicateParam(id));
                     }
                     params.protocols = decode_protocols(&mut param_data)?;
-                }
-                PATH_ID => {
-                    if !seen.insert(id) {
-                        return Err(Error::DuplicateParam(id));
-                    }
-                    // The whole payload is the path; an empty payload is a valid
-                    // (empty) path, distinct from the parameter being absent.
-                    params.path = Some(
-                        std::str::from_utf8(&param_data)
-                            .map_err(|_| Error::InvalidPath(format!("{param_data:?}")))?
-                            .to_string(),
-                    );
                 }
                 0x01 | 0x04..=0x09 | MAX_RECORD_SIZE_ID => {
                     if !seen.insert(id) {
@@ -332,76 +295,6 @@ mod tests {
         assert!(matches!(
             TransportParams::decode(buf.freeze()),
             Err(Error::InvalidProtocol(_))
-        ));
-    }
-
-    #[test]
-    fn path_round_trip() {
-        let params = TransportParams {
-            initial_max_data: 1024,
-            path: Some("/broadcast/room-42".to_string()),
-            ..TransportParams::default()
-        };
-        let decoded = TransportParams::decode(params.encode().unwrap()).unwrap();
-        assert_eq!(decoded.path.as_deref(), Some("/broadcast/room-42"));
-        assert_eq!(decoded.initial_max_data, 1024);
-    }
-
-    // The PATH_ID as it appears on the wire: an 8-byte varint with the top two
-    // bits set (0b11), i.e. PATH_ID | 0xc000_0000_0000_0000.
-    const PATH_ID_WIRE: [u8; 8] = (PATH_ID | (0b11 << 62)).to_be_bytes();
-
-    #[test]
-    fn path_omitted_when_none() {
-        // No path param on the wire when unset, so a peer that never addresses a
-        // resource stays byte-identical to the old format.
-        let bytes = TransportParams::default().encode().unwrap();
-        assert!(!bytes.windows(8).any(|w| w == PATH_ID_WIRE));
-        assert!(TransportParams::decode(bytes).unwrap().path.is_none());
-    }
-
-    #[test]
-    fn empty_path_round_trips_as_some() {
-        // An explicitly empty path is distinct from an absent one: the parameter
-        // is present on the wire and decodes back to `Some("")`.
-        let params = TransportParams {
-            path: Some(String::new()),
-            ..TransportParams::default()
-        };
-        let bytes = params.encode().unwrap();
-        assert!(bytes.windows(8).any(|w| w == PATH_ID_WIRE));
-        assert_eq!(
-            TransportParams::decode(bytes).unwrap().path.as_deref(),
-            Some("")
-        );
-    }
-
-    #[test]
-    fn duplicate_path_param_rejected() {
-        let one = TransportParams {
-            path: Some("/a".to_string()),
-            ..TransportParams::default()
-        }
-        .encode()
-        .unwrap();
-        let mut doubled = BytesMut::from(&one[..]);
-        doubled.extend_from_slice(&one);
-        assert!(matches!(
-            TransportParams::decode(doubled.freeze()),
-            Err(Error::DuplicateParam(PATH_ID))
-        ));
-    }
-
-    #[test]
-    fn invalid_utf8_path_rejected() {
-        // id=PATH_ID, len=1, value=[0xff]
-        let mut buf = BytesMut::new();
-        PATH_ID_VI.encode(&mut buf);
-        VarInt::from_u32(1).encode(&mut buf);
-        buf.put_u8(0xff);
-        assert!(matches!(
-            TransportParams::decode(buf.freeze()),
-            Err(Error::InvalidPath(_))
         ));
     }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -34,15 +34,13 @@ pub struct Session {
     closed: watch::Sender<Option<Error>>,
 
     // Negotiated application protocol (via the application_protocols transport
-    // parameter) and the path the peer advertised (via the `path` parameter).
-    // Both are resolved exactly once, before the session is handed to the caller
-    // (see `established()`), so `protocol()` / `path()` are plain synchronous
-    // getters. `None` inside an OnceLock means "no value"; unset means the peer's
+    // parameter). Resolved exactly once, before the session is handed to the
+    // caller (see `established()`), so `protocol()` is a plain synchronous
+    // getter. `None` inside the OnceLock means "no value"; unset means the peer's
     // params haven't arrived yet (only observable on a session you constructed
-    // without awaiting `established()`). OnceLocks give the resolved values a
-    // stable address so the getters can hand out `&str` borrows.
+    // without awaiting `established()`). The OnceLock gives the resolved value a
+    // stable address so the getter can hand out a `&str` borrow.
     negotiated: Arc<OnceLock<Option<String>>>,
-    peer_path: Arc<OnceLock<Option<String>>>,
 
     // Flips to `true` once the peer's transport parameters have been received and
     // applied (or eagerly for the param-less `webtransport` format). `established()`
@@ -79,10 +77,9 @@ struct SessionState<T: Transport> {
 
     closed: watch::Sender<Option<Error>>,
 
-    // Negotiated protocol, peer path, and handshake-complete signal — see the
-    // matching fields on `Session`.
+    // Negotiated protocol and handshake-complete signal — see the matching
+    // fields on `Session`.
     negotiated: Arc<OnceLock<Option<String>>>,
-    peer_path: Arc<OnceLock<Option<String>>>,
     established: watch::Sender<bool>,
 
     // Flow control state
@@ -511,10 +508,6 @@ impl<T: Transport> SessionState<T> {
             }
         }
 
-        // Surface the peer's path (if any). Unlike protocols this isn't gated on
-        // opt-in: it's optional routing metadata, so an absent param is just None.
-        self.peer_path.set(params.path.clone()).ok();
-
         // Set connection-level send credit from peer's initial_max_data
         self.conn_send_credit
             .increase_max(params.initial_max_data)
@@ -549,8 +542,8 @@ impl<T: Transport> SessionState<T> {
 
         self.peer_params = params;
 
-        // Handshake complete: `negotiated` and `peer_path` are now set, so unblock
-        // `established()` and let the synchronous getters return their final values.
+        // Handshake complete: `negotiated` is now set, so unblock `established()`
+        // and let the synchronous getter return its final value.
         self.established.send_replace(true);
 
         Ok(())
@@ -562,10 +555,9 @@ impl Session {
     /// established before returning.
     ///
     /// "Established" means the peer's transport parameters have been received and
-    /// applied, so [`protocol`](web_transport_trait::Session::protocol) and
-    /// [`path`](Session::path) return their final values. The legacy
-    /// `webtransport` wire format exchanges no parameters, so it is established
-    /// immediately.
+    /// applied, so [`protocol`](web_transport_trait::Session::protocol) returns
+    /// its final value. The legacy `webtransport` wire format exchanges no
+    /// parameters, so it is established immediately.
     ///
     /// Bounded by [`Config::handshake_timeout`](crate::Config::handshake_timeout):
     /// if the peer completes the transport handshake but never sends its
@@ -624,17 +616,6 @@ impl Session {
         }
     }
 
-    /// The path the peer advertised via the `path` transport parameter.
-    ///
-    /// For a server this is the resource path the client requested; for a client
-    /// it's whatever the server advertised (usually `None`). Mirrors
-    /// [`protocol`](web_transport_trait::Session::protocol): a synchronous getter
-    /// that returns the resolved value, since [`connect`](Session::connect) /
-    /// [`accept`](Session::accept) only return once the handshake has completed.
-    pub fn path(&self) -> Option<&str> {
-        self.peer_path.get().and_then(|p| p.as_deref())
-    }
-
     /// Construct a session over the transport and start its run loop, without
     /// waiting for the handshake. The public entry points are the async
     /// [`connect`](Session::connect) / [`accept`](Session::accept), which await
@@ -668,16 +649,10 @@ impl Session {
             }
         }
 
-        // Peer path. Resolved once the peer's transport parameters arrive.
-        let peer_path: Arc<OnceLock<Option<String>>> = Arc::new(OnceLock::new());
-
         // Handshake-complete signal. QMux versions flip it once the peer's params
         // arrive; the legacy `webtransport` format exchanges none, so it (and the
-        // resolved getters) are established eagerly.
+        // resolved getter) are established eagerly.
         let (established_tx, established_rx) = watch::channel(!version.is_qmux());
-        if !version.is_qmux() {
-            peer_path.set(None).ok();
-        }
 
         let open_bi_credit = Credit::new(if version.is_qmux() { 0 } else { u64::MAX });
         let open_uni_credit = Credit::new(if version.is_qmux() { 0 } else { u64::MAX });
@@ -716,7 +691,6 @@ impl Session {
             recv_streams: HashMap::new(),
             closed: closed.clone(),
             negotiated: negotiated.clone(),
-            peer_path: peer_path.clone(),
             established: established_tx,
             conn_send_credit: conn_send_credit.clone(),
             conn_recv_credit: conn_recv_credit.clone(),
@@ -735,8 +709,8 @@ impl Session {
             let err = backend.run().await.err().unwrap_or(Error::Closed);
             // Dropping `backend` drops the `established` sender; an `established()`
             // waiter that was still pending then observes the channel close and
-            // reports this terminal error. The OnceLocks stay unset, so the
-            // synchronous getters report `None` on a never-established session.
+            // reports this terminal error. The OnceLock stays unset, so the
+            // synchronous getter reports `None` on a never-established session.
             // Close all credits so blocked claim()/claim_index() calls unblock
             backend.open_bi_credit.close();
             backend.open_uni_credit.close();
@@ -751,7 +725,7 @@ impl Session {
             // `send_replace`, not `send`: the latter drops the value when there
             // are no receivers, which loses the close reason for any `closed()`
             // call made after the session has already finished closing (e.g. after
-            // awaiting `path()` on a peer that closed without sending params).
+            // awaiting establishment on a peer that closed without sending params).
             // Storing it unconditionally keeps late waiters correct.
             backend.closed.send_replace(Some(err));
         });
@@ -767,7 +741,6 @@ impl Session {
             create_bi: create_bi_tx,
             closed,
             negotiated,
-            peer_path,
             established: established_rx,
             open_bi_credit,
             open_uni_credit,

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -49,16 +49,6 @@ impl Config {
         self
     }
 
-    /// Advertise a requested resource `path`.
-    ///
-    /// TCP has no URL, so a client that needs to address a specific resource
-    /// sends the path in-band. The peer reads it via
-    /// [`Session::path`](crate::Session::path). Omit to send no path.
-    pub fn path(mut self, path: impl Into<String>) -> Self {
-        self.inner.path = Some(path.into());
-        self
-    }
-
     /// Override how long establishment waits for the peer's transport
     /// parameters before failing with [`Error::HandshakeTimeout`]. Defaults to
     /// 10s; a zero duration waits indefinitely. See
@@ -71,9 +61,9 @@ impl Config {
     /// Connect to `addr` and start a client session.
     ///
     /// Awaits the peer's transport parameters before returning, so
-    /// [`Session::protocol`](web_transport_trait::Session::protocol) and
-    /// [`Session::path`](crate::Session::path) are populated on the returned
-    /// session (bounded by [`handshake_timeout`](Self::handshake_timeout)).
+    /// [`Session::protocol`](web_transport_trait::Session::protocol) is populated
+    /// on the returned session (bounded by
+    /// [`handshake_timeout`](Self::handshake_timeout)).
     pub async fn connect(self, addr: impl ToSocketAddrs) -> Result<Session, Error> {
         let stream = TcpStream::connect(addr).await?;
         finish(stream, self.inner, false).await
@@ -96,7 +86,7 @@ async fn finish(
     is_server: bool,
 ) -> Result<Session, Error> {
     // `build_stream_session` awaits the peer's transport parameters before
-    // returning, so `protocol()` and `path()` are resolved on the session we hand
-    // back (bounded by the config's handshake timeout).
+    // returning, so `protocol()` is resolved on the session we hand back
+    // (bounded by the config's handshake timeout).
     build_stream_session(stream, config, is_server).await
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -20,7 +20,6 @@ pub struct Client {
     config: Arc<rustls::ClientConfig>,
     protocols: Vec<(String, Vec<Version>)>,
     require_protocol: bool,
-    path: Option<String>,
 }
 
 impl Client {
@@ -30,7 +29,6 @@ impl Client {
             config,
             protocols: Vec::new(),
             require_protocol: false,
-            path: None,
         }
     }
 
@@ -60,16 +58,6 @@ impl Client {
     /// version ALPNs (`qmux-01`, `qmux-00`, `webtransport`) offered by default.
     pub fn require_protocol(mut self) -> Self {
         self.require_protocol = true;
-        self
-    }
-
-    /// Advertise a requested resource `path`.
-    ///
-    /// TLS has no request line of its own, so when set the path is sent in-band
-    /// via the QMux `path` transport parameter; the server reads it via
-    /// [`Session::path`]. Omit to send no path.
-    pub fn path(mut self, path: impl Into<String>) -> Self {
-        self.path = Some(path.into());
         self
     }
 
@@ -116,10 +104,9 @@ impl Client {
             ));
         }
 
-        let mut session_config = Config::negotiated(version, protocol);
-        session_config.path = self.path.clone();
+        let session_config = Config::negotiated(version, protocol);
         let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-        // `connect` awaits the peer's transport parameters so `path()` is resolved.
+        // `connect` awaits the peer's transport parameters so `protocol()` is resolved.
         Session::connect(transport, session_config).await
     }
 }
@@ -162,7 +149,7 @@ impl Server {
 
         let session_config = Config::negotiated(version, protocol);
         let transport = Stream::new(tls_stream, version, session_config.max_record_size);
-        // `accept` awaits the peer's transport parameters so `path()` is resolved.
+        // `accept` awaits the peer's transport parameters so `protocol()` is resolved.
         Session::accept(transport, session_config).await
     }
 }

--- a/rs/qmux/src/uds.rs
+++ b/rs/qmux/src/uds.rs
@@ -47,16 +47,6 @@ impl Config {
         self
     }
 
-    /// Advertise a requested resource `path`.
-    ///
-    /// A Unix socket has no URL, so a client that needs to address a specific
-    /// resource sends the path in-band. The peer reads it via
-    /// [`Session::path`](crate::Session::path). Omit to send no path.
-    pub fn path(mut self, path: impl Into<String>) -> Self {
-        self.inner.path = Some(path.into());
-        self
-    }
-
     /// Override how long establishment waits for the peer's transport
     /// parameters before failing with [`Error::HandshakeTimeout`]. Defaults to
     /// 10s; a zero duration waits indefinitely. See
@@ -89,7 +79,7 @@ async fn finish(
     is_server: bool,
 ) -> Result<Session, Error> {
     // `build_stream_session` awaits the peer's transport parameters before
-    // returning, so `protocol()` and `path()` are resolved on the session we hand
-    // back (bounded by the config's handshake timeout).
+    // returning, so `protocol()` is resolved on the session we hand back
+    // (bounded by the config's handshake timeout).
     build_stream_session(stream, config, is_server).await
 }

--- a/rs/qmux/tests/negotiation.rs
+++ b/rs/qmux/tests/negotiation.rs
@@ -1,5 +1,5 @@
-//! In-band application-protocol negotiation and resource paths over byte-stream
-//! transports (the `application_protocols` and `path` QMux transport parameters).
+//! In-band application-protocol negotiation over byte-stream transports
+//! (the `application_protocols` QMux transport parameter).
 
 #![cfg(any(feature = "tcp", feature = "uds"))]
 
@@ -115,92 +115,6 @@ mod tcp {
         let err = server.await.unwrap();
 
         assert!(matches!(err, Error::UnexpectedProtocols), "got {err:?}");
-    }
-
-    /// The client's in-band `path` reaches the server, readable right after accept.
-    #[tokio::test]
-    async fn path_reaches_server() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let server = tokio::spawn(async move {
-            let (sock, _) = listener.accept().await.unwrap();
-            let session = qmux::tcp::Config::new(Version::QMux01)
-                .accept(sock)
-                .await
-                .unwrap();
-            // `accept` already awaited the client's params, so `path()` is
-            // resolved here. Own it so the borrow doesn't escape this task.
-            session.path().map(str::to_string)
-        });
-
-        let client = qmux::tcp::Config::new(Version::QMux01)
-            .path("/broadcast/room-42")
-            .connect(addr)
-            .await
-            .unwrap();
-        let server_saw = server.await.unwrap();
-
-        assert_eq!(server_saw.as_deref(), Some("/broadcast/room-42"));
-        // The server set no path of its own, so the client sees none.
-        assert_eq!(client.path(), None);
-    }
-
-    /// Path and protocol negotiation are independent and can be used together.
-    #[tokio::test]
-    async fn path_alongside_protocol() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let server = tokio::spawn(async move {
-            let (sock, _) = listener.accept().await.unwrap();
-            let session = qmux::tcp::Config::new(Version::QMux01)
-                .protocols(["moq-lite-04"])
-                .accept(sock)
-                .await
-                .unwrap();
-            (
-                session.protocol().map(str::to_string),
-                session.path().map(str::to_string),
-            )
-        });
-
-        let client = qmux::tcp::Config::new(Version::QMux01)
-            .protocols(["moq-lite-04"])
-            .path("/live")
-            .connect(addr)
-            .await
-            .unwrap();
-        let (server_protocol, server_path) = server.await.unwrap();
-
-        assert_eq!(server_protocol.as_deref(), Some("moq-lite-04"));
-        assert_eq!(server_path.as_deref(), Some("/live"));
-        assert_eq!(client.protocol(), Some("moq-lite-04"));
-    }
-
-    /// No path on either side resolves to `None`, no parameter on the wire.
-    #[tokio::test]
-    async fn without_path_resolves_to_none() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let server = tokio::spawn(async move {
-            let (sock, _) = listener.accept().await.unwrap();
-            let session = qmux::tcp::Config::new(Version::QMux01)
-                .accept(sock)
-                .await
-                .unwrap();
-            session.path().map(str::to_string)
-        });
-
-        let client = qmux::tcp::Config::new(Version::QMux01)
-            .connect(addr)
-            .await
-            .unwrap();
-        let server_saw = server.await.unwrap();
-
-        assert_eq!(server_saw, None);
-        assert_eq!(client.path(), None);
     }
 
     /// A peer that completes the TCP handshake but never sends its transport


### PR DESCRIPTION
## Summary

Removes the optional in-band `path` feature that was recently added to qmux (#263, #265), while **keeping the rest of those changes**.

The `path` parameter let TCP/TLS/Unix-socket clients send a requested resource path in-band via a QMux-specific transport parameter (ID `0x2b9a4c1f6e3d8052`), since those byte-stream transports have no request line of their own. This PR backs that out.

### Removed
- **proto** (`params.rs`): the `path` transport parameter — struct field, its `PATH_ID` constants, encode/decode logic, and the path-specific tests (round-trip, omitted-when-none, empty-path, duplicate, invalid-utf8).
- **config**: `Config::path` and its threading into the wire transport params.
- **error**: the `Error::InvalidPath` variant.
- **session**: `Session::path()` and the `peer_path` `OnceLock` plumbing (struct fields, resolution, constructor wiring).
- **tcp / uds / tls**: the `.path(..)` builder methods and their doc references.
- **js/qmux** (`frame.ts`): the WebSocket-side rejection of the `path` parameter, plus its test.

### Kept (from the same PRs)
- Synchronous `protocol()` / getters resolved during establishment.
- `Config::handshake_timeout` + `Error::HandshakeTimeout`.
- `#[non_exhaustive]` on `Config`, `Error`, and `Protocol`.
- The `tls::Client` / `tls::Server` builders.
- The `send_replace` close-reason fix.

## Testing
- `cargo test -p qmux --all-features` — all pass.
- `cargo clippy -p qmux --all-features` + `cargo fmt` — clean.
- `bun test src/frame.test.ts` (js/qmux) — pass; biome clean.

(The 2 failing JS tests in `session.test.ts` / `subprotocol.test.ts` are a pre-existing missing-workspace-dependency error, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyCmCdxj3AeeofGo42XEYx)_