### PR TITLE
ci(release-js): publish @moq/web-socket-stream

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "js/**"
       - "rs/web-transport-node/**"
+  # Allow re-running the release jobs on demand (e.g. to publish a package that
+  # was added but never released). The release scripts skip already-published
+  # versions, so a manual run is safe to repeat.
+  workflow_dispatch:
 
 concurrency:
   group: release-js
@@ -79,6 +83,12 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: nix develop --command bun install
+
+      # Publish dependencies before dependents: qmux depends on web-socket-stream,
+      # so the latter must already be on npm for qmux's published range to resolve.
+      - name: Release @moq/web-socket-stream
+        working-directory: js/web-socket-stream
+        run: nix develop --command bun run release
 
       - name: Release @moq/qmux
         working-directory: js/qmux


### PR DESCRIPTION
## Summary

The `release-pure-ts` job in `release-js.yml` published `@moq/qmux` but **never** published its only dependency, `@moq/web-socket-stream`.

qmux's build (`common/package.ts`) correctly rewrites the `workspace:*` dependency to a published range (`^0.1.0`), so every published qmux declares a real dependency on `@moq/web-socket-stream`. But that package was never pushed to npm, so:

```
$ npm view @moq/web-socket-stream version
npm error 404 Not Found - GET .../@moq%2fweb-socket-stream

$ npm view @moq/qmux@0.1.3 dependencies
{ '@moq/web-socket-stream': '^0.1.0' }   # 404s on install
```

Installing `@moq/qmux@0.1.2+` from the public registry fails to resolve, which is why downstreams (e.g. `moq`'s `js/net`) are pinned to the older, dependency-free `0.0.6` — and `0.0.6` is missing the `ready`-rejection fix that landed in 0.1.2, so a refused WebSocket connection hangs forever there instead of failing fast.

## Changes

- **Publish `@moq/web-socket-stream` before `@moq/qmux`.** A dependency must be on npm before its dependent's published range can resolve, so the new release step runs first.
- **Add a `workflow_dispatch` trigger.** This bootstraps the first publish on demand (the `push` trigger only fires on `js/**` changes, and this PR touches only `.github/`). The release scripts skip already-published versions, so manual re-runs are safe and idempotent.

No qmux source change is needed: `session.ts` on `main` already rejects `ready` on a failed connection.

## How to land

1. Merge this PR.
2. Run the **release-js** workflow via *Run workflow* (`workflow_dispatch`). It publishes `@moq/web-socket-stream@0.1.0`, then skips `@moq/qmux@0.1.3` (already published).
3. Once `@moq/web-socket-stream@0.1.0` is on npm, `@moq/qmux@0.1.2/0.1.3` become installable. Downstream `moq` can then bump `@moq/qmux` and drop its local hang workaround ([moq-dev/moq#1957](https://github.com/moq-dev/moq/pull/1957)).

## Test plan

- [x] `bun run build` + publint pass for `@moq/web-socket-stream`
- [x] `release-js.yml` is valid YAML
- [ ] After merge: `workflow_dispatch` run publishes `@moq/web-socket-stream@0.1.0` and `npm install @moq/qmux@0.1.3` resolves cleanly

(Written by Claude Opus 4.8)