### PR TITLE
feat(justfile): add `just clean` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -93,6 +93,59 @@ build-ffi:
 build-ffi-target target:
 	./rs/web-transport-ffi/build.sh --target {{target}} --output rs/web-transport-ffi/dist
 
+# Delete build artifacts and caches to reclaim disk space. web-transport keeps
+# a single root justfile (unlike moq's per-language modules), so the per-language
+# cleanups are inlined here. Sweeps the shared caches, then recurses into any
+# agent worktrees under .claude/worktrees/.
+clean:
+	#!/usr/bin/env bash
+	set -euo pipefail
+
+	# Rust: workspace target dir (also used by maturin for the Python build).
+	cargo clean
+
+	# JS/TS: node_modules, bundler output, tsbuildinfo caches.
+	find . -name .claude -prune -o \
+		-type d \( -name node_modules -o -name dist -o -name out -o -name pkg \) \
+		-prune -exec rm -rf {} +
+	find . -name .claude -prune -o -type f -name '*.tsbuildinfo' -exec rm -f {} +
+
+	# Python: virtualenv, build output, generated uniffi bindings, caches.
+	rm -rf py/web-transport/.venv py/web-transport/dist \
+		py/web-transport/python/web_transport/_uniffi
+	find . -name .claude -prune -o -type d -name __pycache__ -prune -exec rm -rf {} +
+	find . -name .claude -prune -o -type f -name '*.pyc' -exec rm -f {} +
+
+	# Kotlin: gradle build dirs + generated bindings/native libs.
+	find . -name .claude -prune -o -type d \( -name build -o -name .gradle -o -name .kotlin \) -prune -exec rm -rf {} +
+	rm -rf kt/local.properties \
+		kt/web-transport/src/jvmAndAndroidMain/kotlin/uniffi \
+		kt/web-transport/src/jvmMain/resources \
+		kt/web-transport/src/androidMain/jniLibs
+
+	# Swift: SPM build dir + generated bindings/xcframework.
+	rm -rf swift/.build swift/.swiftpm swift/Package.resolved \
+		swift/Sources/WebTransportFFI/Generated.swift swift/WebTransportFFI.xcframework
+
+	# FFI: per-host staticlib/bindings output.
+	rm -rf rs/web-transport-ffi/dist
+
+	# Caches not owned by any one language: nix build result, direnv, wrangler.
+	rm -rf result .direnv
+	find . -name .claude -prune -o -type d -name .wrangler -prune -exec rm -rf {} +
+
+	# Reclaim Nix store space too, if Nix is installed.
+	if command -v nix-collect-garbage &> /dev/null; then nix-collect-garbage -d; fi
+
+	# Agent worktrees each carry their own artifacts. Worktrees don't nest, so
+	# this recurses exactly one level. Tolerate stale worktrees on branches that
+	# predate this recipe.
+	for wt in .claude/worktrees/*/; do
+		[ -f "${wt}justfile" ] || continue
+		echo "==> cleaning ${wt}"
+		(cd "$wt" && just clean) || echo "    (skipped: just clean failed in ${wt})"
+	done
+
 # Upgrade any tooling
 upgrade:
 	rustup upgrade


### PR DESCRIPTION
## What

Adds a `just clean` recipe to the root justfile that deletes build artifacts and caches to reclaim disk space.

## Why

Ports the `just clean` workflow from the moq repo. moq splits clean across per-language sub-justfiles (`just rs clean`, `just js clean`, …), but web-transport keeps a single root justfile (only `kt/` and `swift/` have sub-justfiles, and neither defines `clean`), so the per-language cleanups are inlined into one self-contained recipe — adapted to this repo's actual artifact paths.

## What it cleans

- **Rust**: `cargo clean` (shared target dir, also used by maturin for the Python build)
- **JS/TS**: `node_modules`, `dist`/`out`/`pkg`, `*.tsbuildinfo`
- **Python**: `.venv`, `dist`, generated `python/web_transport/_uniffi`, `__pycache__`/`*.pyc`
- **Kotlin**: `build`/`.gradle`/`.kotlin`, `local.properties`, generated uniffi bindings + `jniLibs`/`resources`
- **Swift**: `.build`/`.swiftpm`/`Package.resolved`, generated `Generated.swift` + xcframework
- **FFI**: `rs/web-transport-ffi/dist`
- **Shared caches**: `result`, `.direnv`, `.wrangler`, plus `nix-collect-garbage -d` if Nix is present
- **Worktrees**: recurses one level into `.claude/worktrees/*/`

## Notes for reviewers

- `dependabot.yml` from moq was also requested, but it's already present in this repo and already matches moq's (cooldown + grouped cargo/bun/uv/github-actions updates). The only moq-specific difference is a `reqwest-middleware` cargo `ignore` that doesn't apply here, so no dependabot changes were made.
- Verified the recipe parses (`just --list`) and the bash body passes `bash -n`. The destructive recipe itself was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)