### PR TITLE
feat(quinn): wrap send_datagram_wait and datagram_send_buffer_space

### DIFF
--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -303,6 +303,32 @@ impl Session {
         Ok(())
     }
 
+    /// Sends an application datagram, waiting for buffer space if the send buffer is full.
+    ///
+    /// Unlike [`send_datagram`](Self::send_datagram), this applies backpressure instead of
+    /// returning an error when there are too many outstanding datagrams.
+    ///
+    /// Datagrams are unreliable and may be dropped or delivered out of order.
+    /// The data must be smaller than [`max_datagram_size`](Self::max_datagram_size).
+    pub async fn send_datagram_wait(&self, data: Bytes) -> Result<(), SessionError> {
+        let result = if !self.header_datagram.is_empty() {
+            // Unfortunately, we need to allocate/copy each datagram because of the Quinn API.
+            // Pls go +1 if you care: https://github.com/quinn-rs/quinn/issues/1724
+            let mut buf = BytesMut::with_capacity(self.header_datagram.len() + data.len());
+
+            // Prepend the datagram with the header indicating the session ID.
+            buf.extend_from_slice(&self.header_datagram);
+            buf.extend_from_slice(&data);
+
+            self.conn.send_datagram_wait(buf.into()).await
+        } else {
+            self.conn.send_datagram_wait(data).await
+        };
+
+        result.map_err(|e| self.map_error(e))?;
+        Ok(())
+    }
+
     /// Computes the maximum size of datagrams that may be passed to
     /// [`send_datagram`](Self::send_datagram).
     pub fn max_datagram_size(&self) -> usize {
@@ -311,6 +337,16 @@ impl Session {
             .max_datagram_size()
             .expect("datagram support is required");
         mtu.saturating_sub(self.header_datagram.len())
+    }
+
+    /// The number of bytes of available space in the outgoing datagram buffer.
+    ///
+    /// The session-ID header is subtracted, so this reflects the payload bytes that may be
+    /// passed to [`send_datagram`](Self::send_datagram) before it starts dropping datagrams.
+    pub fn datagram_send_buffer_space(&self) -> usize {
+        self.conn
+            .datagram_send_buffer_space()
+            .saturating_sub(self.header_datagram.len())
     }
 
     /// Close the session with an error code and reason.


### PR DESCRIPTION
## Summary

Wraps two Quinn `Connection` datagram APIs on the `web-transport-quinn` `Session`:

- **`send_datagram_wait`** — like `send_datagram`, but awaits buffer space instead of returning an error when there are too many outstanding datagrams (backpressure rather than drop). Uses the same session-ID header prepend as `send_datagram`.
- **`datagram_send_buffer_space`** — passes through quinn's value minus the session-ID header length, mirroring how `max_datagram_size` accounts for the header so the number reflects usable payload bytes.

These are exposed only on the concrete quinn `Session` (not the shared `web-transport-trait`), since `datagram_send_buffer_space` has no clean cross-backend equivalent (e.g. the browser WebTransport API exposes no live buffer-space query).

## Test plan

- `cargo check -p web-transport-quinn` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)