### PR TITLE
feat(qmux): transport backpressure via a shared-state writer task

### DIFF
--- a/rs/qmux/CHANGELOG.md
+++ b/rs/qmux/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(qmux)* the `Session` now drives the transport's send and receive halves on separate tasks so a write stalled on transport backpressure no longer blocks reads (or control-frame processing). The writer task pulls the outbound queues in priority order — control ahead of datagrams ahead of bulk stream data (still scheduled by `sendOrder`) — sharing per-stream state with the reader through a lock rather than a bytes channel. `Session::send_datagram` sheds datagrams the moment the transport backs up (the writer stops draining the datagram lane), rather than buffering them behind a stalled socket where they'd arrive stale.
 - *(qmux)* dropping the last `Session` clone now closes the connection promptly, tearing down the backend tasks and failing any in-flight stream `write`/`read` with `Error::Closed` (previously teardown waited for the transport to notice). Hold a `Session` clone for as long as you use its streams.
+- *(qmux)* the session idle timeout is *deferred* while a write is wedged on transport backpressure: a stalled `send` proves the peer is still there (its receive window is full) but also blocks the keep-alive, so a healthy backpressured connection isn't mistaken for a dead one. The deferral is bounded to one extra idle window, so a peer that dies under backpressure is still reclaimed (rather than hanging until the transport's own, much longer, timeout).
 
 ### Breaking
 

--- a/rs/qmux/CHANGELOG.md
+++ b/rs/qmux/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(qmux)* datagram support (RFC 9221) on QMux01: `send_datagram`/`recv_datagram`/`max_datagram_size` on `Session`, negotiated via the `max_datagram_frame_size` transport parameter and configured with `Config::max_datagram_frame_size` (enabled by default). Datagrams are unavailable on QMux00 and the legacy `webtransport` format.
 
+### Changed
+
+- *(qmux)* the `Session` now drives the transport's send and receive halves on separate tasks so a write stalled on transport backpressure no longer blocks reads (or control-frame processing). The writer task pulls the outbound queues in priority order — control ahead of datagrams ahead of bulk stream data (still scheduled by `sendOrder`) — sharing per-stream state with the reader through a lock rather than a bytes channel. `Session::send_datagram` sheds datagrams the moment the transport backs up (the writer stops draining the datagram lane), rather than buffering them behind a stalled socket where they'd arrive stale.
+- *(qmux)* dropping the last `Session` clone now closes the connection promptly, tearing down the backend tasks and failing any in-flight stream `write`/`read` with `Error::Closed` (previously teardown waited for the transport to notice). Hold a `Session` clone for as long as you use its streams.
+
+### Breaking
+
+- *(qmux)* the `Transport` trait now splits into `TransportWriter` + `TransportReader` halves via `Transport::split`; `send`/`recv`/`close` moved onto those halves and `TransportWriter::maintain` was added for timer-driven work (e.g. WebSocket keep-alive). Custom `Transport` implementations must adopt the new shape; the built-in TCP/TLS/Unix/WebSocket transports and `Session::connect`/`accept` are unaffected.
+
 ## [0.3.1](https://github.com/moq-dev/web-transport/compare/qmux-v0.2.0...qmux-v0.3.1) - 2026-06-25
 
 ### Added

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -50,7 +50,7 @@ pub use error::Error;
 pub use proto::Version;
 pub use session::{RecvStream, SendStream, Session};
 pub use stream::{StreamDir, StreamId};
-pub use transport::Transport;
+pub use transport::{Transport, TransportReader, TransportWriter};
 // The concrete byte-stream transport lives at `transport::Stream` rather than the
 // crate root, so the name doesn't collide with the STREAM-frame `Stream` type.
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1,15 +1,15 @@
 use std::{
-    collections::{hash_map, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, OnceLock,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc, Mutex, OnceLock,
     },
 };
 
 use crate::config::Config;
 use crate::credit::Credit;
 use crate::sched::PriorityQueue;
-use crate::transport::Transport;
+use crate::transport::{Transport, TransportReader, TransportWriter};
 use crate::{
     proto::varint_size, ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir,
     StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD,
@@ -24,10 +24,44 @@ use web_transport_trait as generic;
 /// applying backpressure to the whole session.
 const DATAGRAM_RECV_BUFFER: usize = 1024;
 
-/// How many outbound datagrams to buffer before dropping. When the transport is
-/// backpressured, `send_datagram` sheds datagrams here rather than growing an
-/// unbounded queue — droppable is the whole point of an unreliable datagram.
-const DATAGRAM_SEND_BUFFER: usize = 1024;
+/// How many outbound datagrams to buffer before dropping. The writer pulls from
+/// this lane; when it stalls on transport backpressure it stops pulling, the lane
+/// fills, and `send_datagram` drops on a full lane. Kept small so shedding tracks
+/// real backpressure closely rather than after a deep buffer of stale datagrams.
+const DATAGRAM_SEND_BUFFER: usize = 64;
+
+/// Shared, lock-guarded per-stream backend state. The reader task inserts/looks
+/// up entries as inbound frames arrive; the writer task retires an entry when it
+/// emits that stream's terminal frame (FIN/RESET/STOP_SENDING). Guarded by a
+/// plain `std::sync::Mutex` — never held across an `.await` — so both tasks share
+/// it without message passing, the way a QUIC endpoint shares connection state.
+#[derive(Default)]
+struct Streams {
+    send: HashMap<StreamId, SendState>,
+    recv: HashMap<StreamId, RecvState>,
+}
+
+/// Closes the connection once the last [`Session`] handle is dropped. Held in an
+/// `Arc` cloned with every `Session`, so its `Drop` runs only when they're all
+/// gone — at which point it flips `closed`, tearing the backend tasks down
+/// promptly rather than waiting for the transport to notice. Mirrors how a QUIC
+/// endpoint's connection handle owns the connection's lifetime.
+struct SessionGuard {
+    closed: watch::Sender<Option<Error>>,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        self.closed.send_if_modified(|slot| {
+            if slot.is_none() {
+                *slot = Some(Error::Closed);
+                true
+            } else {
+                false
+            }
+        });
+    }
+}
 
 /// A multiplexed session over a reliable transport.
 #[derive(Clone)]
@@ -85,6 +119,9 @@ pub struct Session {
     // Resolved from the peer's transport parameters before the session is handed
     // to the caller (0 = the peer doesn't accept datagrams).
     datagram_max_size: Arc<AtomicUsize>,
+
+    // Closes the connection when the last `Session` clone drops. Never read.
+    _guard: Arc<SessionGuard>,
 }
 
 /// Tracks which peer-initiated recv-stream indices (in one direction) are open,
@@ -136,13 +173,20 @@ impl RecvOpen {
     }
 }
 
-struct SessionState<T: Transport> {
-    transport: T,
+/// Reader-side task state: owns the transport receive half and processes inbound
+/// frames. The outbound path (scheduling, encoding, sending, keep-alive) lives in
+/// [`WriterState`]; the two tasks share `streams` and the record-limit / idle
+/// atomics instead of passing messages.
+struct SessionState<R: TransportReader> {
+    reader: R,
     config: Config,
     is_server: bool,
 
+    // Handed (cloned) to newly-created peer-initiated stream frontends so they can
+    // enqueue their own data (`outbound`) and control frames (`control`). The
+    // reader never pulls from these — the writer does.
     outbound: PriorityQueue,
-    outbound_priority: (mpsc::UnboundedSender<Frame>, mpsc::UnboundedReceiver<Frame>),
+    control: mpsc::UnboundedSender<Frame>,
 
     accept_bi: mpsc::Sender<(SendStream, RecvStream)>,
     accept_uni: mpsc::Sender<RecvStream>,
@@ -150,8 +194,8 @@ struct SessionState<T: Transport> {
     create_uni: mpsc::Receiver<(StreamId, SendState)>,
     create_bi: mpsc::Receiver<(StreamId, SendState, RecvState)>,
 
-    send_streams: HashMap<StreamId, SendState>,
-    recv_streams: HashMap<StreamId, RecvState>,
+    // Shared per-stream backend state (with the writer task).
+    streams: Arc<Mutex<Streams>>,
 
     closed: watch::Sender<Option<Error>>,
 
@@ -175,51 +219,194 @@ struct SessionState<T: Transport> {
 
     // Open/closed bookkeeping for peer-initiated recv streams, per direction, so a
     // post-terminal frame on a retired id is ignored rather than resurrecting a
-    // brand-new accepted stream. See `RecvOpen`. QMux only: MAX_STREAMS flow
-    // control bounds the hole set to at most the peer's stream limit.
+    // brand-new accepted stream. See `RecvOpen`. Reader-only (not shared with the
+    // writer). QMux only: MAX_STREAMS flow control bounds the hole set to at most
+    // the peer's stream limit.
     recv_open_bi: RecvOpen,
     recv_open_uni: RecvOpen,
 
-    // QMux01 idle-timeout state (engaged once we've received the peer's params)
+    // QMux01 idle-timeout state: the reader closes the session if no frame arrives
+    // within the window (the writer handles the keep-alive ping side).
     last_recv_at: tokio::time::Instant,
-    last_send_at: tokio::time::Instant,
-    next_ping_seq: u64,
 
     // Inbound datagram sink (see the matching field on `Session`) plus the
     // shared send-limit cell resolved from the peer's params.
     recv_datagram: mpsc::Sender<Bytes>,
     datagram_max_size: Arc<AtomicUsize>,
 
-    // Receiver for outbound datagrams enqueued by `send_datagram`.
-    outbound_datagram: mpsc::Receiver<Bytes>,
+    // Effective outbound record-size limit and idle-timeout (ms), shared with the
+    // writer. Both are written once, when the peer's transport parameters arrive.
+    record_limit: Arc<AtomicU64>,
+    idle_timeout_ms: Arc<AtomicU64>,
 }
 
-impl<T: Transport> SessionState<T> {
-    async fn run(&mut self) -> Result<(), Error> {
-        // QMux requires TRANSPORT_PARAMETERS as the first frame on the connection.
-        if self.config.version.is_qmux() {
-            self.send_transport_parameters().await?;
-        }
+/// Pick the next outbound frame in strict priority order: control (lossless,
+/// e.g. RESET/STOP/CLOSE/window updates) first, then datagrams (low-latency but
+/// droppable), then bulk stream data scheduled by [`PriorityQueue`]. Returns
+/// `None` only once the stream queue is closed, which drives session teardown.
+///
+/// Each source's future is cancel-safe (`mpsc::recv` and `PriorityQueue::pop`
+/// remove nothing until they resolve), so losing this race in the caller's
+/// `select!` never drops a frame.
+async fn next_outbound(
+    control: &mut mpsc::UnboundedReceiver<Frame>,
+    datagram: &mut mpsc::Receiver<Bytes>,
+    stream: &PriorityQueue,
+) -> Option<Frame> {
+    tokio::select! {
+        biased;
+        Some(frame) = control.recv() => Some(frame),
+        // `.into()` builds the length-prefixed (0x31) form we always emit.
+        Some(payload) = datagram.recv() => Some(Frame::Datagram(payload.into())),
+        frame = stream.pop() => frame,
+    }
+}
 
-        let mut closed = self.closed.subscribe();
+/// Writer-side task state: owns the transport send half and is the sole producer
+/// on the wire. It pulls the outbound queues in strict priority order via
+/// [`next_outbound`], retires the stream a terminal frame closes and encodes it
+/// under the shared `streams` lock, then writes it. Runs on its own task so a
+/// write blocked on transport backpressure never stalls the reader. It also owns
+/// the QMux keep-alive ping (it's the side that knows when we last sent).
+struct WriterState<W: TransportWriter> {
+    writer: W,
+    version: Version,
 
+    control: mpsc::UnboundedReceiver<Frame>,
+    datagrams: mpsc::Receiver<Bytes>,
+    outbound: PriorityQueue,
+
+    // Shared with the reader task.
+    streams: Arc<Mutex<Streams>>,
+    record_limit: Arc<AtomicU64>,
+    idle_timeout_ms: Arc<AtomicU64>,
+
+    closed: watch::Sender<Option<Error>>,
+
+    last_send_at: tokio::time::Instant,
+    next_ping_seq: u64,
+}
+
+impl<W: TransportWriter> WriterState<W> {
+    /// Record the first terminal error so the reader's `closed` branch unblocks.
+    fn note_closed(&self, err: Error) {
+        self.closed.send_if_modified(|slot| {
+            if slot.is_none() {
+                *slot = Some(err);
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    async fn run(&mut self) {
+        let mut closed_rx = self.closed.subscribe();
         loop {
-            // Compute the effective idle timeout — the smaller of the two non-zero values.
-            // While we're still waiting on the peer's transport parameters, treat the
-            // timeout as disabled so we don't tear the connection down before negotiation.
-            let idle_timeout_ms = self.effective_idle_timeout_ms();
-            let idle_deadline =
-                idle_timeout_ms.map(|ms| self.last_recv_at + std::time::Duration::from_millis(ms));
-            // Keep-alive: send a QX_PING when we've been silent for a third of the timeout.
-            // (Any frame counts as activity; this fires only when both sides are idle.)
-            // Clamp to 1ms so a tiny configured timeout doesn't yield a zero-duration
-            // deadline that fires every loop iteration.
-            let ping_deadline = idle_timeout_ms
-                .map(|ms| self.last_send_at + std::time::Duration::from_millis((ms / 3).max(1)));
+            // Keep-alive: send a QX_PING once we've been silent for a third of the
+            // idle timeout. 0 = disabled (non-QMux01, or params not yet exchanged).
+            // Clamp to 1ms so a tiny timeout doesn't yield a zero-duration deadline.
+            let idle_ms = self.idle_timeout_ms.load(Ordering::Acquire);
+            let ping_deadline = (idle_ms != 0).then(|| {
+                self.last_send_at + std::time::Duration::from_millis((idle_ms / 3).max(1))
+            });
 
             tokio::select! {
                 biased;
-                result = self.transport.recv() => {
+                frame = next_outbound(&mut self.control, &mut self.datagrams, &self.outbound) => {
+                    match frame {
+                        Some(frame) => {
+                            if let Err(err) = self.transmit(frame).await {
+                                self.note_closed(err);
+                                break;
+                            }
+                        }
+                        // The stream queue was closed on teardown.
+                        None => break,
+                    }
+                }
+                _ = async { tokio::time::sleep_until(ping_deadline.unwrap()).await }, if ping_deadline.is_some() => {
+                    let seq = self.next_ping_seq;
+                    self.next_ping_seq = self.next_ping_seq.wrapping_add(1);
+                    let ping = Frame::Ping(crate::Ping { sequence: seq, response: false });
+                    if let Err(err) = self.transmit(ping).await {
+                        self.note_closed(err);
+                        break;
+                    }
+                }
+                // Transport-level maintenance (WebSocket keep-alive Ping); never
+                // resolves for transports without timer-driven work.
+                result = self.writer.maintain() => {
+                    if let Err(err) = result {
+                        self.note_closed(err);
+                        break;
+                    }
+                }
+                // Wrapped so the `watch::Ref` guard is dropped before the branch
+                // resolves — otherwise it (non-`Send`), held across a `send` await,
+                // would make the task non-`Send`.
+                _ = async { closed_rx.wait_for(|slot| slot.is_some()).await.ok(); } => {
+                    // Session tearing down: best-effort flush of any queued control
+                    // frames (e.g. a ConnectionClose) before we stop.
+                    while let Ok(frame) = self.control.try_recv() {
+                        if self.transmit(frame).await.is_err() {
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        let _ = self.writer.close().await;
+    }
+
+    /// Retire the stream a terminal frame closes, encode the frame (validating its
+    /// size for QMux01), and write it. The `streams` lock is only held for the
+    /// synchronous retirement, never across the `send` await.
+    async fn transmit(&mut self, frame: Frame) -> Result<(), Error> {
+        match &frame {
+            Frame::ResetStream(reset) => {
+                self.streams.lock().unwrap().send.remove(&reset.id);
+            }
+            Frame::Stream(stream) if stream.fin => {
+                self.streams.lock().unwrap().send.remove(&stream.id);
+            }
+            Frame::StopSending(stop) => {
+                self.streams.lock().unwrap().recv.remove(&stop.id);
+            }
+            _ => {}
+        }
+
+        let bytes = frame.encode(self.version)?;
+        if self.version == Version::QMux01 {
+            // `record_limit` holds the draft-01 default until the peer's params
+            // arrive, then the peer's `max_record_size`.
+            let limit = self.record_limit.load(Ordering::Acquire);
+            if bytes.len() as u64 > limit {
+                return Err(Error::FrameTooLarge);
+            }
+        }
+        self.writer.send(bytes).await?;
+        self.last_send_at = tokio::time::Instant::now();
+        Ok(())
+    }
+}
+
+impl<R: TransportReader> SessionState<R> {
+    async fn run(&mut self) -> Result<(), Error> {
+        let mut closed = self.closed.subscribe();
+
+        loop {
+            // Close the session if the peer goes silent past the idle timeout. The
+            // writer owns the keep-alive ping that keeps this from firing while a
+            // healthy peer is merely idle. Disabled until the params are exchanged.
+            let idle_deadline = self
+                .effective_idle_timeout_ms()
+                .map(|ms| self.last_recv_at + std::time::Duration::from_millis(ms));
+
+            tokio::select! {
+                biased;
+                result = self.reader.recv() => {
                     let data = result?;
                     self.last_recv_at = tokio::time::Instant::now();
                     if self.config.version == Version::QMux01 {
@@ -238,7 +425,7 @@ impl<T: Transport> SessionState<T> {
                             credit.increase_max(self.peer_params.initial_max_stream_data_uni).ok();
                         }
                     }
-                    self.send_streams.insert(id, send);
+                    self.streams.lock().unwrap().send.insert(id, send);
                 }
                 Some((id, send, recv)) = self.create_bi.recv() => {
                     if self.params_received {
@@ -246,34 +433,13 @@ impl<T: Transport> SessionState<T> {
                             credit.increase_max(self.peer_params.initial_max_stream_data_bidi_remote).ok();
                         }
                     }
-                    self.send_streams.insert(id, send);
-                    self.recv_streams.insert(id, recv);
-                }
-                frame = self.outbound_priority.1.recv() => {
-                    match frame {
-                        Some(frame) => self.send_frame(frame).await?,
-                        None => return Err(Error::Closed),
-                    };
-                }
-                Some(payload) = self.outbound_datagram.recv() => {
-                    // Ahead of bulk stream data for low latency, behind control.
-                    self.send_frame(Frame::Datagram(payload.into())).await?;
-                }
-                frame = self.outbound.pop() => {
-                    match frame {
-                        Some(frame) => self.send_frame(frame).await?,
-                        None => return Err(Error::Closed),
-                    };
+                    let mut streams = self.streams.lock().unwrap();
+                    streams.send.insert(id, send);
+                    streams.recv.insert(id, recv);
                 }
                 _ = async { tokio::time::sleep_until(idle_deadline.unwrap()).await }, if idle_deadline.is_some() => {
                     tracing::debug!("idle timeout fired");
                     return Err(Error::IdleTimeout);
-                }
-                _ = async { tokio::time::sleep_until(ping_deadline.unwrap()).await }, if ping_deadline.is_some() => {
-                    // Periodic keep-alive: send a QX_PING so the peer's idle timer resets.
-                    let seq = self.next_ping_seq;
-                    self.next_ping_seq = self.next_ping_seq.wrapping_add(1);
-                    self.send_frame(Frame::Ping(crate::Ping { sequence: seq, response: false })).await?;
                 }
                 _ = async { closed.wait_for(|err| err.is_some()).await.ok(); } => {
                     return Err(closed.borrow().clone().unwrap_or(Error::Closed))
@@ -301,51 +467,6 @@ impl<T: Transport> SessionState<T> {
         }
     }
 
-    /// Send a QX_TRANSPORT_PARAMETERS frame with our defaults.
-    async fn send_transport_parameters(&mut self) -> Result<(), Error> {
-        let frame = Frame::TransportParameters(self.our_params.clone());
-        self.send_encoded(frame.encode(self.config.version)?).await
-    }
-
-    /// Send pre-encoded frame bytes, validating against the peer's
-    /// `max_record_size` for QMux01. The transport handles any
-    /// transport-level framing (size varint on TCP/TLS; implicit on WS).
-    async fn send_encoded(&mut self, bytes: Bytes) -> Result<(), Error> {
-        if self.config.version == Version::QMux01 {
-            // Until the peer's TRANSPORT_PARAMETERS arrive, fall back to the draft-01
-            // default so we don't accidentally send a record the peer must reject.
-            let limit = if self.params_received {
-                self.peer_params.max_record_size
-            } else {
-                crate::proto::DEFAULT_MAX_RECORD_SIZE
-            };
-            if bytes.len() as u64 > limit {
-                return Err(Error::FrameTooLarge);
-            }
-        }
-        self.transport.send(bytes).await?;
-        self.last_send_at = tokio::time::Instant::now();
-        Ok(())
-    }
-
-    async fn send_frame(&mut self, frame: Frame) -> Result<(), Error> {
-        // Update our state first.
-        match &frame {
-            Frame::ResetStream(reset) => {
-                self.send_streams.remove(&reset.id);
-            }
-            Frame::Stream(stream) if stream.fin => {
-                self.send_streams.remove(&stream.id);
-            }
-            Frame::StopSending(stop) => {
-                self.recv_streams.remove(&stop.id);
-            }
-            _ => {}
-        };
-
-        self.send_encoded(frame.encode(self.config.version)?).await
-    }
-
     /// Per-direction open/closed bookkeeping for peer-initiated recv streams.
     fn recv_open(&self, dir: StreamDir) -> &RecvOpen {
         match dir {
@@ -368,221 +489,220 @@ impl<T: Transport> SessionState<T> {
                     return Err(Error::InvalidStreamId);
                 }
 
-                // Ignore post-terminal frames on an already-closed peer-initiated
-                // stream. Once we deliver a FIN/RESET the entry is dropped, so
-                // without this a duplicate/late STREAM frame would fall through and
-                // be treated as a brand-new accepted stream (stream resurrection).
-                // `is_closed` distinguishes a retired id from one that was only
-                // implicitly opened (a higher index arrived first) and hasn't had
-                // its own first frame yet — the latter is still new. Locally-
-                // initiated ids are left to the `is_server` guard below; only QMux
-                // tracks this, where MAX_STREAMS bounds the hole set.
+                // Ignore a post-terminal frame on a retired peer-initiated stream
+                // before consuming connection credit — otherwise a flood of
+                // duplicate/late frames would drain conn flow-control that's never
+                // replenished (they're not delivered). `is_closed` distinguishes a
+                // retired id from one merely implicitly opened (a higher index
+                // arrived first); a live stream is delivered by the fast path below,
+                // so exclude it. Only QMux tracks this (MAX_STREAMS bounds the holes).
+                let live = self.streams.lock().unwrap().recv.contains_key(&stream.id);
                 if self.config.version.is_qmux()
                     && stream.id.server_initiated() != self.is_server
-                    && !self.recv_streams.contains_key(&stream.id)
+                    && !live
                     && self.recv_open(stream.id.dir()).is_closed(stream.id.index())
                 {
                     return Ok(());
                 }
 
-                // Validate receive-side flow control
+                // Connection-level flow control.
                 let data_len = stream.data.len() as u64;
-                if data_len > 0 {
-                    // Connection-level check
-                    if !self.conn_recv_credit.receive(data_len) {
-                        return Err(Error::FlowControlError);
-                    }
-
-                    // Stream-level check (for existing streams)
-                    if let Some(recv) = self.recv_streams.get(&stream.id) {
-                        if !recv.recv_credit.receive(data_len) {
-                            return Err(Error::FlowControlError);
-                        }
-                    }
-                    // For new streams, we check after creation below
+                if data_len > 0 && !self.conn_recv_credit.receive(data_len) {
+                    return Err(Error::FlowControlError);
                 }
 
-                match self.recv_streams.entry(stream.id) {
-                    hash_map::Entry::Vacant(e) => {
-                        if self.is_server == stream.id.server_initiated() {
-                            // Already closed, ignore it.
-                            return Ok(());
-                        }
-
-                        // Validate stream count limits (QMux only)
-                        // Per QUIC RFC 9000 §4.6, the limit applies to the stream index,
-                        // not the count of seen streams. A peer opening stream index N
-                        // implicitly opens all streams 0..N.
-                        if self.config.version.is_qmux() {
-                            let credit = match stream.id.dir() {
-                                StreamDir::Bi => &self.recv_bi_credit,
-                                StreamDir::Uni => &self.recv_uni_credit,
-                            };
-                            if !credit.receive_up_to(stream.id.index() + 1) {
-                                return Err(Error::StreamLimitExceeded);
-                            }
-
-                            // Record that we're instantiating a frontend for this
-                            // id, so a later frame on it (after it's retired) is
-                            // recognized as closed rather than resurrected. Runs
-                            // after the credit gate, which bounds the hole set to at
-                            // most MAX_STREAMS. Reached only for peer-initiated ids
-                            // (the `is_server` guard above returned otherwise).
-                            // Access the field directly (not via `recv_open_mut`)
-                            // so the borrow stays disjoint from the `recv_streams`
-                            // entry held open by this match.
-                            match stream.id.dir() {
-                                StreamDir::Bi => &mut self.recv_open_bi,
-                                StreamDir::Uni => &mut self.recv_open_uni,
-                            }
-                            .record(stream.id.index());
-                        }
-
-                        let (tx, rx) = mpsc::unbounded_channel();
-                        let (tx2, rx2) = mpsc::unbounded_channel();
-
-                        // Determine initial stream recv window
-                        let recv_window = if self.config.version.is_qmux() {
-                            match stream.id.dir() {
-                                StreamDir::Bi => {
-                                    self.our_params.initial_max_stream_data_bidi_remote
-                                }
-                                StreamDir::Uni => self.our_params.initial_max_stream_data_uni,
-                            }
-                        } else {
-                            u64::MAX
-                        };
-
-                        let recv_credit = Credit::new(recv_window);
-
-                        // Validate stream-level for the first frame on new stream
-                        if data_len > 0 && !recv_credit.receive(data_len) {
+                // Fast path: an existing stream. Check its window and deliver under
+                // a brief lock (never held across an await).
+                {
+                    let mut streams = self.streams.lock().unwrap();
+                    if let Some(recv) = streams.recv.get(&stream.id) {
+                        if data_len > 0 && !recv.recv_credit.receive(data_len) {
                             return Err(Error::FlowControlError);
                         }
+                        let id = stream.id;
+                        let fin = stream.fin;
+                        recv.inbound_data.send(stream).ok();
+                        if fin {
+                            streams.recv.remove(&id);
+                        }
+                        return Ok(());
+                    }
+                }
 
-                        let recv_backend = RecvState {
-                            inbound_data: tx,
-                            inbound_reset: tx2,
-                            recv_credit: recv_credit.clone(),
+                // A frame on one of our own (already-retired) streams: ignore it.
+                if self.is_server == stream.id.server_initiated() {
+                    return Ok(());
+                }
+
+                // New peer-initiated stream. Enforce the stream-count limit — per
+                // RFC 9000 §4.6 opening index N implicitly opens all of 0..N.
+                if self.config.version.is_qmux() {
+                    let credit = match stream.id.dir() {
+                        StreamDir::Bi => &self.recv_bi_credit,
+                        StreamDir::Uni => &self.recv_uni_credit,
+                    };
+                    if !credit.receive_up_to(stream.id.index() + 1) {
+                        return Err(Error::StreamLimitExceeded);
+                    }
+
+                    // Record that we've instantiated a frontend for this id, so a
+                    // later frame on it (once retired) reads as closed rather than
+                    // resurrecting a new stream. After the credit gate, which bounds
+                    // the hole set to MAX_STREAMS.
+                    match stream.id.dir() {
+                        StreamDir::Bi => &mut self.recv_open_bi,
+                        StreamDir::Uni => &mut self.recv_open_uni,
+                    }
+                    .record(stream.id.index());
+                }
+
+                let (tx, rx) = mpsc::unbounded_channel();
+                let (tx2, rx2) = mpsc::unbounded_channel();
+
+                // Determine initial stream recv window
+                let recv_window = if self.config.version.is_qmux() {
+                    match stream.id.dir() {
+                        StreamDir::Bi => self.our_params.initial_max_stream_data_bidi_remote,
+                        StreamDir::Uni => self.our_params.initial_max_stream_data_uni,
+                    }
+                } else {
+                    u64::MAX
+                };
+
+                let recv_credit = Credit::new(recv_window);
+
+                // Stream-level flow control for the first frame on the new stream.
+                if data_len > 0 && !recv_credit.receive(data_len) {
+                    return Err(Error::FlowControlError);
+                }
+
+                let recv_backend = RecvState {
+                    inbound_data: tx,
+                    inbound_reset: tx2,
+                    recv_credit: recv_credit.clone(),
+                };
+
+                let recv_streams_credit = if self.config.version.is_qmux() {
+                    Some(match stream.id.dir() {
+                        StreamDir::Bi => self.recv_bi_credit.clone(),
+                        StreamDir::Uni => self.recv_uni_credit.clone(),
+                    })
+                } else {
+                    None
+                };
+
+                let recv_frontend = RecvStream {
+                    id: stream.id,
+                    inbound_data: rx,
+                    inbound_reset: rx2,
+                    outbound_priority: self.control.clone(),
+                    buffer: Bytes::new(),
+                    closed: None,
+                    fin: false,
+                    recv_credit,
+                    conn_recv_credit: self.conn_recv_credit.clone(),
+                    version: self.config.version,
+                    recv_streams_credit,
+                };
+
+                match stream.id.dir() {
+                    StreamDir::Uni => {
+                        self.accept_uni
+                            .send(recv_frontend)
+                            .await
+                            .map_err(|_| Error::Closed)?;
+                    }
+                    StreamDir::Bi => {
+                        let (tx, rx) = mpsc::unbounded_channel();
+                        let send_backend = SendState {
+                            inbound_stopped: tx,
+                            stream_credit: if self.config.version.is_qmux() {
+                                // Peer opened this bidi stream, so our send limit
+                                // is their bidi_local (they are local to this stream)
+                                Some(Credit::new(
+                                    self.peer_params.initial_max_stream_data_bidi_local,
+                                ))
+                            } else {
+                                None
+                            },
                         };
 
-                        let recv_streams_credit = if self.config.version.is_qmux() {
-                            Some(match stream.id.dir() {
-                                StreamDir::Bi => self.recv_bi_credit.clone(),
-                                StreamDir::Uni => self.recv_uni_credit.clone(),
-                            })
-                        } else {
-                            None
-                        };
-
-                        let recv_frontend = RecvStream {
+                        let send_frontend = SendStream {
                             id: stream.id,
-                            inbound_data: rx,
-                            inbound_reset: rx2,
-                            outbound_priority: self.outbound_priority.0.clone(),
-                            buffer: Bytes::new(),
+                            outbound: self.outbound.clone(),
+                            outbound_priority: self.control.clone(),
+                            inbound_stopped: rx,
+                            offset: 0,
+                            priority: 0,
                             closed: None,
                             fin: false,
-                            recv_credit,
-                            conn_recv_credit: self.conn_recv_credit.clone(),
-                            version: self.config.version,
-                            recv_streams_credit,
+                            stream_credit: send_backend.stream_credit.clone(),
+                            conn_credit: if self.config.version.is_qmux() {
+                                Some(self.conn_send_credit.clone())
+                            } else {
+                                None
+                            },
                         };
 
-                        match stream.id.dir() {
-                            StreamDir::Uni => {
-                                self.accept_uni
-                                    .send(recv_frontend)
-                                    .await
-                                    .map_err(|_| Error::Closed)?;
-                            }
-                            StreamDir::Bi => {
-                                let (tx, rx) = mpsc::unbounded_channel();
-                                let send_backend = SendState {
-                                    inbound_stopped: tx,
-                                    stream_credit: if self.config.version.is_qmux() {
-                                        // Peer opened this bidi stream, so our send limit
-                                        // is their bidi_local (they are local to this stream)
-                                        Some(Credit::new(
-                                            self.peer_params.initial_max_stream_data_bidi_local,
-                                        ))
-                                    } else {
-                                        None
-                                    },
-                                };
-
-                                let send_frontend = SendStream {
-                                    id: stream.id,
-                                    outbound: self.outbound.clone(),
-                                    outbound_priority: self.outbound_priority.0.clone(),
-                                    inbound_stopped: rx,
-                                    offset: 0,
-                                    priority: 0,
-                                    closed: None,
-                                    fin: false,
-                                    stream_credit: send_backend.stream_credit.clone(),
-                                    conn_credit: if self.config.version.is_qmux() {
-                                        Some(self.conn_send_credit.clone())
-                                    } else {
-                                        None
-                                    },
-                                };
-
-                                self.send_streams.insert(stream.id, send_backend);
-                                self.accept_bi
-                                    .send((send_frontend, recv_frontend))
-                                    .await
-                                    .map_err(|_| Error::Closed)?;
-                            }
-                        };
-
-                        let fin = stream.fin;
-                        recv_backend.inbound_data.send(stream).ok();
-
-                        if !fin {
-                            e.insert(recv_backend);
-                        }
-                    }
-                    hash_map::Entry::Occupied(mut e) => {
-                        let fin = stream.fin;
-                        e.get_mut().inbound_data.send(stream).ok();
-                        if fin {
-                            e.remove();
-                        }
+                        self.streams
+                            .lock()
+                            .unwrap()
+                            .send
+                            .insert(stream.id, send_backend);
+                        self.accept_bi
+                            .send((send_frontend, recv_frontend))
+                            .await
+                            .map_err(|_| Error::Closed)?;
                     }
                 };
+
+                let id = stream.id;
+                let fin = stream.fin;
+                recv_backend.inbound_data.send(stream).ok();
+
+                if !fin {
+                    self.streams.lock().unwrap().recv.insert(id, recv_backend);
+                }
             }
             Frame::ResetStream(reset) => {
                 if !reset.id.can_recv(self.is_server) {
                     return Err(Error::InvalidStreamId);
                 }
 
-                if let Some(recv) = self.recv_streams.remove(&reset.id) {
-                    // Live stream: deliver the reset and drop it. It was recorded
-                    // in `recv_open` at creation, so it now reads as closed.
-                    recv.inbound_reset.send(reset).ok();
-                } else if self.config.version.is_qmux()
-                    && reset.id.server_initiated() != self.is_server
+                // Live stream: deliver the reset and drop it (it was recorded in
+                // `recv_open` at creation, so it now reads as closed).
+                let reset_id = reset.id;
+                let delivered = {
+                    let mut streams = self.streams.lock().unwrap();
+                    if let Some(recv) = streams.recv.remove(&reset_id) {
+                        recv.inbound_reset.send(reset).ok();
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if !delivered
+                    && self.config.version.is_qmux()
+                    && reset_id.server_initiated() != self.is_server
                 {
                     // RESET_STREAM can be the *first* frame for a peer-initiated
                     // stream (it implicitly opens the id). Record it as closed so a
-                    // later STREAM on the same id is recognized as retired rather
-                    // than resurrected into a new accepted stream. Gate on the
-                    // stream limit first, mirroring the STREAM path, so the hole set
-                    // stays bounded by MAX_STREAMS. Locally-initiated ids are left
-                    // to the `is_server` guard on the STREAM path.
-                    let credit = match reset.id.dir() {
+                    // later STREAM on the same id is recognized as retired rather than
+                    // resurrected into a new accepted stream. Gate on the stream limit
+                    // first (mirroring the STREAM path) so the hole set stays bounded
+                    // by MAX_STREAMS.
+                    let credit = match reset_id.dir() {
                         StreamDir::Bi => &self.recv_bi_credit,
                         StreamDir::Uni => &self.recv_uni_credit,
                     };
-                    if !credit.receive_up_to(reset.id.index() + 1) {
+                    if !credit.receive_up_to(reset_id.index() + 1) {
                         return Err(Error::StreamLimitExceeded);
                     }
-                    match reset.id.dir() {
+                    match reset_id.dir() {
                         StreamDir::Bi => &mut self.recv_open_bi,
                         StreamDir::Uni => &mut self.recv_open_uni,
                     }
-                    .record(reset.id.index());
+                    .record(reset_id.index());
                 }
             }
             Frame::StopSending(stop) => {
@@ -590,8 +710,8 @@ impl<T: Transport> SessionState<T> {
                     return Err(Error::InvalidStreamId);
                 }
 
-                if let Some(stream) = self.send_streams.get_mut(&stop.id) {
-                    stream.inbound_stopped.send(stop).ok();
+                if let Some(send) = self.streams.lock().unwrap().send.get(&stop.id) {
+                    send.inbound_stopped.send(stop).ok();
                 }
             }
             Frame::ConnectionClose(close) => {
@@ -607,7 +727,7 @@ impl<T: Transport> SessionState<T> {
                 self.conn_send_credit.increase_max(max)?;
             }
             Frame::MaxStreamData { id, max } => {
-                if let Some(send) = self.send_streams.get(&id) {
+                if let Some(send) = self.streams.lock().unwrap().send.get(&id) {
                     if let Some(credit) = &send.stream_credit {
                         credit.increase_max(max)?;
                     }
@@ -634,7 +754,7 @@ impl<T: Transport> SessionState<T> {
                         sequence: ping.sequence,
                         response: true,
                     });
-                    self.outbound_priority.0.send(response).ok();
+                    self.control.send(response).ok();
                 }
             }
             // DATAGRAM: fan out to the receive channel. `max_datagram_frame_size`
@@ -701,7 +821,7 @@ impl<T: Transport> SessionState<T> {
             .ok();
 
         // Update per-stream send credits for already-opened streams
-        for (id, send) in &self.send_streams {
+        for (id, send) in &self.streams.lock().unwrap().send {
             if let Some(credit) = &send.stream_credit {
                 let initial = match id.dir() {
                     StreamDir::Bi => {
@@ -718,6 +838,24 @@ impl<T: Transport> SessionState<T> {
                 credit.increase_max(initial).ok();
             }
         }
+
+        // Publish the two scalars the writer task needs, now that they're known:
+        // the outbound record-size limit (QMux01 only) and the effective idle
+        // timeout for its keep-alive ping. `record_limit` was seeded with the
+        // draft-01 default; raise it to the peer's advertised size.
+        let idle_ms = if self.config.version == Version::QMux01 {
+            self.record_limit
+                .store(params.max_record_size, Ordering::Release);
+            // Same rule as `effective_idle_timeout_ms`: min of the non-zero values.
+            match (self.our_params.max_idle_timeout, params.max_idle_timeout) {
+                (0, 0) => 0,
+                (a, 0) | (0, a) => a,
+                (a, b) => a.min(b),
+            }
+        } else {
+            0
+        };
+        self.idle_timeout_ms.store(idle_ms, Ordering::Release);
 
         // Resolve the datagram send limit. Datagrams are a QMux01-only feature
         // (they rely on the record layer for framing), so they stay disabled on
@@ -835,15 +973,56 @@ impl Session {
         let (create_bi_tx, create_bi_rx) = mpsc::channel(8);
 
         let outbound = PriorityQueue::new(8);
-        let (outbound_priority_tx, outbound_priority_rx) = mpsc::unbounded_channel();
+        // Control lane (lossless): RESET/STOP/CLOSE, window updates, pings, and the
+        // initial TRANSPORT_PARAMETERS. The reader and stream frontends produce;
+        // the writer consumes.
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
 
-        // Bounded, lossy inbound-datagram channel: the backend drops on a full
-        // buffer rather than stalling, matching QUIC's unreliable semantics.
+        // Bounded, lossy datagram channels — drop on a full buffer rather than
+        // stalling, matching QUIC's unreliable semantics. When the writer stalls on
+        // backpressure it stops draining `outbound_datagram`, which fills and makes
+        // `send_datagram` shed.
         let (recv_datagram_tx, recv_datagram_rx) = mpsc::channel(DATAGRAM_RECV_BUFFER);
         let (outbound_datagram_tx, outbound_datagram_rx) = mpsc::channel(DATAGRAM_SEND_BUFFER);
         let datagram_max_size = Arc::new(AtomicUsize::new(0));
 
+        // Shared with the writer task: per-stream backend state, plus the two
+        // scalars the writer needs — the outbound record-size limit (QMux01 seeds
+        // it with the draft-01 default) and the effective idle timeout for its
+        // keep-alive ping (0 until the peer's params arrive).
+        let streams: Arc<Mutex<Streams>> = Arc::new(Mutex::new(Streams::default()));
+        let record_limit = Arc::new(AtomicU64::new(crate::proto::DEFAULT_MAX_RECORD_SIZE));
+        let idle_timeout_ms = Arc::new(AtomicU64::new(0));
+
         let closed = watch::Sender::new(None);
+
+        // The QMux handshake requires TRANSPORT_PARAMETERS as the first frame. It
+        // leads the FIFO control lane, so the writer emits it before anything else.
+        if version.is_qmux() {
+            control_tx
+                .send(Frame::TransportParameters(our_params.clone()))
+                .ok();
+        }
+
+        // Split the transport into halves driven by two tasks: a write blocked on
+        // backpressure must never stall reads. The writer is the sole producer on
+        // the wire, pulling the outbound queues in priority order and sharing the
+        // stream maps + scalars above with the reader (no message-passing handoff).
+        let (writer_half, reader_half) = transport.split();
+        let mut writer = WriterState {
+            writer: writer_half,
+            version,
+            control: control_rx,
+            datagrams: outbound_datagram_rx,
+            outbound: outbound.clone(),
+            streams: streams.clone(),
+            record_limit: record_limit.clone(),
+            idle_timeout_ms: idle_timeout_ms.clone(),
+            closed: closed.clone(),
+            last_send_at: tokio::time::Instant::now(),
+            next_ping_seq: 0,
+        };
+        tokio::spawn(async move { writer.run().await });
 
         // Protocol negotiation. Only `Negotiate` resolves in-band (once the
         // peer's params arrive); the out-of-band cases resolve immediately.
@@ -887,17 +1066,16 @@ impl Session {
         });
 
         let mut backend = SessionState {
-            transport,
+            reader: reader_half,
             config: config.clone(),
+            is_server,
             outbound: outbound.clone(),
-            outbound_priority: (outbound_priority_tx.clone(), outbound_priority_rx),
+            control: control_tx.clone(),
             accept_bi: accept_bi_tx,
             accept_uni: accept_uni_tx,
             create_uni: create_uni_rx,
             create_bi: create_bi_rx,
-            is_server,
-            send_streams: HashMap::new(),
-            recv_streams: HashMap::new(),
+            streams: streams.clone(),
             closed: closed.clone(),
             negotiated: negotiated.clone(),
             established: established_tx,
@@ -913,11 +1091,10 @@ impl Session {
             recv_open_bi: RecvOpen::default(),
             recv_open_uni: RecvOpen::default(),
             last_recv_at: tokio::time::Instant::now(),
-            last_send_at: tokio::time::Instant::now(),
-            next_ping_seq: 0,
             recv_datagram: recv_datagram_tx,
             datagram_max_size: datagram_max_size.clone(),
-            outbound_datagram: outbound_datagram_rx,
+            record_limit: record_limit.clone(),
+            idle_timeout_ms: idle_timeout_ms.clone(),
         };
         tokio::spawn(async move {
             let err = backend.run().await.err().unwrap_or(Error::Closed);
@@ -931,7 +1108,7 @@ impl Session {
             backend.conn_send_credit.close();
             backend.conn_recv_credit.close();
             backend.outbound.close();
-            for send in backend.send_streams.values() {
+            for send in backend.streams.lock().unwrap().send.values() {
                 if let Some(credit) = &send.stream_credit {
                     credit.close();
                 }
@@ -944,11 +1121,16 @@ impl Session {
             backend.closed.send_replace(Some(err));
         });
 
+        // Closes the connection once every `Session` clone has dropped.
+        let guard = Arc::new(SessionGuard {
+            closed: closed.clone(),
+        });
+
         Session {
             is_server,
             config,
             outbound,
-            outbound_priority: outbound_priority_tx,
+            outbound_priority: control_tx,
             accept_bi: Arc::new(tokio::sync::Mutex::new(accept_bi_rx)),
             accept_uni: Arc::new(tokio::sync::Mutex::new(accept_uni_rx)),
             create_uni: create_uni_tx,
@@ -963,6 +1145,7 @@ impl Session {
             recv_datagram: Arc::new(tokio::sync::Mutex::new(recv_datagram_rx)),
             datagram_max_size,
             outbound_datagram: outbound_datagram_tx,
+            _guard: guard,
         }
     }
 }
@@ -1137,10 +1320,11 @@ impl generic::Session for Session {
             return Err(Error::FrameTooLarge);
         }
         // Best-effort and synchronous, matching the trait's fire-and-forget
-        // contract. A full buffer means the transport is backpressured: drop the
-        // datagram (returning `Ok`) rather than block or grow without bound — an
-        // unreliable datagram is meant to be droppable. A closed session (the
-        // receiver is gone) surfaces as `Closed`.
+        // contract. When the writer stalls on transport backpressure it stops
+        // draining this lane, so a full lane *is* the backpressure signal: shed the
+        // datagram (returning `Ok` — an unreliable datagram is meant to be
+        // droppable) rather than block or grow without bound. A closed lane means
+        // the session is gone.
         match self.outbound_datagram.try_send(payload) {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => Ok(()),
@@ -1636,7 +1820,7 @@ mod recv_open_tests {
 
     use web_transport_proto::VarInt;
 
-    use super::{Session, Transport};
+    use super::{Session, Transport, TransportReader, TransportWriter};
     use crate::proto::{Frame, ResetStream, Stream};
     use crate::{Config, Error, StreamDir, StreamId, Version};
 
@@ -1648,20 +1832,42 @@ mod recv_open_tests {
         incoming: mpsc::UnboundedReceiver<Bytes>,
     }
 
+    struct ScriptedWriter;
+
+    struct ScriptedReader {
+        incoming: mpsc::UnboundedReceiver<Bytes>,
+    }
+
     impl Transport for ScriptedTransport {
+        type Writer = ScriptedWriter;
+        type Reader = ScriptedReader;
+
+        fn split(self) -> (ScriptedWriter, ScriptedReader) {
+            (
+                ScriptedWriter,
+                ScriptedReader {
+                    incoming: self.incoming,
+                },
+            )
+        }
+    }
+
+    impl TransportWriter for ScriptedWriter {
         async fn send(&mut self, _data: Bytes) -> Result<(), Error> {
             Ok(())
         }
 
+        async fn close(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    impl TransportReader for ScriptedReader {
         async fn recv(&mut self) -> Result<Bytes, Error> {
             match self.incoming.recv().await {
                 Some(bytes) => Ok(bytes),
                 None => std::future::pending().await,
             }
-        }
-
-        async fn close(&mut self) -> Result<(), Error> {
-            Ok(())
         }
     }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex, OnceLock,
     },
 };
@@ -251,6 +251,19 @@ struct SessionState<R: TransportReader> {
     // writer. Both are written once, when the peer's transport parameters arrive.
     record_limit: Arc<AtomicU64>,
     idle_timeout_ms: Arc<AtomicU64>,
+
+    // Set by the writer while a `send` is in flight (see `WriterState`). The reader
+    // consults it before firing the idle timeout, so transport backpressure isn't
+    // mistaken for a dead peer.
+    writer_backpressured: Arc<AtomicBool>,
+
+    // When the reader started deferring the idle timeout because the writer was
+    // backpressured, or `None` if it isn't currently deferring. Bounds the deferral:
+    // backpressure buys the connection at most one extra idle window before it's
+    // reclaimed anyway, so a peer that dies with our send buffer full is still
+    // idle-closed (just later) rather than hanging until the transport times out.
+    // Reset on any receive.
+    backpressure_suppressed_since: Option<tokio::time::Instant>,
 }
 
 /// Pick the next outbound frame in strict priority order: control (lossless,
@@ -275,6 +288,18 @@ async fn next_outbound(
     }
 }
 
+/// RFC 9000 §10.1 effective idle timeout in ms: the smaller of the two advertised
+/// values, ignoring a zero (disabled) side. Returns 0 when both are disabled.
+/// Shared by the reader's idle deadline and the writer's keep-alive cadence so the
+/// two never drift.
+fn negotiated_idle_timeout_ms(ours: u64, peer: u64) -> u64 {
+    match (ours, peer) {
+        (0, 0) => 0,
+        (a, 0) | (0, a) => a,
+        (a, b) => a.min(b),
+    }
+}
+
 /// Writer-side task state: owns the transport send half and is the sole producer
 /// on the wire. It pulls the outbound queues in strict priority order via
 /// [`next_outbound`], retires the stream a terminal frame closes and encodes it
@@ -293,6 +318,11 @@ struct WriterState<W: TransportWriter> {
     streams: Arc<Mutex<Streams>>,
     record_limit: Arc<AtomicU64>,
     idle_timeout_ms: Arc<AtomicU64>,
+
+    // Set while a `send` is in flight so the reader can tell a wedged-on-
+    // backpressure connection (peer alive, its recv window full) apart from a
+    // genuinely dead one, and not idle-close the former. See `transmit`.
+    writer_backpressured: Arc<AtomicBool>,
 
     closed: watch::Sender<Option<Error>>,
 
@@ -399,7 +429,15 @@ impl<W: TransportWriter> WriterState<W> {
                 return Err(Error::FrameTooLarge);
             }
         }
-        self.writer.send(bytes).await?;
+        // Flag the in-flight write so the reader won't idle-close a connection
+        // that's merely backpressured: a `send` stuck here proves the peer is
+        // still there (its receive window is just full). Cleared as soon as the
+        // write lands. Only the session idle timeout consults this — a WebSocket
+        // transport's own keep-alive deadline is independent.
+        self.writer_backpressured.store(true, Ordering::Release);
+        let result = self.writer.send(bytes).await;
+        self.writer_backpressured.store(false, Ordering::Release);
+        result?;
         self.last_send_at = tokio::time::Instant::now();
         Ok(())
     }
@@ -422,6 +460,8 @@ impl<R: TransportReader> SessionState<R> {
                 result = self.reader.recv() => {
                     let data = result?;
                     self.last_recv_at = tokio::time::Instant::now();
+                    // Real progress ends any backpressure deferral window.
+                    self.backpressure_suppressed_since = None;
                     if self.config.version == Version::QMux01 {
                         // QMux01: data is a record containing one or more frames
                         for frame in Frame::decode_record(data)? {
@@ -432,6 +472,33 @@ impl<R: TransportReader> SessionState<R> {
                     }
                 }
                 _ = async { tokio::time::sleep_until(idle_deadline.unwrap()).await }, if idle_deadline.is_some() => {
+                    let now = tokio::time::Instant::now();
+                    // One idle window of grace (the deadline is armed, so this is Some).
+                    let grace = std::time::Duration::from_millis(
+                        self.effective_idle_timeout_ms().unwrap_or(0),
+                    );
+                    match self.backpressure_suppressed_since {
+                        // Already deferring: keep the connection alive until the grace
+                        // window elapses, then reclaim it even if still backpressured —
+                        // a peer that died with our send buffer full must not hang here.
+                        Some(since) if now.duration_since(since) < grace => {
+                            self.last_recv_at = now; // re-arm the deadline; avoid a busy spin
+                            continue;
+                        }
+                        // Grace exhausted — fall through and idle-close.
+                        Some(_) => {}
+                        None => {
+                            if self.writer_backpressured.load(Ordering::Acquire) {
+                                // Writer wedged on transport backpressure: the peer's
+                                // receive window is full, which is evidence it's alive
+                                // and that we simply can't get a keep-alive out. Defer
+                                // the close, but only for the bounded grace above.
+                                self.backpressure_suppressed_since = Some(now);
+                                self.last_recv_at = now;
+                                continue;
+                            }
+                        }
+                    }
                     tracing::debug!("idle timeout fired");
                     return Err(Error::IdleTimeout);
                 }
@@ -451,13 +518,12 @@ impl<R: TransportReader> SessionState<R> {
         if self.config.version != Version::QMux01 || !self.params_received {
             return None;
         }
-        match (
+        match negotiated_idle_timeout_ms(
             self.our_params.max_idle_timeout,
             self.peer_params.max_idle_timeout,
         ) {
-            (0, 0) => None,
-            (a, 0) | (0, a) => Some(a),
-            (a, b) => Some(a.min(b)),
+            0 => None,
+            ms => Some(ms),
         }
     }
 
@@ -850,12 +916,7 @@ impl<R: TransportReader> SessionState<R> {
         let idle_ms = if self.config.version == Version::QMux01 {
             self.record_limit
                 .store(params.max_record_size, Ordering::Release);
-            // Same rule as `effective_idle_timeout_ms`: min of the non-zero values.
-            match (self.our_params.max_idle_timeout, params.max_idle_timeout) {
-                (0, 0) => 0,
-                (a, 0) | (0, a) => a,
-                (a, b) => a.min(b),
-            }
+            negotiated_idle_timeout_ms(self.our_params.max_idle_timeout, params.max_idle_timeout)
         } else {
             0
         };
@@ -994,6 +1055,9 @@ impl Session {
         let streams: Arc<Mutex<Streams>> = Arc::new(Mutex::new(Streams::default()));
         let record_limit = Arc::new(AtomicU64::new(crate::proto::DEFAULT_MAX_RECORD_SIZE));
         let idle_timeout_ms = Arc::new(AtomicU64::new(0));
+        // True while the writer is blocked in a `send`; lets the reader distinguish
+        // transport backpressure from a dead peer when the idle timeout fires.
+        let writer_backpressured = Arc::new(AtomicBool::new(false));
 
         let closed = watch::Sender::new(None);
 
@@ -1019,6 +1083,7 @@ impl Session {
             streams: streams.clone(),
             record_limit: record_limit.clone(),
             idle_timeout_ms: idle_timeout_ms.clone(),
+            writer_backpressured: writer_backpressured.clone(),
             closed: closed.clone(),
             last_send_at: tokio::time::Instant::now(),
             next_ping_seq: 0,
@@ -1094,6 +1159,8 @@ impl Session {
             datagram_max_size: datagram_max_size.clone(),
             record_limit: record_limit.clone(),
             idle_timeout_ms: idle_timeout_ms.clone(),
+            writer_backpressured,
+            backpressure_suppressed_since: None,
         };
         tokio::spawn(async move {
             let err = backend.run().await.err().unwrap_or(Error::Closed);

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -39,6 +39,17 @@ const DATAGRAM_SEND_BUFFER: usize = 64;
 struct Streams {
     send: HashMap<StreamId, SendState>,
     recv: HashMap<StreamId, RecvState>,
+
+    // The peer's initial per-stream send-credit limits, applied to the streams
+    // we open. Zero until the peer's transport parameters arrive;
+    // `recv_transport_parameters` publishes them here under this lock, and
+    // `open_uni`/`open_bi` seed a freshly opened stream's credit from them under
+    // the same lock. That serialization credits a stream opened concurrently with
+    // the handshake exactly once — either here at open time, or by the params
+    // handler when it walks the map (whichever takes the lock second sees the
+    // other's effect).
+    peer_initial_max_stream_data_uni: u64,
+    peer_initial_max_stream_data_bidi_remote: u64,
 }
 
 /// Closes the connection once the last [`Session`] handle is dropped. Held in an
@@ -75,8 +86,12 @@ pub struct Session {
     accept_bi: Arc<tokio::sync::Mutex<mpsc::Receiver<(SendStream, RecvStream)>>>,
     accept_uni: Arc<tokio::sync::Mutex<mpsc::Receiver<RecvStream>>>,
 
-    create_uni: mpsc::Sender<(StreamId, SendState)>,
-    create_bi: mpsc::Sender<(StreamId, SendState, RecvState)>,
+    // Shared per-stream backend state (with the reader and writer tasks). The
+    // frontend registers the streams it opens directly under this lock — see
+    // `open_uni`/`open_bi` — rather than handing them to the reader over a
+    // channel, so the backend exists before the returned stream can enqueue a
+    // frame (no open-vs-writer race) and there's no message-passing hop.
+    streams: Arc<Mutex<Streams>>,
 
     closed: watch::Sender<Option<Error>>,
 
@@ -191,10 +206,8 @@ struct SessionState<R: TransportReader> {
     accept_bi: mpsc::Sender<(SendStream, RecvStream)>,
     accept_uni: mpsc::Sender<RecvStream>,
 
-    create_uni: mpsc::Receiver<(StreamId, SendState)>,
-    create_bi: mpsc::Receiver<(StreamId, SendState, RecvState)>,
-
-    // Shared per-stream backend state (with the writer task).
+    // Shared per-stream backend state (with the frontend and writer). The
+    // frontend inserts streams it opens; the reader inserts peer-initiated ones.
     streams: Arc<Mutex<Streams>>,
 
     closed: watch::Sender<Option<Error>>,
@@ -417,25 +430,6 @@ impl<R: TransportReader> SessionState<R> {
                     } else if let Some(frame) = Frame::decode(data, self.config.version)? {
                         self.recv_frame(frame).await?;
                     }
-                }
-                Some((id, send)) = self.create_uni.recv() => {
-                    // Apply peer's stream credit if transport params already received
-                    if self.params_received {
-                        if let Some(credit) = &send.stream_credit {
-                            credit.increase_max(self.peer_params.initial_max_stream_data_uni).ok();
-                        }
-                    }
-                    self.streams.lock().unwrap().send.insert(id, send);
-                }
-                Some((id, send, recv)) = self.create_bi.recv() => {
-                    if self.params_received {
-                        if let Some(credit) = &send.stream_credit {
-                            credit.increase_max(self.peer_params.initial_max_stream_data_bidi_remote).ok();
-                        }
-                    }
-                    let mut streams = self.streams.lock().unwrap();
-                    streams.send.insert(id, send);
-                    streams.recv.insert(id, recv);
                 }
                 _ = async { tokio::time::sleep_until(idle_deadline.unwrap()).await }, if idle_deadline.is_some() => {
                     tracing::debug!("idle timeout fired");
@@ -820,22 +814,32 @@ impl<R: TransportReader> SessionState<R> {
             .increase_max(params.initial_max_streams_uni)
             .ok();
 
-        // Update per-stream send credits for already-opened streams
-        for (id, send) in &self.streams.lock().unwrap().send {
-            if let Some(credit) = &send.stream_credit {
-                let initial = match id.dir() {
-                    StreamDir::Bi => {
-                        if id.server_initiated() == self.is_server {
-                            // We initiated this stream — peer's bidi_remote applies
-                            params.initial_max_stream_data_bidi_remote
-                        } else {
-                            // Peer initiated this stream — peer's bidi_local applies
-                            params.initial_max_stream_data_bidi_local
+        // Publish the peer's initial per-stream send limits and credit the streams
+        // we've already opened — both under one lock, so a stream being opened
+        // concurrently is credited exactly once: either it's already in the map and
+        // this walk credits it, or it's not yet inserted and `open_uni`/`open_bi`
+        // reads the values we just published and credits itself.
+        {
+            let mut streams = self.streams.lock().unwrap();
+            streams.peer_initial_max_stream_data_uni = params.initial_max_stream_data_uni;
+            streams.peer_initial_max_stream_data_bidi_remote =
+                params.initial_max_stream_data_bidi_remote;
+            for (id, send) in &streams.send {
+                if let Some(credit) = &send.stream_credit {
+                    let initial = match id.dir() {
+                        StreamDir::Bi => {
+                            if id.server_initiated() == self.is_server {
+                                // We initiated this stream — peer's bidi_remote applies
+                                params.initial_max_stream_data_bidi_remote
+                            } else {
+                                // Peer initiated this stream — peer's bidi_local applies
+                                params.initial_max_stream_data_bidi_local
+                            }
                         }
-                    }
-                    StreamDir::Uni => params.initial_max_stream_data_uni,
-                };
-                credit.increase_max(initial).ok();
+                        StreamDir::Uni => params.initial_max_stream_data_uni,
+                    };
+                    credit.increase_max(initial).ok();
+                }
             }
         }
 
@@ -969,9 +973,6 @@ impl Session {
         let (accept_bi_tx, accept_bi_rx) = mpsc::channel(1024);
         let (accept_uni_tx, accept_uni_rx) = mpsc::channel(1024);
 
-        let (create_uni_tx, create_uni_rx) = mpsc::channel(8);
-        let (create_bi_tx, create_bi_rx) = mpsc::channel(8);
-
         let outbound = PriorityQueue::new(8);
         // Control lane (lossless): RESET/STOP/CLOSE, window updates, pings, and the
         // initial TRANSPORT_PARAMETERS. The reader and stream frontends produce;
@@ -1073,8 +1074,6 @@ impl Session {
             control: control_tx.clone(),
             accept_bi: accept_bi_tx,
             accept_uni: accept_uni_tx,
-            create_uni: create_uni_rx,
-            create_bi: create_bi_rx,
             streams: streams.clone(),
             closed: closed.clone(),
             negotiated: negotiated.clone(),
@@ -1133,8 +1132,7 @@ impl Session {
             outbound_priority: control_tx,
             accept_bi: Arc::new(tokio::sync::Mutex::new(accept_bi_rx)),
             accept_uni: Arc::new(tokio::sync::Mutex::new(accept_uni_rx)),
-            create_uni: create_uni_tx,
-            create_bi: create_bi_tx,
+            streams,
             closed,
             negotiated,
             established: established_rx,
@@ -1208,10 +1206,20 @@ impl generic::Session for Session {
             },
         };
 
-        self.create_uni
-            .send((id, send_backend))
-            .await
-            .map_err(|_| Error::Closed)?;
+        // Register the backend before returning the frontend, so the stream exists
+        // in the shared map before it can enqueue a frame. Seed its send credit
+        // from the peer's params if they've already arrived (otherwise it's still
+        // zero here and `recv_transport_parameters` will credit it later) — see the
+        // note on `Streams::peer_initial_max_stream_data_uni`.
+        {
+            let mut streams = self.streams.lock().unwrap();
+            if let Some(credit) = &send_backend.stream_credit {
+                credit
+                    .increase_max(streams.peer_initial_max_stream_data_uni)
+                    .ok();
+            }
+            streams.send.insert(id, send_backend);
+        }
 
         Ok(send_frontend)
     }
@@ -1278,10 +1286,18 @@ impl generic::Session for Session {
             recv_streams_credit: None, // We initiated this stream, no stream count tracking
         };
 
-        self.create_bi
-            .send((id, send_backend, recv_backend))
-            .await
-            .map_err(|_| Error::Closed)?;
+        // Register both backends before returning the frontends (see `open_uni`).
+        // A bidi stream we initiate sends under the peer's `bidi_remote` limit.
+        {
+            let mut streams = self.streams.lock().unwrap();
+            if let Some(credit) = &send_backend.stream_credit {
+                credit
+                    .increase_max(streams.peer_initial_max_stream_data_bidi_remote)
+                    .ok();
+            }
+            streams.send.insert(id, send_backend);
+            streams.recv.insert(id, recv_backend);
+        }
 
         Ok((send_frontend, recv_frontend))
     }

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -7,15 +7,44 @@ use crate::Error;
 /// Each `send`/`recv` operates on a single complete message (frame).
 /// For WebSocket, this maps to individual WS binary messages.
 /// For TCP/TLS byte streams, the transport handles frame delimiting.
+///
+/// A transport splits into independently-owned send and receive halves so the
+/// session can drive them on separate tasks: a write blocked on transport
+/// backpressure must never stall reads (and vice versa). This decoupling is what
+/// lets the session observe backpressure and shed unreliable datagrams instead
+/// of buffering them behind a stalled socket.
 pub trait Transport: Send + 'static {
-    /// Send a message.
-    fn send(&mut self, data: Bytes) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    /// The independently-owned send half.
+    type Writer: TransportWriter;
+    /// The independently-owned receive half.
+    type Reader: TransportReader;
 
-    /// Receive the next complete message.
-    fn recv(&mut self) -> impl std::future::Future<Output = Result<Bytes, Error>> + Send;
+    /// Split into send and receive halves.
+    fn split(self) -> (Self::Writer, Self::Reader);
+}
+
+/// The send half of a [`Transport`].
+pub trait TransportWriter: Send + 'static {
+    /// Send a single complete message.
+    fn send(&mut self, data: Bytes) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
     /// Gracefully close the transport.
     fn close(&mut self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+    /// Perform any timer-driven background work and resolve once it's done. The
+    /// session's writer loop selects on this alongside outbound frames, so a
+    /// transport can piggy-back periodic maintenance (e.g. a WebSocket keep-alive
+    /// Ping) on the same task that owns the send half. The default never
+    /// resolves — transports with nothing to do (TCP, Unix sockets) use it as-is.
+    fn maintain(&mut self) -> impl std::future::Future<Output = Result<(), Error>> + Send {
+        std::future::pending()
+    }
+}
+
+/// The receive half of a [`Transport`].
+pub trait TransportReader: Send + 'static {
+    /// Receive the next complete message.
+    fn recv(&mut self) -> impl std::future::Future<Output = Result<Bytes, Error>> + Send;
 }
 
 // Stream: message I/O over a byte stream (TCP/TLS/Unix).
@@ -35,7 +64,7 @@ mod stream_transport {
     use tokio::task::JoinHandle;
     use web_transport_proto::VarInt;
 
-    use super::Transport;
+    use super::{Transport, TransportReader, TransportWriter};
     use crate::{Error, Version, MAX_FRAME_PAYLOAD, MAX_FRAME_SIZE};
 
     /// Bound on queued frames waiting for the session to drain them. Bytes the
@@ -64,9 +93,20 @@ mod stream_transport {
     /// # }
     /// ```
     pub struct Stream<T> {
-        rx: mpsc::Receiver<Result<Bytes, Error>>,
+        writer: StreamWriter<T>,
+        reader: StreamReader,
+    }
+
+    /// The send half of a byte-stream [`Stream`].
+    pub struct StreamWriter<T> {
         writer: BufWriter<tokio::io::WriteHalf<T>>,
         version: Version,
+    }
+
+    /// The receive half of a byte-stream [`Stream`]. Owns the reader task's
+    /// abort handle so the task can't outlive the receive half.
+    pub struct StreamReader {
+        rx: mpsc::Receiver<Result<Bytes, Error>>,
         /// Aborted on drop so the reader task can't outlive the transport.
         reader_task: JoinHandle<()>,
     }
@@ -87,15 +127,25 @@ mod stream_transport {
                 tx,
             ));
             Self {
-                rx,
-                writer: BufWriter::new(write),
-                version,
-                reader_task,
+                writer: StreamWriter {
+                    writer: BufWriter::new(write),
+                    version,
+                },
+                reader: StreamReader { rx, reader_task },
             }
         }
     }
 
-    impl<T> Drop for Stream<T> {
+    impl<T: AsyncRead + AsyncWrite + Send + 'static> Transport for Stream<T> {
+        type Writer = StreamWriter<T>;
+        type Reader = StreamReader;
+
+        fn split(self) -> (StreamWriter<T>, StreamReader) {
+            (self.writer, self.reader)
+        }
+    }
+
+    impl Drop for StreamReader {
         fn drop(&mut self) {
             // Make sure the reader task doesn't outlive the transport; otherwise
             // it would hold the read half open until the connection drops.
@@ -103,7 +153,7 @@ mod stream_transport {
         }
     }
 
-    impl<T: AsyncRead + AsyncWrite + Send + 'static> Transport for Stream<T> {
+    impl<T: AsyncWrite + Send + 'static> TransportWriter for StreamWriter<T> {
         async fn send(&mut self, data: Bytes) -> Result<(), Error> {
             // QMux01 frames travel inside size-prefixed records on byte streams.
             // (Records are implicit on WebSocket, where the message boundary delimits them.)
@@ -117,16 +167,18 @@ mod stream_transport {
             Ok(())
         }
 
+        async fn close(&mut self) -> Result<(), Error> {
+            self.writer.shutdown().await?;
+            Ok(())
+        }
+    }
+
+    impl TransportReader for StreamReader {
         async fn recv(&mut self) -> Result<Bytes, Error> {
             // mpsc::Receiver::recv is cancel safe, so dropping this future never
             // loses a buffered frame. `None` means the reader task exited without
             // sending — treat as a clean close.
             self.rx.recv().await.unwrap_or(Err(Error::Closed))
-        }
-
-        async fn close(&mut self) -> Result<(), Error> {
-            self.writer.shutdown().await?;
-            Ok(())
         }
     }
 
@@ -349,6 +401,7 @@ mod stream_transport {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::transport::{Transport, TransportReader};
         use tokio::io::AsyncWriteExt;
 
         // Drip a frame in one byte at a time, racing each `recv` against an
@@ -358,7 +411,7 @@ mod stream_transport {
         #[tokio::test]
         async fn recv_is_cancel_safe_across_partial_writes() {
             let (client, mut server) = tokio::io::duplex(64 * 1024);
-            let mut transport = Stream::new(client, Version::QMux00, 16 * 1024);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux00, 16 * 1024).split();
 
             // STREAM frame, type 0x0a (len bit set), id=4, length=5, payload="hello".
             let mut frame = Vec::new();
@@ -386,7 +439,7 @@ mod stream_transport {
         #[tokio::test]
         async fn recv_qmux01_record_is_cancel_safe() {
             let (client, mut server) = tokio::io::duplex(64 * 1024);
-            let mut transport = Stream::new(client, Version::QMux01, 16 * 1024);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux01, 16 * 1024).split();
 
             // 1-byte varint length (0x08) followed by 8 bytes of payload.
             let mut record = vec![0x08];
@@ -414,7 +467,7 @@ mod stream_transport {
         #[tokio::test]
         async fn recv_returns_consecutive_frames_in_order() {
             let (client, mut server) = tokio::io::duplex(64 * 1024);
-            let mut transport = Stream::new(client, Version::QMux00, 16 * 1024);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux00, 16 * 1024).split();
 
             // Two STREAM frames (type 0x0a) for stream ids 4 and 8.
             let frame_a: Vec<u8> = [0x0a, 0x04, 0x05].into_iter().chain(*b"hello").collect();
@@ -436,7 +489,7 @@ mod stream_transport {
         #[tokio::test]
         async fn recv_propagates_parse_error_then_closes() {
             let (client, mut server) = tokio::io::duplex(64 * 1024);
-            let mut transport = Stream::new(client, Version::QMux00, 16 * 1024);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux00, 16 * 1024).split();
 
             // Frame type 0x02 isn't a recognized QMux00 frame type.
             server.write_all(&[0x02]).await.unwrap();
@@ -456,7 +509,7 @@ mod stream_transport {
         #[tokio::test]
         async fn recv_record_exceeding_max_returns_frame_too_large() {
             let (client, mut server) = tokio::io::duplex(64 * 1024);
-            let mut transport = Stream::new(client, Version::QMux01, 4);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux01, 4).split();
 
             // 1-byte varint length = 5, which exceeds the configured max of 4.
             server.write_all(&[0x05]).await.unwrap();
@@ -469,7 +522,7 @@ mod stream_transport {
 }
 
 #[cfg(any(feature = "tcp", all(unix, feature = "uds")))]
-pub use stream_transport::Stream;
+pub use stream_transport::{Stream, StreamReader, StreamWriter};
 
 // Shared plumbing for the byte-stream transports (TCP, Unix sockets).
 #[cfg(any(feature = "tcp", all(unix, feature = "uds")))]
@@ -511,44 +564,86 @@ mod ws_transport {
     use std::time::Duration;
 
     use bytes::Bytes;
+    use futures::stream::{SplitSink, SplitStream};
     use tokio::time::{Instant, Interval, MissedTickBehavior, Sleep};
     use tokio_tungstenite::tungstenite;
 
-    use super::Transport;
+    use super::{Transport, TransportReader, TransportWriter};
     use crate::ws::KeepAlive;
     use crate::Error;
 
+    type Message = tungstenite::Message;
+
+    /// The combined `Stream + Sink` bound every WebSocket half requires.
+    pub(crate) trait WsStream:
+        futures::Stream<Item = Result<Message, tungstenite::Error>>
+        + futures::Sink<Message, Error = tungstenite::Error>
+        + Unpin
+        + Send
+        + 'static
+    {
+    }
+    impl<T> WsStream for T where
+        T: futures::Stream<Item = Result<Message, tungstenite::Error>>
+            + futures::Sink<Message, Error = tungstenite::Error>
+            + Unpin
+            + Send
+            + 'static
+    {
+    }
+
     pub(crate) struct WsTransport<T> {
         ws: T,
-        keep_alive: Option<KeepAliveState>,
+        keep_alive: Option<KeepAlive>,
     }
 
-    struct KeepAliveState {
-        // Fires on each interval; we send a Ping when it does.
+    impl<T> WsTransport<T> {
+        pub fn new(ws: T) -> Self {
+            Self {
+                ws,
+                keep_alive: None,
+            }
+        }
+
+        pub fn with_keep_alive(mut self, keep_alive: KeepAlive) -> Self {
+            self.keep_alive = Some(keep_alive);
+            self
+        }
+    }
+
+    /// Writer-side keep-alive: emit a Ping every `interval`.
+    struct PingState {
+        // Fires on each interval; the writer sends a Ping when it does.
         interval: Interval,
-
-        // Resets every time we receive a frame. If it elapses, the peer is gone.
-        deadline: Pin<Box<Sleep>>,
-
-        timeout: Duration,
     }
 
-    impl KeepAliveState {
+    impl PingState {
         fn new(config: KeepAlive) -> Self {
-            // tokio::time::interval panics on a zero Duration, and a deadline shorter than the
-            // interval would fire before the first ping. Floor both to 1ms so a misconfigured
-            // KeepAlive degrades into "very chatty" instead of crashing.
+            // tokio::time::interval panics on a zero Duration; floor to 1ms so a
+            // misconfigured KeepAlive degrades into "very chatty" instead of crashing.
             let interval_dur = config.interval.max(Duration::from_millis(1));
-            let timeout = config.timeout.max(interval_dur);
-
             // Skip catch-up bursts after a long pause; we just want one Ping per tick.
             let mut interval = tokio::time::interval(interval_dur);
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             // First tick fires immediately by default; consume it so we don't ping on connect.
             interval.reset();
+            Self { interval }
+        }
+    }
 
+    /// Reader-side keep-alive: close the session if no frame arrives within `timeout`.
+    struct DeadlineState {
+        // Resets every time we receive a frame. If it elapses, the peer is gone.
+        deadline: Pin<Box<Sleep>>,
+        timeout: Duration,
+    }
+
+    impl DeadlineState {
+        fn new(config: KeepAlive) -> Self {
+            let interval_dur = config.interval.max(Duration::from_millis(1));
+            // A deadline shorter than the interval would fire before the first ping.
+            let timeout = config.timeout.max(interval_dur);
             Self {
-                interval,
                 deadline: Box::pin(tokio::time::sleep(timeout)),
                 timeout,
             }
@@ -559,108 +654,117 @@ mod ws_transport {
         }
     }
 
-    impl<T> WsTransport<T>
-    where
-        T: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
-            + futures::Sink<tungstenite::Message, Error = tungstenite::Error>
-            + Unpin
-            + Send
-            + 'static,
-    {
-        pub fn new(ws: T) -> Self {
-            Self {
-                ws,
-                keep_alive: None,
-            }
-        }
+    /// The send half of a [`WsTransport`]: owns the sink and drives keep-alive Pings.
+    pub(crate) struct WsWriter<T: WsStream> {
+        sink: SplitSink<T, Message>,
+        ping: Option<PingState>,
+    }
 
-        pub fn with_keep_alive(mut self, keep_alive: KeepAlive) -> Self {
-            self.keep_alive = Some(KeepAliveState::new(keep_alive));
-            self
+    /// The receive half of a [`WsTransport`]: owns the stream and the idle deadline.
+    pub(crate) struct WsReader<T: WsStream> {
+        stream: SplitStream<T>,
+        deadline: Option<DeadlineState>,
+    }
+
+    impl<T: WsStream> Transport for WsTransport<T> {
+        type Writer = WsWriter<T>;
+        type Reader = WsReader<T>;
+
+        fn split(self) -> (WsWriter<T>, WsReader<T>) {
+            use futures::StreamExt;
+            // BiLock-backed halves: the sink and stream can be polled concurrently
+            // on separate tasks, briefly serializing on the shared socket.
+            let (sink, stream) = self.ws.split();
+            let (ping, deadline) = match self.keep_alive {
+                Some(ka) => (Some(PingState::new(ka)), Some(DeadlineState::new(ka))),
+                None => (None, None),
+            };
+            (WsWriter { sink, ping }, WsReader { stream, deadline })
         }
     }
 
-    impl<T> Transport for WsTransport<T>
-    where
-        T: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
-            + futures::Sink<tungstenite::Message, Error = tungstenite::Error>
-            + Unpin
-            + Send
-            + 'static,
-    {
+    impl<T: WsStream> TransportWriter for WsWriter<T> {
         async fn send(&mut self, data: Bytes) -> Result<(), Error> {
             use futures::SinkExt;
-
-            self.ws
-                .send(tungstenite::Message::Binary(data))
+            self.sink
+                .send(Message::Binary(data))
                 .await
                 .map_err(|_| Error::Closed)?;
             Ok(())
         }
 
-        async fn recv(&mut self) -> Result<Bytes, Error> {
-            use futures::{SinkExt, StreamExt};
+        async fn close(&mut self) -> Result<(), Error> {
+            use futures::SinkExt;
+            self.sink.close().await.map_err(|_| Error::Closed)?;
+            Ok(())
+        }
 
-            // Destructure so we can take separate &mut borrows of `ws` and `keep_alive`.
-            let Self { ws, keep_alive } = self;
+        async fn maintain(&mut self) -> Result<(), Error> {
+            use futures::SinkExt;
+            match &mut self.ping {
+                Some(ping) => {
+                    // Wait for the next interval, then send one keep-alive Ping. The
+                    // session's writer loop re-invokes this each time it resolves, so
+                    // pings keep flowing without a dedicated task. tungstenite's
+                    // auto-queued Pong replies (from the reader) also flush here.
+                    ping.interval.tick().await;
+                    self.sink
+                        .send(Message::Ping(Bytes::new()))
+                        .await
+                        .map_err(|_| Error::Closed)?;
+                    Ok(())
+                }
+                // No keep-alive configured: never resolves, so the writer loop's
+                // select simply ignores this branch.
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    impl<T: WsStream> TransportReader for WsReader<T> {
+        async fn recv(&mut self) -> Result<Bytes, Error> {
+            use futures::StreamExt;
+
+            // Destructure so we can take separate &mut borrows of `stream` and `deadline`.
+            let Self { stream, deadline } = self;
 
             loop {
                 enum Event<M> {
                     Message(M),
-                    SendPing,
                     Timeout,
                 }
 
-                let event = match keep_alive {
-                    Some(ka) => tokio::select! {
-                        msg = ws.next() => Event::Message(msg),
-                        _ = ka.interval.tick() => Event::SendPing,
-                        _ = ka.deadline.as_mut() => Event::Timeout,
+                let event = match deadline {
+                    Some(d) => tokio::select! {
+                        msg = stream.next() => Event::Message(msg),
+                        _ = d.deadline.as_mut() => Event::Timeout,
                     },
-                    None => Event::Message(ws.next().await),
+                    None => Event::Message(stream.next().await),
                 };
 
                 let message = match event {
                     Event::Message(msg) => msg.ok_or(Error::Closed)??,
-                    Event::SendPing => {
-                        ws.send(tungstenite::Message::Ping(Bytes::new()))
-                            .await
-                            .map_err(|_| Error::Closed)?;
-                        continue;
-                    }
                     Event::Timeout => {
                         tracing::debug!("websocket keep_alive timeout");
                         return Err(Error::Closed);
                     }
                 };
 
-                if let Some(ka) = keep_alive.as_mut() {
-                    ka.observe_recv();
+                if let Some(d) = deadline.as_mut() {
+                    d.observe_recv();
                 }
 
                 match message {
-                    tungstenite::Message::Binary(data) => {
-                        return Ok(data);
-                    }
-                    tungstenite::Message::Close(_) => {
-                        return Err(Error::Closed);
-                    }
-                    tungstenite::Message::Ping(_)
-                    | tungstenite::Message::Pong(_)
-                    | tungstenite::Message::Text(_)
-                    | tungstenite::Message::Frame(_) => {
+                    Message::Binary(data) => return Ok(data),
+                    Message::Close(_) => return Err(Error::Closed),
+                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {
                         // tungstenite auto-queues a Pong reply when it reads a Ping;
-                        // it gets flushed on our next send/read. No manual reply needed.
+                        // the writer half flushes it on its next send/ping. The reader
+                        // owns no sink, so there's nothing to reply with here.
                         continue;
                     }
                 }
             }
-        }
-
-        async fn close(&mut self) -> Result<(), Error> {
-            use futures::SinkExt;
-            self.ws.close().await.map_err(|_| Error::Closed)?;
-            Ok(())
         }
     }
 }

--- a/rs/qmux/tests/backpressure.rs
+++ b/rs/qmux/tests/backpressure.rs
@@ -1,0 +1,192 @@
+//! Transport-backpressure behavior enabled by the split writer task:
+//!
+//!  - a write stalled on transport backpressure must NOT stall reads
+//!    (head-of-line blocking across directions), and
+//!  - unreliable datagrams must be *shed* the moment the transport backs up,
+//!    rather than buffered behind a stalled socket where they'd arrive stale.
+
+#![cfg(feature = "tcp")]
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use qmux::{Config, Error, Session, Transport, TransportReader, TransportWriter, Version};
+use tokio::sync::{mpsc, watch};
+use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
+
+/// In-memory transport whose writer blocks while a shared gate is closed,
+/// standing in for a socket that has stopped accepting writes. `gate: None`
+/// means "always open" (no backpressure).
+struct GatedTransport {
+    tx: mpsc::Sender<Bytes>,
+    rx: mpsc::Receiver<Bytes>,
+    gate: Option<watch::Receiver<bool>>,
+}
+
+struct GatedWriter {
+    tx: mpsc::Sender<Bytes>,
+    gate: Option<watch::Receiver<bool>>,
+}
+
+struct GatedReader {
+    rx: mpsc::Receiver<Bytes>,
+}
+
+impl Transport for GatedTransport {
+    type Writer = GatedWriter;
+    type Reader = GatedReader;
+
+    fn split(self) -> (GatedWriter, GatedReader) {
+        (
+            GatedWriter {
+                tx: self.tx,
+                gate: self.gate,
+            },
+            GatedReader { rx: self.rx },
+        )
+    }
+}
+
+impl TransportWriter for GatedWriter {
+    async fn send(&mut self, data: Bytes) -> Result<(), Error> {
+        // Block while the gate is closed — the test's stand-in for a full socket.
+        if let Some(gate) = &mut self.gate {
+            gate.wait_for(|&open| open)
+                .await
+                .map_err(|_| Error::Closed)?;
+        }
+        self.tx.send(data).await.map_err(|_| Error::Closed)
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl TransportReader for GatedReader {
+    async fn recv(&mut self) -> Result<Bytes, Error> {
+        self.rx.recv().await.ok_or(Error::Closed)
+    }
+}
+
+/// A client/server pair where only the *client's* writer is gated by `gate`.
+/// The gate is open during construction so the handshake completes.
+async fn pair(gate: watch::Receiver<bool>) -> (Session, Session) {
+    let (c2s_tx, c2s_rx) = mpsc::channel(256);
+    let (s2c_tx, s2c_rx) = mpsc::channel(256);
+
+    let client_transport = GatedTransport {
+        tx: c2s_tx,
+        rx: s2c_rx,
+        gate: Some(gate),
+    };
+    let server_transport = GatedTransport {
+        tx: s2c_tx,
+        rx: c2s_rx,
+        gate: None,
+    };
+
+    let config = Config::new(Version::QMux01);
+    let (client, server) = tokio::join!(
+        Session::connect(client_transport, config.clone()),
+        Session::accept(server_transport, config),
+    );
+    (client.unwrap(), server.unwrap())
+}
+
+/// The core head-of-line-blocking fix: with the client's writer wedged on
+/// transport backpressure, the client must still receive data from the server.
+/// Under the old single-task design the blocked `send().await` also froze the
+/// reader, so this read would hang.
+#[tokio::test]
+async fn reads_are_not_blocked_by_a_stalled_writer() {
+    let (gate_tx, gate_rx) = watch::channel(true); // open: handshake flows
+    let (client, server) = pair(gate_rx).await;
+
+    // Close the gate: the client's writer now blocks on its next send.
+    gate_tx.send(false).unwrap();
+
+    // The client fills its outbound pipeline with a large payload; the writer
+    // task wedges on the gate with the queue full.
+    let client_writer = client.clone();
+    let writer = tokio::spawn(async move {
+        let mut s = client_writer.open_uni().await.unwrap();
+        let _ = s.write(&vec![b'C'; 512 * 1024]).await; // blocks; may error on teardown
+        client_writer // keep the session alive
+    });
+
+    // Give the writer time to fill the pipeline and park on the gate.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !writer.is_finished(),
+        "client writer should be parked on the closed gate"
+    );
+
+    // The server (ungated) sends a stream to the client.
+    let mut ss = server.open_uni().await.unwrap();
+    ss.write(b"hello from server").await.unwrap();
+    ss.finish().unwrap();
+
+    // The client must accept and read it despite its own writer being wedged.
+    let mut rs = tokio::time::timeout(Duration::from_secs(2), client.accept_uni())
+        .await
+        .expect("accept must not be blocked by the stalled writer")
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(2), rs.read_all())
+        .await
+        .expect("read must not be blocked by the stalled writer")
+        .unwrap();
+    assert_eq!(&got[..], b"hello from server");
+
+    // Reopen the gate so the writer can unblock, then clean up.
+    gate_tx.send(true).unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), writer).await;
+}
+
+/// Datagrams enqueued while the transport is backpressured are shed, not
+/// buffered: after releasing the writer, the peer sees far fewer than were sent.
+#[tokio::test]
+async fn datagrams_are_shed_under_backpressure() {
+    let (gate_tx, gate_rx) = watch::channel(true);
+    let (client, server) = pair(gate_rx).await;
+
+    assert!(
+        client.max_datagram_size() > 0,
+        "datagrams must be enabled for this test"
+    );
+
+    // Wedge the client writer, then fill the pipeline with stream data so the
+    // writer channel is provably at zero free capacity.
+    gate_tx.send(false).unwrap();
+    let client_filler = client.clone();
+    let filler = tokio::spawn(async move {
+        let mut s = client_filler.open_uni().await.unwrap();
+        let _ = s.write(&vec![b'F'; 512 * 1024]).await;
+        client_filler
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Every datagram in this burst should be shed: the writer is backpressured.
+    const N: usize = 200;
+    for i in 0..N {
+        client
+            .send_datagram(Bytes::from(vec![i as u8; 8]))
+            .expect("send_datagram is best-effort and must not error when backpressured");
+    }
+
+    // Release the writer and count what actually reaches the server.
+    gate_tx.send(true).unwrap();
+    let mut received = 0usize;
+    while let Ok(Ok(_)) =
+        tokio::time::timeout(Duration::from_millis(200), server.recv_datagram()).await
+    {
+        received += 1;
+    }
+
+    assert!(
+        received < N,
+        "backpressured datagrams must be shed, but {received}/{N} arrived"
+    );
+
+    filler.abort();
+}

--- a/rs/qmux/tests/backpressure.rs
+++ b/rs/qmux/tests/backpressure.rs
@@ -183,10 +183,88 @@ async fn datagrams_are_shed_under_backpressure() {
         received += 1;
     }
 
+    // The outbound datagram lane is 64 deep (DATAGRAM_SEND_BUFFER), so at most
+    // ~64 of the 200 can sit buffered while the writer is wedged; the rest are
+    // shed. Bound the count well under N so a regression that grows the lane or
+    // stops shedding is caught — `received < N` alone would still pass with, say,
+    // a 128-deep buffer.
     assert!(
-        received < N,
-        "backpressured datagrams must be shed, but {received}/{N} arrived"
+        received <= 96,
+        "backpressured datagrams must be shed down to ~the 64-deep lane, but {received}/{N} arrived"
     );
 
     filler.abort();
+}
+
+/// A connection whose writer is wedged on transport backpressure DEFERS its idle
+/// timeout — the wedge proves the peer's receive window is full, so it's alive and
+/// we simply can't get a keep-alive out. But the deferral is *bounded*: a peer that
+/// dies with our send buffer full is still reclaimed within roughly one extra idle
+/// window, instead of hanging until the transport's own (much longer) timeout.
+#[tokio::test]
+async fn idle_timeout_deferred_but_bounded_under_backpressure() {
+    let (c2s_tx, c2s_rx) = mpsc::channel(256);
+    let (s2c_tx, s2c_rx) = mpsc::channel(256);
+    // Keep the client's receive channel open even after the server task goes
+    // away, so the client sees a *silent but open* peer rather than a transport
+    // close. This isolates the client's own idle logic: the server (writer not
+    // gated) will itself idle-close once the wedged client goes quiet.
+    let _s2c_keepalive = s2c_tx.clone();
+
+    let (gate_tx, gate_rx) = watch::channel(true); // open: handshake flows
+    let client_transport = GatedTransport {
+        tx: c2s_tx,
+        rx: s2c_rx,
+        gate: Some(gate_rx),
+    };
+    let server_transport = GatedTransport {
+        tx: s2c_tx,
+        rx: c2s_rx,
+        gate: None,
+    };
+
+    // Short idle timeout so the test is quick; the deferral grace is one more
+    // window, so a stuck-backpressured peer is reclaimed at roughly 2× (~300ms).
+    let mut config = Config::new(Version::QMux01);
+    config.max_idle_timeout = 150;
+    let (client, server) = tokio::join!(
+        Session::connect(client_transport, config.clone()),
+        Session::accept(server_transport, config),
+    );
+    let client = client.unwrap();
+    let _server = server.unwrap();
+
+    // Wedge the client writer: close the gate, then push a write it can't drain.
+    gate_tx.send(false).unwrap();
+    let client_writer = client.clone();
+    let writer = tokio::spawn(async move {
+        let mut s = client_writer.open_uni().await.unwrap();
+        let _ = s.write(&vec![b'X'; 256 * 1024]).await;
+        client_writer
+    });
+
+    // Observe the client's close reason (resolves only once it actually closes).
+    let client_closed = client.clone();
+    let closed = tokio::spawn(async move { client_closed.closed().await });
+
+    // Past the raw 150ms idle window but within the bounded grace: still open.
+    // With no deferral the client would already have idle-closed by now.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        !closed.is_finished(),
+        "idle-close must be deferred while the writer is backpressured (within grace)"
+    );
+
+    // Past the grace: the connection is reclaimed even though still backpressured,
+    // so a peer that died under backpressure can't hang here indefinitely.
+    let reason = tokio::time::timeout(Duration::from_millis(600), closed)
+        .await
+        .expect("bounded deferral must eventually idle-close a stuck-backpressured peer")
+        .unwrap();
+    assert!(
+        matches!(reason, Error::IdleTimeout),
+        "expected IdleTimeout once the grace elapses, got {reason:?}"
+    );
+
+    writer.abort();
 }

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use qmux::{Config, Error, Session, Transport, Version};
+use qmux::{Config, Error, Session, Transport, TransportReader, TransportWriter, Version};
 use tokio::sync::mpsc;
 use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
 
@@ -20,21 +20,49 @@ struct ThrottledTransport {
     delay: Duration,
 }
 
+/// The throttled send half.
+struct ThrottledWriter {
+    tx: mpsc::Sender<Bytes>,
+    delay: Duration,
+}
+
+/// The receive half.
+struct ThrottledReader {
+    rx: mpsc::Receiver<Bytes>,
+}
+
 impl Transport for ThrottledTransport {
+    type Writer = ThrottledWriter;
+    type Reader = ThrottledReader;
+
+    fn split(self) -> (ThrottledWriter, ThrottledReader) {
+        (
+            ThrottledWriter {
+                tx: self.tx,
+                delay: self.delay,
+            },
+            ThrottledReader { rx: self.rx },
+        )
+    }
+}
+
+impl TransportWriter for ThrottledWriter {
     async fn send(&mut self, data: Bytes) -> Result<(), Error> {
         // The delay is what fills the session's outbound priority queue: while
-        // we're sleeping here, the writer loop can't pull the next frame, so
+        // we're sleeping here, the writer task can't pull the next frame, so
         // producers back up behind the capacity bound.
         tokio::time::sleep(self.delay).await;
         self.tx.send(data).await.map_err(|_| Error::Closed)
     }
 
-    async fn recv(&mut self) -> Result<Bytes, Error> {
-        self.rx.recv().await.ok_or(Error::Closed)
-    }
-
     async fn close(&mut self) -> Result<(), Error> {
         Ok(())
+    }
+}
+
+impl TransportReader for ThrottledReader {
+    async fn recv(&mut self) -> Result<Bytes, Error> {
+        self.rx.recv().await.ok_or(Error::Closed)
     }
 }
 


### PR DESCRIPTION
## What

Gives `rs/qmux` proper transport backpressure: the `Session` drives the transport's send and receive halves on **two tasks** so a write stalled on transport backpressure no longer blocks reads or control-frame processing. The two tasks share per-stream state through a `Mutex<Streams>` — the way a QUIC endpoint shares connection state — rather than a bytes channel.

- **Writer task** is the sole producer on the wire: it pulls the outbound queues in strict priority order (**control > datagram > stream**, streams still scheduled by `sendOrder`), retires the stream a terminal frame closes + encodes it under the shared lock, then writes.
- **Reader task** processes inbound frames.

## Changes

- **`Transport` trait split** (breaking): `Transport::split(self) -> (impl TransportWriter, impl TransportReader)`; `send`/`recv`/`close` moved onto the halves, and `TransportWriter::maintain` added for timer-driven work (WebSocket keep-alive Ping). Built-in TCP/TLS/Unix/WebSocket transports and `Session::connect`/`accept` are unaffected; only custom `Transport` impls need updating.
- **Datagram shedding**: `send_datagram` drops the moment the transport backs up — the writer stops draining the bounded datagram lane, so a full lane *is* the backpressure signal, rather than buffering datagrams behind a stalled socket where they'd arrive stale.
- **Streams register under the shared lock**: `open_uni`/`open_bi` insert the backend directly under the `streams` lock before returning the frontend, deleting the `create_uni`/`create_bi` channels. Closes an open-vs-writer race and removes the last message-passing hop. Peer per-stream credit limits live under the same lock so a stream opened concurrently with the handshake is credited exactly once.
- **Bounded idle-timeout deferral under backpressure**: a keep-alive can't go out while a write is wedged, so the idle timeout is *deferred* (not cancelled) — but bounded to one extra idle window, so a peer that dies with our send buffer full is still reclaimed at ~2× the idle timeout rather than hanging until the transport's own, much longer, timeout.
- **Prompt teardown**: dropping the last `Session` clone closes the connection and fails in-flight stream `write`/`read` with `Error::Closed`, instead of waiting for the transport to notice.

## Tests

New `tests/backpressure.rs`: reads-not-blocked-by-stalled-writer (the HoL fix), datagram shedding, and bounded idle-deferral (verifies both that the close is deferred past the raw window *and* that it fires within the bounded grace). Full suite green; clippy clean on all feature sets.