### PR TITLE
fix(qmux): harden inbound DATAGRAM frame-size validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,18 +42,18 @@
     },
     "js/web-transport": {
       "name": "@moq/web-transport",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "devDependencies": {
         "@napi-rs/cli": "^3",
         "@types/node": "^24.3.0",
         "typescript": "^5.9.2",
       },
       "optionalDependencies": {
-        "@moq/web-transport-darwin-arm64": "0.1.2",
-        "@moq/web-transport-darwin-x64": "0.1.2",
-        "@moq/web-transport-linux-arm64-gnu": "0.1.2",
-        "@moq/web-transport-linux-x64-gnu": "0.1.2",
-        "@moq/web-transport-win32-x64-msvc": "0.1.2",
+        "@moq/web-transport-darwin-arm64": "0.1.3",
+        "@moq/web-transport-darwin-x64": "0.1.3",
+        "@moq/web-transport-linux-arm64-gnu": "0.1.3",
+        "@moq/web-transport-linux-x64-gnu": "0.1.3",
+        "@moq/web-transport-win32-x64-msvc": "0.1.3",
       },
     },
   },
@@ -195,6 +195,16 @@
     "@moq/web-socket-stream": ["@moq/web-socket-stream@workspace:js/web-socket-stream"],
 
     "@moq/web-transport": ["@moq/web-transport@workspace:js/web-transport"],
+
+    "@moq/web-transport-darwin-arm64": ["@moq/web-transport-darwin-arm64@0.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MSKd2lmgjABS6A4CoaYA2m5XibJFUi3hzz/5TTrWAiRHU8t6WV5iHcPKLMblgXi+QSZ7iLlEL0tXzmN9u0qkJw=="],
+
+    "@moq/web-transport-darwin-x64": ["@moq/web-transport-darwin-x64@0.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Kml/EUk8EWiKNkBRcLR8JEpMOqxEpDEHHaDlLd+ro84BY/MAgiJGiVKebGZI6QP2C2OalfAqZZQ0Eh8bB6w62Q=="],
+
+    "@moq/web-transport-linux-arm64-gnu": ["@moq/web-transport-linux-arm64-gnu@0.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Y3/Uko9N3X1b68hTgKVrLwpbMgtbvert0ADvIoziE1wczMcoORsys6dE9APH1jeZaXYgLAN5sVf7fdSMFI6HAQ=="],
+
+    "@moq/web-transport-linux-x64-gnu": ["@moq/web-transport-linux-x64-gnu@0.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-WVFRgrhrQUWEKM4uBgBwfz1vGmGOU7DtM38VqlW1+6+bEm6+a0jMJ/6HUBz1bEdzzKZsVcVoT66cZoymyvzjHA=="],
+
+    "@moq/web-transport-win32-x64-msvc": ["@moq/web-transport-win32-x64-msvc@0.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yPWBiujSW4bOByb1kfVyBd28MWoLpKneqel4k5KqW941Ofc6H/czegvtmDiFswx1KH531EjKljmuyilH+2g8Rw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -87,11 +87,16 @@ export interface TransportParameters {
 	params: TransportParams;
 }
 
-/** An unreliable datagram (RFC 9221). The payload carries no length prefix in
- * the frame struct here; on the wire it is length-delimited (0x31). */
+/** An unreliable datagram (RFC 9221). */
 export interface Datagram {
 	type: "datagram";
 	data: Uint8Array;
+	/** Whether the frame carried an explicit length varint on the wire (the
+	 * `0x31` form) rather than the no-length `0x30` form, whose payload is
+	 * delimited by the enclosing record. We always *emit* `0x31`; decoders set
+	 * this so the receive path can size the frame exactly for
+	 * `max_datagram_frame_size` validation. Absent (encode side) means `0x31`. */
+	lengthPrefixed?: boolean;
 }
 
 export interface TransportParams {
@@ -738,7 +743,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 
 	// DATAGRAM without length — payload runs to the end of the record
 	if (frameType === 0x30n) {
-		return { type: "datagram", data: buffer };
+		return { type: "datagram", data: buffer, lengthPrefixed: false };
 	}
 
 	// DATAGRAM with length
@@ -747,7 +752,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		const len = Number(v.value);
 		let data: Uint8Array;
 		[data, buffer] = take(buffer, len);
-		return { type: "datagram", data };
+		return { type: "datagram", data, lengthPrefixed: true };
 	}
 
 	// Unknown frame type
@@ -904,7 +909,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 	// DATAGRAM without length — payload runs to the end of the record
 	if (frameType === 0x30n) {
 		const data = buffer;
-		return [{ type: "datagram", data }, buffer.slice(buffer.byteLength)];
+		return [{ type: "datagram", data, lengthPrefixed: false }, buffer.slice(buffer.byteLength)];
 	}
 
 	// DATAGRAM with length
@@ -913,7 +918,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		const len = Number(v.value);
 		let data: Uint8Array;
 		[data, buffer] = take(buffer, len);
-		return [{ type: "datagram", data }, buffer];
+		return [{ type: "datagram", data, lengthPrefixed: true }, buffer];
 	}
 
 	// Unknown: skip remaining (can't delimit)

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -62,6 +62,11 @@ class FakePeer {
 	sendText(text: string) {
 		this.#recv.enqueue(text);
 	}
+	/** Inject a raw binary record — bytes the encoder wouldn't normally emit
+	 * (e.g. the no-length 0x30 datagram form). */
+	sendRaw(bytes: Uint8Array) {
+		this.#recv.enqueue(bytes);
+	}
 	/** All frames the Session has written so far, decoded. */
 	received(): Frame.Any[] {
 		return this.sent.flatMap((b) => Frame.decodeRecord(b));
@@ -213,6 +218,22 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "datagram", data: new Uint8Array([9, 9]) });
 		const { value } = await session.datagrams.readable.getReader().read();
 		expect(Array.from(value as Uint8Array)).toEqual([9, 9]);
+		session.close();
+	});
+
+	test("datagrams: a no-length (0x30) DATAGRAM is sized without a length varint", async () => {
+		// ourParams.maxDatagramFrameSize = 10. A 0x30 datagram carries no length
+		// varint, so a 9-byte payload is a 1 + 9 = 10-byte frame — exactly the
+		// limit — even though the length-prefixed reconstruction (1 + 1 + 9 = 11)
+		// would wrongly drop it. Hand-build the record: a 0x30 type byte + payload.
+		const { session, peer } = connect({ maxDatagramFrameSize: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const payload = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+		peer.sendRaw(new Uint8Array([0x30, ...payload]));
+		const { value } = await session.datagrams.readable.getReader().read();
+		expect(Array.from(value as Uint8Array)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 		session.close();
 	});
 

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -188,6 +188,34 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
+	test("datagrams: a DATAGRAM whose frame exactly fits our advertised size is delivered", async () => {
+		// ourParams.maxDatagramFrameSize = 10; an 8-byte payload encodes to a
+		// 1 (type) + 1 (length varint) + 8 = 10-byte frame — exactly the limit.
+		const { session, peer } = connect({ maxDatagramFrameSize: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({ type: "datagram", data: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]) });
+		const { value } = await session.datagrams.readable.getReader().read();
+		expect(Array.from(value as Uint8Array)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+		session.close();
+	});
+
+	test("datagrams: a DATAGRAM whose frame overflows our advertised size is dropped", async () => {
+		// ourParams.maxDatagramFrameSize = 10. A 10-byte payload passes the old
+		// payload-only check but its encoded frame is 1 + 1 + 10 = 12 > 10, so it
+		// must be dropped. The following in-limit datagram is what the reader sees.
+		const { session, peer } = connect({ maxDatagramFrameSize: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({ type: "datagram", data: new Uint8Array(10) });
+		peer.send({ type: "datagram", data: new Uint8Array([9, 9]) });
+		const { value } = await session.datagrams.readable.getReader().read();
+		expect(Array.from(value as Uint8Array)).toEqual([9, 9]);
+		session.close();
+	});
+
 	test("datagrams: maxDatagramSize reflects the peer's advertised frame size", async () => {
 		const { session, peer } = connect();
 		await session.ready;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -598,9 +598,13 @@ export default class Session implements WebTransport {
 			// Only accept datagrams if we advertised support (a conforming peer
 			// won't send otherwise) and the encoded frame fits the size we
 			// advertised — drop oversized ones rather than delivering them.
-			// `maxDatagramFrameSize` limits the whole frame (type byte + length
-			// varint + payload), so reconstruct that size before comparing.
-			const frameSize = BigInt(1 + VarInt.from(frame.data.byteLength).size() + frame.data.byteLength);
+			// `maxDatagramFrameSize` limits the whole frame, whose size depends on
+			// the wire form: the no-length `0x30` form is just a type byte plus
+			// payload, while `0x31` adds a length varint. The decoder records which
+			// arrived so we can size it exactly.
+			const len = frame.data.byteLength;
+			const header = frame.lengthPrefixed === false ? 1 : 1 + VarInt.from(len).size();
+			const frameSize = BigInt(header + len);
 			if (this.#ourParams.maxDatagramFrameSize > 0n && frameSize <= this.#ourParams.maxDatagramFrameSize) {
 				this.datagrams.push(frame.data);
 			}

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -596,12 +596,12 @@ export default class Session implements WebTransport {
 			this.#uniStreamCredit.increaseMax(frame.max);
 		} else if (frame.type === "datagram") {
 			// Only accept datagrams if we advertised support (a conforming peer
-			// won't send otherwise) and the payload fits the frame size we
+			// won't send otherwise) and the encoded frame fits the size we
 			// advertised — drop oversized ones rather than delivering them.
-			if (
-				this.#ourParams.maxDatagramFrameSize > 0n &&
-				BigInt(frame.data.byteLength) <= this.#ourParams.maxDatagramFrameSize
-			) {
+			// `maxDatagramFrameSize` limits the whole frame (type byte + length
+			// varint + payload), so reconstruct that size before comparing.
+			const frameSize = BigInt(1 + VarInt.from(frame.data.byteLength).size() + frame.data.byteLength);
+			if (this.#ourParams.maxDatagramFrameSize > 0n && frameSize <= this.#ourParams.maxDatagramFrameSize) {
 				this.datagrams.push(frame.data);
 			}
 		} else if (frame.type === "ping_request") {

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -100,6 +100,47 @@ pub struct Ping {
     pub response: bool,
 }
 
+/// An unreliable datagram (RFC 9221).
+#[derive(Debug, Clone)]
+pub struct Datagram {
+    /// The payload bytes.
+    pub data: Bytes,
+    /// Whether the frame carried an explicit length varint on the wire (the
+    /// `0x31` form) rather than the no-length `0x30` form, whose payload is
+    /// delimited by the enclosing record. We always *emit* `0x31`; this is
+    /// preserved on decode so [`frame_size`](Datagram::frame_size) can report
+    /// the exact encoded size for `max_datagram_frame_size` validation.
+    pub length_prefixed: bool,
+}
+
+impl Datagram {
+    /// The encoded on-wire frame size in bytes: type byte + optional length
+    /// varint + payload. This is what `max_datagram_frame_size` (RFC 9221)
+    /// bounds, so the receive path compares against it.
+    pub(crate) fn frame_size(&self) -> u64 {
+        let len = self.data.len() as u64;
+        // The type is a 1-byte varint (0x30/0x31); the length varint is only
+        // present in the 0x31 form.
+        let header = if self.length_prefixed {
+            1 + super::varint_size(len)
+        } else {
+            1
+        };
+        header + len
+    }
+}
+
+/// Build the length-prefixed (`0x31`) datagram we always emit. Decoders that
+/// observe the no-length `0x30` form construct [`Datagram`] directly instead.
+impl From<Bytes> for Datagram {
+    fn from(data: Bytes) -> Self {
+        Self {
+            data,
+            length_prefixed: true,
+        }
+    }
+}
+
 /// A QUIC-compatible frame for multiplexed transport.
 #[derive(Debug, Clone)]
 pub enum Frame {
@@ -124,9 +165,8 @@ pub enum Frame {
     StreamsBlockedUni(u64),
     TransportParameters(TransportParams),
     Ping(Ping),
-    /// An unreliable datagram (RFC 9221). The payload carries no length prefix
-    /// on the wire; it is delimited by the enclosing record boundary.
-    Datagram(Bytes),
+    /// An unreliable datagram (RFC 9221).
+    Datagram(Datagram),
 }
 
 impl Frame {
@@ -293,7 +333,10 @@ impl Frame {
             // DATAGRAM without length — rest of record is payload
             0x30 => {
                 let payload = data.split_to(data.remaining());
-                Ok(Some(Frame::Datagram(payload)))
+                Ok(Some(Frame::Datagram(Datagram {
+                    data: payload,
+                    length_prefixed: false,
+                })))
             }
             // DATAGRAM with length
             0x31 => {
@@ -302,7 +345,10 @@ impl Frame {
                     return Err(Error::Short);
                 }
                 let payload = data.split_to(len as usize);
-                Ok(Some(Frame::Datagram(payload)))
+                Ok(Some(Frame::Datagram(Datagram {
+                    data: payload,
+                    length_prefixed: true,
+                })))
             }
             // QX_TRANSPORT_PARAMETERS
             0x3f5153300d0a0d0a => {
@@ -444,12 +490,12 @@ impl Frame {
                 }
                 VarInt::try_from(ping.sequence)?.encode(buf);
             }
-            Frame::Datagram(payload) => {
+            Frame::Datagram(datagram) => {
                 // Length-prefixed form (0x31): self-delimiting regardless of
                 // framing. See DATAGRAM_LEN for why we emit it uniformly.
                 DATAGRAM_LEN.encode(buf);
-                VarInt::try_from(payload.len())?.encode(buf);
-                buf.put_slice(payload);
+                VarInt::try_from(datagram.data.len())?.encode(buf);
+                buf.put_slice(&datagram.data);
             }
         }
 
@@ -626,7 +672,10 @@ impl Frame {
             // DATAGRAM without length — rest of message is payload
             0x30 => {
                 let payload = data.split_to(data.remaining());
-                Ok(Some(Frame::Datagram(payload)))
+                Ok(Some(Frame::Datagram(Datagram {
+                    data: payload,
+                    length_prefixed: false,
+                })))
             }
             // DATAGRAM with length
             0x31 => {
@@ -635,7 +684,10 @@ impl Frame {
                     return Err(Error::Short);
                 }
                 let payload = data.split_to(len as usize);
-                Ok(Some(Frame::Datagram(payload)))
+                Ok(Some(Frame::Datagram(Datagram {
+                    data: payload,
+                    length_prefixed: true,
+                })))
             }
             // QX_TRANSPORT_PARAMETERS
             0x3f5153300d0a0d0a => {

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -140,7 +140,9 @@ impl Frame {
         // can't accidentally emit draft-01 wire bytes on a draft-00 session.
         if version != Version::QMux01 {
             match self {
-                Frame::Padding | Frame::Ping(_) => return Err(Error::InvalidFrameType(0)),
+                Frame::Padding | Frame::Ping(_) | Frame::Datagram(_) => {
+                    return Err(Error::InvalidFrameType(0))
+                }
                 _ => {}
             }
         }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -518,18 +518,23 @@ impl<T: Transport> SessionState<T> {
                     self.outbound_priority.0.send(response).ok();
                 }
             }
-            // DATAGRAM: fan out to the receive channel. Accept only if we
-            // advertised support (a conforming peer won't send otherwise) and the
-            // payload fits within the frame size we advertised — reject oversized
-            // ones rather than buffering them, mirroring the STREAM check above.
-            // Delivery is best-effort past that, so drop the datagram if the
+            // DATAGRAM: fan out to the receive channel. `max_datagram_frame_size`
+            // caps the whole *frame* (type byte + length varint + payload), not
+            // just the payload, so reconstruct the encoded size and compare against
+            // the limit we advertised. A peer that sends a datagram we never
+            // advertised support for, or one that overflows the negotiated limit,
+            // is a protocol violation — surface it rather than silently dropping.
+            // Delivery past that is best-effort, so drop the datagram if the
             // channel is full rather than blocking the session loop.
             Frame::Datagram(payload) => {
-                if self.our_params.max_datagram_frame_size != 0
-                    && payload.len() as u64 <= self.our_params.max_datagram_frame_size
-                {
-                    let _ = self.recv_datagram.try_send(payload);
+                if self.our_params.max_datagram_frame_size == 0 {
+                    return Err(Error::DatagramsUnsupported);
                 }
+                let frame_size = 1 + varint_size(payload.len() as u64) + payload.len() as u64;
+                if frame_size > self.our_params.max_datagram_frame_size {
+                    return Err(Error::FrameTooLarge);
+                }
+                let _ = self.recv_datagram.try_send(payload);
             }
         }
 
@@ -1496,5 +1501,101 @@ mod negotiate_tests {
     fn no_overlap_is_none() {
         assert_eq!(negotiate_protocol(true, &v(&["a"]), &v(&["b"])), None);
         assert_eq!(negotiate_protocol(true, &v(&["a"]), &[]), None);
+    }
+}
+
+// Receive-side DATAGRAM validation. A conforming peer self-limits, so these
+// drive a real server `Session` from a hand-crafted raw peer that injects the
+// records a conforming client never would.
+#[cfg(all(test, feature = "tcp"))]
+mod datagram_recv_tests {
+    use super::*;
+    use crate::transport::Stream;
+    use tokio::io::{AsyncWriteExt, DuplexStream};
+    use web_transport_trait::Session as _;
+
+    /// Wrap a QMux01 frame in its size-prefixed record — the byte-stream framing
+    /// [`Stream`] delimits on the wire.
+    fn record(frame: Bytes) -> Bytes {
+        let mut buf = bytes::BytesMut::new();
+        VarInt::try_from(frame.len()).unwrap().encode(&mut buf);
+        buf.extend_from_slice(&frame);
+        buf.freeze()
+    }
+
+    /// Establish a real server `Session` opposite a raw peer over an in-memory
+    /// duplex, returning the server plus the raw write half so the test can inject
+    /// arbitrary records. The raw peer sends its `TRANSPORT_PARAMETERS` first, as a
+    /// real QMux01 client would, so the server reaches "established".
+    async fn raw_peer(server_cfg: Config) -> (Session, DuplexStream) {
+        let (server_io, mut raw) = tokio::io::duplex(1024 * 1024);
+        let transport = Stream::new(server_io, Version::QMux01, server_cfg.max_record_size);
+        let accept = tokio::spawn(Session::accept(transport, server_cfg));
+
+        let client_params = Config::new(Version::QMux01).to_transport_params();
+        let params = Frame::TransportParameters(client_params)
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(params)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        let server = accept.await.unwrap().unwrap();
+        (server, raw)
+    }
+
+    /// A DATAGRAM whose *frame* size (type byte + length varint + payload) exceeds
+    /// the advertised `max_datagram_frame_size` is a protocol violation, not
+    /// something to silently drop.
+    #[tokio::test]
+    async fn oversized_frame_closes_session() {
+        let mut cfg = Config::new(Version::QMux01);
+        cfg.max_datagram_frame_size = 100;
+        let (server, mut raw) = raw_peer(cfg).await;
+
+        // Usable payload is 97 (100 - 1 type byte - 2 length-varint bytes); a
+        // 98-byte payload tips the encoded frame to 101 > 100.
+        let datagram = Frame::Datagram(Bytes::from(vec![0u8; 98]))
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(datagram)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::FrameTooLarge));
+    }
+
+    /// A DATAGRAM on a session that advertised `max_datagram_frame_size = 0` was
+    /// never negotiated; reject the session rather than accept the frame.
+    #[tokio::test]
+    async fn unnegotiated_datagram_closes_session() {
+        let mut cfg = Config::new(Version::QMux01);
+        cfg.max_datagram_frame_size = 0;
+        let (server, mut raw) = raw_peer(cfg).await;
+
+        let datagram = Frame::Datagram(Bytes::from_static(b"hi"))
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(datagram)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::DatagramsUnsupported));
+    }
+
+    /// A DATAGRAM whose encoded frame exactly hits the advertised limit is
+    /// delivered — the bound is inclusive.
+    #[tokio::test]
+    async fn frame_at_limit_delivered() {
+        let mut cfg = Config::new(Version::QMux01);
+        cfg.max_datagram_frame_size = 100;
+        let (server, mut raw) = raw_peer(cfg).await;
+
+        // 97-byte payload → 1 + 2 + 97 == 100 == the limit.
+        let payload = vec![7u8; 97];
+        let datagram = Frame::Datagram(Bytes::from(payload.clone()))
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(datagram)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert_eq!(server.recv_datagram().await.unwrap().as_ref(), &payload[..]);
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -201,7 +201,7 @@ impl<T: Transport> SessionState<T> {
                 }
                 Some(payload) = self.outbound_datagram.recv() => {
                     // Ahead of bulk stream data for low latency, behind control.
-                    self.send_frame(Frame::Datagram(payload)).await?;
+                    self.send_frame(Frame::Datagram(payload.into())).await?;
                 }
                 frame = self.outbound.pop() => {
                     match frame {
@@ -520,21 +520,22 @@ impl<T: Transport> SessionState<T> {
             }
             // DATAGRAM: fan out to the receive channel. `max_datagram_frame_size`
             // caps the whole *frame* (type byte + length varint + payload), not
-            // just the payload, so reconstruct the encoded size and compare against
-            // the limit we advertised. A peer that sends a datagram we never
-            // advertised support for, or one that overflows the negotiated limit,
-            // is a protocol violation — surface it rather than silently dropping.
-            // Delivery past that is best-effort, so drop the datagram if the
-            // channel is full rather than blocking the session loop.
-            Frame::Datagram(payload) => {
+            // just the payload, so compare against the frame's exact encoded size
+            // — which depends on the wire form (`Datagram::frame_size` accounts
+            // for the 0x30 no-length form having no length varint). A peer that
+            // sends a datagram we never advertised support for, or one that
+            // overflows the negotiated limit, is a protocol violation — surface it
+            // rather than silently dropping. Delivery past that is best-effort, so
+            // drop the datagram if the channel is full rather than blocking the
+            // session loop.
+            Frame::Datagram(datagram) => {
                 if self.our_params.max_datagram_frame_size == 0 {
                     return Err(Error::DatagramsUnsupported);
                 }
-                let frame_size = 1 + varint_size(payload.len() as u64) + payload.len() as u64;
-                if frame_size > self.our_params.max_datagram_frame_size {
+                if datagram.frame_size() > self.our_params.max_datagram_frame_size {
                     return Err(Error::FrameTooLarge);
                 }
-                let _ = self.recv_datagram.try_send(payload);
+                let _ = self.recv_datagram.try_send(datagram.data);
             }
         }
 
@@ -1554,7 +1555,7 @@ mod datagram_recv_tests {
 
         // Usable payload is 97 (100 - 1 type byte - 2 length-varint bytes); a
         // 98-byte payload tips the encoded frame to 101 > 100.
-        let datagram = Frame::Datagram(Bytes::from(vec![0u8; 98]))
+        let datagram = Frame::Datagram(Bytes::from(vec![0u8; 98]).into())
             .encode(Version::QMux01)
             .unwrap();
         raw.write_all(&record(datagram)).await.unwrap();
@@ -1571,7 +1572,7 @@ mod datagram_recv_tests {
         cfg.max_datagram_frame_size = 0;
         let (server, mut raw) = raw_peer(cfg).await;
 
-        let datagram = Frame::Datagram(Bytes::from_static(b"hi"))
+        let datagram = Frame::Datagram(Bytes::from_static(b"hi").into())
             .encode(Version::QMux01)
             .unwrap();
         raw.write_all(&record(datagram)).await.unwrap();
@@ -1590,10 +1591,34 @@ mod datagram_recv_tests {
 
         // 97-byte payload → 1 + 2 + 97 == 100 == the limit.
         let payload = vec![7u8; 97];
-        let datagram = Frame::Datagram(Bytes::from(payload.clone()))
+        let datagram = Frame::Datagram(Bytes::from(payload.clone()).into())
             .encode(Version::QMux01)
             .unwrap();
         raw.write_all(&record(datagram)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert_eq!(server.recv_datagram().await.unwrap().as_ref(), &payload[..]);
+    }
+
+    /// The no-length (0x30) form carries no length varint, so its frame is only
+    /// `1 + payload`. The size check must use that exact size, not the larger
+    /// length-prefixed reconstruction — otherwise a conforming 0x30 datagram at
+    /// the boundary is wrongly rejected.
+    #[tokio::test]
+    async fn no_length_datagram_uses_exact_frame_size() {
+        let mut cfg = Config::new(Version::QMux01);
+        cfg.max_datagram_frame_size = 100;
+        let (server, mut raw) = raw_peer(cfg).await;
+
+        // A 99-byte 0x30 payload is a 1 + 99 = 100-byte frame — exactly the limit
+        // — even though the length-prefixed reconstruction (1 + 2 + 99 = 102)
+        // would overshoot it. We never emit 0x30, so hand-build the frame: a
+        // single 0x30 type byte (a 1-byte varint) followed by the payload.
+        let payload = vec![3u8; 99];
+        let mut frame = bytes::BytesMut::new();
+        frame.put_u8(0x30);
+        frame.extend_from_slice(&payload);
+        raw.write_all(&record(frame.freeze())).await.unwrap();
         raw.flush().await.unwrap();
 
         assert_eq!(server.recv_datagram().await.unwrap().as_ref(), &payload[..]);

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -114,7 +114,7 @@ fn assert_frames_eq(got: &Frame, want: &Frame, version: Version) {
             assert_eq!(a, b, "streams_blocked_uni")
         }
         (Frame::Datagram(a), Frame::Datagram(b)) => {
-            assert_eq!(a.as_ref(), b.as_ref(), "datagram payload")
+            assert_eq!(a.data.as_ref(), b.data.as_ref(), "datagram payload")
         }
         (a, b) => panic!("frame variants don't match: got {a:?}, want {b:?}"),
     }
@@ -246,7 +246,7 @@ fn qmux01_datagram() {
     // 0x31 = DATAGRAM | LEN; len=2, payload "hi". Datagrams are a QMux01 feature;
     // we always emit the length-prefixed form.
     let bytes = [0x31, 0x02, b'h', b'i'];
-    let frame = Frame::Datagram(Bytes::from_static(b"hi"));
+    let frame = Frame::Datagram(Bytes::from_static(b"hi").into());
     assert_round_trip(Version::QMux01, &bytes, &frame);
 }
 
@@ -256,7 +256,7 @@ fn datagram_rejected_on_non_qmux01() {
     // must fail rather than emit draft-01 bytes onto a draft-00 / WebTransport
     // session that can't interpret them.
     for version in [Version::WebTransport, Version::QMux00] {
-        let err = Frame::Datagram(Bytes::from_static(b"hi"))
+        let err = Frame::Datagram(Bytes::from_static(b"hi").into())
             .encode(version)
             .expect_err("datagram must not encode on non-QMux01");
         assert!(matches!(err, Error::InvalidFrameType(_)), "got {err:?}");
@@ -272,7 +272,12 @@ fn qmux_datagram_no_length_decodes() {
         .expect("decode succeeds")
         .expect("datagram is not an ignored frame");
     match decoded {
-        Frame::Datagram(payload) => assert_eq!(payload.as_ref(), b"hi"),
+        Frame::Datagram(dg) => {
+            assert_eq!(dg.data.as_ref(), b"hi");
+            // The no-length form is preserved so the size check can use its
+            // true (length-varint-free) frame size.
+            assert!(!dg.length_prefixed, "0x30 form must decode as no-length");
+        }
         other => panic!("expected datagram, got {other:?}"),
     }
 }
@@ -282,7 +287,7 @@ fn record_datagram_then_stream_decodes_both() {
     // The length-prefixed datagram (0x31) must stop consumption at its payload
     // boundary so a following frame in the same record still decodes — the exact
     // reason we always emit 0x31 rather than the no-length 0x30 form.
-    let datagram = Frame::Datagram(Bytes::from_static(b"hi"))
+    let datagram = Frame::Datagram(Bytes::from_static(b"hi").into())
         .encode(Version::QMux01)
         .unwrap();
     let stream = Frame::Stream(Stream {
@@ -300,7 +305,7 @@ fn record_datagram_then_stream_decodes_both() {
     let frames = Frame::decode_record(Bytes::from(record)).expect("record decodes");
     assert_eq!(frames.len(), 2, "both frames decode");
     match &frames[0] {
-        Frame::Datagram(p) => assert_eq!(p.as_ref(), b"hi"),
+        Frame::Datagram(dg) => assert_eq!(dg.data.as_ref(), b"hi"),
         other => panic!("expected datagram, got {other:?}"),
     }
     match &frames[1] {

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -21,7 +21,7 @@
 
 use bytes::Bytes;
 use qmux::proto::{ConnectionClose, Frame, ResetStream, StopSending, Stream};
-use qmux::{StreamId, Version};
+use qmux::{Error, StreamId, Version};
 use web_transport_proto::VarInt;
 
 /// Round-trip helper: hard-coded bytes ↔ expected frame, both directions.
@@ -248,6 +248,19 @@ fn qmux01_datagram() {
     let bytes = [0x31, 0x02, b'h', b'i'];
     let frame = Frame::Datagram(Bytes::from_static(b"hi"));
     assert_round_trip(Version::QMux01, &bytes, &frame);
+}
+
+#[test]
+fn datagram_rejected_on_non_qmux01() {
+    // Datagrams are a QMux01-only frame; encoding one for an older wire version
+    // must fail rather than emit draft-01 bytes onto a draft-00 / WebTransport
+    // session that can't interpret them.
+    for version in [Version::WebTransport, Version::QMux00] {
+        let err = Frame::Datagram(Bytes::from_static(b"hi"))
+            .encode(version)
+            .expect_err("datagram must not encode on non-QMux01");
+        assert!(matches!(err, Error::InvalidFrameType(_)), "got {err:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What

Hardens inbound DATAGRAM frame-size validation across the Rust and JS qmux implementations. `max_datagram_frame_size` (RFC 9221) bounds the entire frame — type byte + length varint + payload — but the receive paths were comparing only the **payload** length against it.

## Why

Pre-existing behavior from #274 (merged), flagged by CodeRabbit on #277. The bug had two symptoms:

1. A datagram whose *payload* fit the limit but whose *encoded frame* overflowed it was accepted anyway.
2. Oversized datagrams (and datagrams received when datagrams were never negotiated) were **silently dropped** rather than surfaced as protocol errors.

## Changes

- **`rs/qmux/src/session.rs`** — the `Frame::Datagram` receive branch now reconstructs the encoded frame size `1 + varint_size(len) + len` before comparing. It returns `Error::DatagramsUnsupported` when a datagram arrives on a session that advertised `max == 0`, and `Error::FrameTooLarge` when the negotiated limit is exceeded — both terminate the session as protocol violations instead of dropping.
- **`js/qmux/src/session.ts`** — compares the full frame size `1 + VarInt.from(byteLength).size() + byteLength` against `maxDatagramFrameSize` (kept the drop-on-oversize behavior; scope here was the comparison fix).
- **`rs/qmux/src/proto/frame.rs`** — added `Frame::Datagram(_)` to the non-QMux01 encode rejection list alongside `Padding`/`Ping`, since datagrams are QMux01-only.

### Note on the decode guard

I did **not** add a symmetric decode-side version guard. `decode_qmux` already decodes other QMux01-only frames (e.g. `Ping`) version-agnostically and relies on the encode path + session logic for enforcement, so guarding only datagrams would be inconsistent. The new session-level `max == 0 → DatagramsUnsupported` check already rejects any datagram a QMux00 session receives, which is the actual exposure.

## Tests

- **Rust** (`wire_format.rs`): `datagram_rejected_on_non_qmux01` covers the encode guard.
- **Rust** (`session.rs`): new in-crate `datagram_recv_tests` module drives a real server `Session` from a hand-crafted raw peer over an in-memory duplex — covering oversized-frame rejection, unnegotiated-datagram rejection, and inclusive-boundary delivery.
- **JS** (`session.test.ts`): exact-fit-delivered and overflow-dropped tests (the overflow case is a direct regression for the payload-vs-frame bug).

All green: `cargo test -p qmux`, `cargo clippy -p qmux --all-features --tests`, `cargo fmt --check`, `bun run check`, `bun test`. (The two `bun run check` warnings are pre-existing in the generated `js/web-transport/napi.cjs`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)