### PR TITLE
fix(qmux): datagram protocol-violation close (JS) + seal proto enums, rename transport halves

### DIFF
--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -206,19 +206,27 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
-	test("datagrams: a DATAGRAM whose frame overflows our advertised size is dropped", async () => {
-		// ourParams.maxDatagramFrameSize = 10. A 10-byte payload passes the old
-		// payload-only check but its encoded frame is 1 + 1 + 10 = 12 > 10, so it
-		// must be dropped. The following in-limit datagram is what the reader sees.
+	test("datagrams: a DATAGRAM whose frame overflows our advertised size is fatal", async () => {
+		// ourParams.maxDatagramFrameSize = 10. A 10-byte payload encodes to a
+		// 1 + 1 + 10 = 12-byte frame > 10 — a peer exceeding the size we negotiated
+		// is a PROTOCOL_VIOLATION (RFC 9221), so the session must close, not drop.
 		const { session, peer } = connect({ maxDatagramFrameSize: 10n });
 		await session.ready;
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		peer.send({ type: "datagram", data: new Uint8Array(10) });
-		peer.send({ type: "datagram", data: new Uint8Array([9, 9]) });
-		const { value } = await session.datagrams.readable.getReader().read();
-		expect(Array.from(value as Uint8Array)).toEqual([9, 9]);
-		session.close();
+		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+	});
+
+	test("datagrams: a DATAGRAM we never advertised support for is fatal", async () => {
+		// ourParams.maxDatagramFrameSize = 0 → we advertised no datagram support, so
+		// receiving one at all is a PROTOCOL_VIOLATION (RFC 9221), not a droppable frame.
+		const { session, peer } = connect({ maxDatagramFrameSize: 0n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({ type: "datagram", data: new Uint8Array([1, 2, 3]) });
+		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
 	});
 
 	test("datagrams: a no-length (0x30) DATAGRAM is sized without a length varint", async () => {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -129,8 +129,11 @@ export class Datagrams implements WebTransportDatagramDuplexStream {
 
 	/** Deliver an inbound datagram to the reader, dropping it if the queue is full. */
 	push(data: Uint8Array): void {
-		if (this.#incoming.desiredSize !== null && this.#incoming.desiredSize <= 0) {
-			return; // reader is behind — shed load
+		// `desiredSize` is null once the readable is closed/errored (e.g. a datagram
+		// arriving in a WS message the read loop delivers just after the session
+		// closed); enqueue would throw, so drop silently — matching Rust's try_send.
+		if (this.#incoming.desiredSize === null || this.#incoming.desiredSize <= 0) {
+			return; // reader is behind or gone — shed load
 		}
 		this.#incoming.enqueue(data);
 	}
@@ -567,7 +570,8 @@ export default class Session implements WebTransport {
 				}
 			}
 		} catch (error) {
-			console.error("Failed to decode frame:", error);
+			// A decode failure or a frame that violates a negotiated limit is fatal.
+			console.error("Protocol violation:", error);
 			this.close({ closeCode: 1002, reason: "Protocol violation" });
 		}
 	}
@@ -595,19 +599,27 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "max_streams_uni") {
 			this.#uniStreamCredit.increaseMax(frame.max);
 		} else if (frame.type === "datagram") {
-			// Only accept datagrams if we advertised support (a conforming peer
-			// won't send otherwise) and the encoded frame fits the size we
-			// advertised — drop oversized ones rather than delivering them.
-			// `maxDatagramFrameSize` limits the whole frame, whose size depends on
-			// the wire form: the no-length `0x30` form is just a type byte plus
-			// payload, while `0x31` adds a length varint. The decoder records which
-			// arrived so we can size it exactly.
+			// `max_datagram_frame_size` is negotiated: we advertised the largest
+			// DATAGRAM frame we're willing to receive, so a peer that sends one we
+			// never accepted — or one larger than we advertised — has violated the
+			// contract. Per RFC 9221 that's a fatal PROTOCOL_VIOLATION, not a
+			// droppable frame; throwing here closes the session via #onData (matching
+			// the Rust implementation's DatagramsUnsupported / FrameTooLarge).
+			//
+			// The limit bounds the whole frame, whose size depends on the wire form:
+			// the no-length `0x30` form is just a type byte plus payload, while `0x31`
+			// adds a length varint. The decoder records which arrived so we can size
+			// it exactly.
+			if (this.#ourParams.maxDatagramFrameSize === 0n) {
+				throw new Error("received a DATAGRAM but did not advertise datagram support");
+			}
 			const len = frame.data.byteLength;
 			const header = frame.lengthPrefixed === false ? 1 : 1 + VarInt.from(len).size();
 			const frameSize = BigInt(header + len);
-			if (this.#ourParams.maxDatagramFrameSize > 0n && frameSize <= this.#ourParams.maxDatagramFrameSize) {
-				this.datagrams.push(frame.data);
+			if (frameSize > this.#ourParams.maxDatagramFrameSize) {
+				throw new Error("received a DATAGRAM larger than our advertised max_datagram_frame_size");
 			}
+			this.datagrams.push(frame.data);
 		} else if (frame.type === "ping_request") {
 			// Respond to ping requests
 			this.#sendPriorityFrame({ type: "ping_response", sequence: frame.sequence });

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -50,9 +50,11 @@ pub use error::Error;
 pub use proto::Version;
 pub use session::{RecvStream, SendStream, Session};
 pub use stream::{StreamDir, StreamId};
-pub use transport::{Transport, TransportReader, TransportWriter};
-// The concrete byte-stream transport lives at `transport::Stream` rather than the
-// crate root, so the name doesn't collide with the STREAM-frame `Stream` type.
+pub use transport::Transport;
+// The transport half-traits live at `transport::{Reader, Writer}` and the concrete
+// byte-stream transport at `transport::Stream`, rather than the crate root — the
+// bare `Reader`/`Writer`/`Stream` names would be too generic (and `Stream` would
+// collide with the STREAM-frame `Stream` type) alongside the rest of the API.
 
 /// All supported ALPN identifiers, in preference order.
 ///

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -102,6 +102,7 @@ pub struct Ping {
 
 /// An unreliable datagram (RFC 9221).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Datagram {
     /// The payload bytes.
     pub data: Bytes,
@@ -143,6 +144,7 @@ impl From<Bytes> for Datagram {
 
 /// A QUIC-compatible frame for multiplexed transport.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Frame {
     Padding,
     ResetStream(ResetStream),

--- a/rs/qmux/src/proto/params.rs
+++ b/rs/qmux/src/proto/params.rs
@@ -11,6 +11,7 @@ use crate::Error;
 /// All values default to 0 (per QUIC), meaning no data/streams allowed
 /// until the peer advertises its limits.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct TransportParams {
     pub max_idle_timeout: u64,                    // ID 0x01 (milliseconds)
     pub initial_max_data: u64,                    // ID 0x04

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -224,6 +224,38 @@ impl PriorityQueue {
         }
     }
 
+    /// Drop every queued frame for `id`, unscheduling it and freeing the
+    /// capacity they held. Used when a stream is reset: any STREAM data still
+    /// buffered here must not reach the wire *after* the RESET_STREAM, or it's
+    /// post-terminal data that wastes congestion window on a stream the peer has
+    /// already abandoned. No-op if the stream has nothing queued.
+    pub fn remove(&self, id: StreamId) {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(slot) = inner.streams.remove(&id) else {
+            return;
+        };
+        let removed = slot.frames.len();
+
+        // Unschedule it from its band (it's scheduled iff it had frames, which it
+        // did). `slot.priority` is the single source of truth for which band.
+        if let Some(queue) = inner.bands.get_mut(&slot.priority) {
+            if let Some(pos) = queue.iter().position(|&s| s == id) {
+                queue.remove(pos);
+            }
+            if queue.is_empty() {
+                inner.bands.remove(&slot.priority);
+            }
+        }
+
+        inner.len -= removed;
+        drop(inner);
+        // Freed `removed` slots; wake that many blocked producers (mirrors the
+        // per-slot notify in `pop_locked`).
+        for _ in 0..removed {
+            self.has_space.notify_one();
+        }
+    }
+
     /// Close the queue, unblocking any blocked producers and the consumer.
     pub fn close(&self) {
         {
@@ -377,5 +409,50 @@ mod tests {
         // Draining one frame makes room.
         q.pop().await.unwrap();
         pushing.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn remove_drops_a_streams_queued_frames() {
+        let q = PriorityQueue::new(8);
+        let a = sid(0);
+        let b = sid(1);
+
+        q.push(5, a, frame(a, 1)).await.unwrap();
+        q.push(5, a, frame(a, 2)).await.unwrap();
+        q.push(5, b, frame(b, 9)).await.unwrap();
+
+        // Reset `a`: its queued frames vanish, `b`'s survive.
+        q.remove(a);
+
+        assert_eq!(id_of(&q.pop().await.unwrap()), b);
+        // Nothing left: the next pop blocks, so a closed-drain returns None.
+        q.close();
+        assert!(q.pop().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_frees_capacity_for_blocked_producers() {
+        let q = PriorityQueue::new(2);
+        let a = sid(0);
+        let b = sid(1);
+        q.push(5, a, frame(a, 1)).await.unwrap();
+        q.push(5, a, frame(a, 2)).await.unwrap();
+
+        // Queue is full; a push for `b` blocks.
+        let q2 = q.clone();
+        let pushing = tokio::spawn(async move { q2.push(5, b, frame(b, 1)).await });
+        tokio::task::yield_now().await;
+        assert!(!pushing.is_finished(), "push should block while full");
+
+        // Removing `a` frees both slots and wakes the blocked producer.
+        q.remove(a);
+        pushing.await.unwrap().unwrap();
+        assert_eq!(id_of(&q.pop().await.unwrap()), b);
+    }
+
+    #[tokio::test]
+    async fn remove_unknown_stream_is_noop() {
+        let q = PriorityQueue::new(8);
+        q.remove(sid(99)); // must not panic or underflow
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::config::Config;
 use crate::credit::Credit;
 use crate::sched::PriorityQueue;
-use crate::transport::{Transport, TransportReader, TransportWriter};
+use crate::transport::{Reader, Transport, Writer};
 use crate::{
     proto::varint_size, ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir,
     StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD,
@@ -192,7 +192,7 @@ impl RecvOpen {
 /// frames. The outbound path (scheduling, encoding, sending, keep-alive) lives in
 /// [`WriterState`]; the two tasks share `streams` and the record-limit / idle
 /// atomics instead of passing messages.
-struct SessionState<R: TransportReader> {
+struct SessionState<R: Reader> {
     reader: R,
     config: Config,
     is_server: bool,
@@ -306,7 +306,7 @@ fn negotiated_idle_timeout_ms(ours: u64, peer: u64) -> u64 {
 /// under the shared `streams` lock, then writes it. Runs on its own task so a
 /// write blocked on transport backpressure never stalls the reader. It also owns
 /// the QMux keep-alive ping (it's the side that knows when we last sent).
-struct WriterState<W: TransportWriter> {
+struct WriterState<W: Writer> {
     writer: W,
     version: Version,
 
@@ -330,7 +330,7 @@ struct WriterState<W: TransportWriter> {
     next_ping_seq: u64,
 }
 
-impl<W: TransportWriter> WriterState<W> {
+impl<W: Writer> WriterState<W> {
     /// Record the first terminal error so the reader's `closed` branch unblocks.
     fn note_closed(&self, err: Error) {
         self.closed.send_if_modified(|slot| {
@@ -443,7 +443,7 @@ impl<W: TransportWriter> WriterState<W> {
     }
 }
 
-impl<R: TransportReader> SessionState<R> {
+impl<R: Reader> SessionState<R> {
     async fn run(&mut self) -> Result<(), Error> {
         let mut closed = self.closed.subscribe();
 
@@ -1903,7 +1903,7 @@ mod recv_open_tests {
 
     use web_transport_proto::VarInt;
 
-    use super::{Session, Transport, TransportReader, TransportWriter};
+    use super::{Reader, Session, Transport, Writer};
     use crate::proto::{Frame, ResetStream, Stream};
     use crate::{Config, Error, StreamDir, StreamId, Version};
 
@@ -1935,7 +1935,7 @@ mod recv_open_tests {
         }
     }
 
-    impl TransportWriter for ScriptedWriter {
+    impl Writer for ScriptedWriter {
         async fn send(&mut self, _data: Bytes) -> Result<(), Error> {
             Ok(())
         }
@@ -1945,7 +1945,7 @@ mod recv_open_tests {
         }
     }
 
-    impl TransportReader for ScriptedReader {
+    impl Reader for ScriptedReader {
         async fn recv(&mut self) -> Result<Bytes, Error> {
             match self.incoming.recv().await {
                 Some(bytes) => Ok(bytes),

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1491,6 +1491,8 @@ impl SendStream {
                 code,
                 final_size: self.offset,
             };
+            // Flush queued STREAM data so none trails the RESET_STREAM on the wire.
+            self.outbound.remove(self.id);
             self.outbound_priority.send(frame.into()).ok();
         }
         self.closed = Some(error.clone());
@@ -1645,6 +1647,10 @@ impl generic::SendStream for SendStream {
             final_size: self.offset,
         };
 
+        // Flush any STREAM data still queued for this stream: it must not go out
+        // after the RESET_STREAM, where it would be post-terminal data burning
+        // congestion window on a stream the peer has abandoned.
+        self.outbound.remove(self.id);
         self.outbound_priority.send(frame.into()).ok();
         self.closed = Some(Error::StreamReset(code));
     }

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -15,16 +15,16 @@ use crate::Error;
 /// of buffering them behind a stalled socket.
 pub trait Transport: Send + 'static {
     /// The independently-owned send half.
-    type Writer: TransportWriter;
+    type Writer: Writer;
     /// The independently-owned receive half.
-    type Reader: TransportReader;
+    type Reader: Reader;
 
     /// Split into send and receive halves.
     fn split(self) -> (Self::Writer, Self::Reader);
 }
 
 /// The send half of a [`Transport`].
-pub trait TransportWriter: Send + 'static {
+pub trait Writer: Send + 'static {
     /// Send a single complete message.
     fn send(&mut self, data: Bytes) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
@@ -42,7 +42,7 @@ pub trait TransportWriter: Send + 'static {
 }
 
 /// The receive half of a [`Transport`].
-pub trait TransportReader: Send + 'static {
+pub trait Reader: Send + 'static {
     /// Receive the next complete message.
     fn recv(&mut self) -> impl std::future::Future<Output = Result<Bytes, Error>> + Send;
 }
@@ -64,7 +64,7 @@ mod stream_transport {
     use tokio::task::JoinHandle;
     use web_transport_proto::VarInt;
 
-    use super::{Transport, TransportReader, TransportWriter};
+    use super::{Reader, Transport, Writer};
     use crate::{Error, Version, MAX_FRAME_PAYLOAD, MAX_FRAME_SIZE};
 
     /// Bound on queued frames waiting for the session to drain them. Bytes the
@@ -153,7 +153,7 @@ mod stream_transport {
         }
     }
 
-    impl<T: AsyncWrite + Send + 'static> TransportWriter for StreamWriter<T> {
+    impl<T: AsyncWrite + Send + 'static> Writer for StreamWriter<T> {
         async fn send(&mut self, data: Bytes) -> Result<(), Error> {
             // QMux01 frames travel inside size-prefixed records on byte streams.
             // (Records are implicit on WebSocket, where the message boundary delimits them.)
@@ -173,7 +173,7 @@ mod stream_transport {
         }
     }
 
-    impl TransportReader for StreamReader {
+    impl Reader for StreamReader {
         async fn recv(&mut self) -> Result<Bytes, Error> {
             // mpsc::Receiver::recv is cancel safe, so dropping this future never
             // loses a buffered frame. `None` means the reader task exited without
@@ -401,7 +401,7 @@ mod stream_transport {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::transport::{Transport, TransportReader};
+        use crate::transport::{Reader, Transport};
         use tokio::io::AsyncWriteExt;
 
         // Drip a frame in one byte at a time, racing each `recv` against an
@@ -568,7 +568,7 @@ mod ws_transport {
     use tokio::time::{Instant, Interval, MissedTickBehavior, Sleep};
     use tokio_tungstenite::tungstenite;
 
-    use super::{Transport, TransportReader, TransportWriter};
+    use super::{Reader, Transport, Writer};
     use crate::ws::KeepAlive;
     use crate::Error;
 
@@ -683,7 +683,7 @@ mod ws_transport {
         }
     }
 
-    impl<T: WsStream> TransportWriter for WsWriter<T> {
+    impl<T: WsStream> Writer for WsWriter<T> {
         async fn send(&mut self, data: Bytes) -> Result<(), Error> {
             use futures::SinkExt;
             self.sink
@@ -721,7 +721,7 @@ mod ws_transport {
         }
     }
 
-    impl<T: WsStream> TransportReader for WsReader<T> {
+    impl<T: WsStream> Reader for WsReader<T> {
         async fn recv(&mut self) -> Result<Bytes, Error> {
             use futures::StreamExt;
 

--- a/rs/qmux/tests/backpressure.rs
+++ b/rs/qmux/tests/backpressure.rs
@@ -10,7 +10,8 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use qmux::{Config, Error, Session, Transport, TransportReader, TransportWriter, Version};
+use qmux::transport::{Reader, Writer};
+use qmux::{Config, Error, Session, Transport, Version};
 use tokio::sync::{mpsc, watch};
 use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
 
@@ -47,7 +48,7 @@ impl Transport for GatedTransport {
     }
 }
 
-impl TransportWriter for GatedWriter {
+impl Writer for GatedWriter {
     async fn send(&mut self, data: Bytes) -> Result<(), Error> {
         // Block while the gate is closed — the test's stand-in for a full socket.
         if let Some(gate) = &mut self.gate {
@@ -63,7 +64,7 @@ impl TransportWriter for GatedWriter {
     }
 }
 
-impl TransportReader for GatedReader {
+impl Reader for GatedReader {
     async fn recv(&mut self) -> Result<Bytes, Error> {
         self.rx.recv().await.ok_or(Error::Closed)
     }

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -8,7 +8,8 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use qmux::{Config, Error, Session, Transport, TransportReader, TransportWriter, Version};
+use qmux::transport::{Reader, Writer};
+use qmux::{Config, Error, Session, Transport, Version};
 use tokio::sync::mpsc;
 use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
 
@@ -46,7 +47,7 @@ impl Transport for ThrottledTransport {
     }
 }
 
-impl TransportWriter for ThrottledWriter {
+impl Writer for ThrottledWriter {
     async fn send(&mut self, data: Bytes) -> Result<(), Error> {
         // The delay is what fills the session's outbound priority queue: while
         // we're sleeping here, the writer task can't pull the next frame, so
@@ -60,7 +61,7 @@ impl TransportWriter for ThrottledWriter {
     }
 }
 
-impl TransportReader for ThrottledReader {
+impl Reader for ThrottledReader {
     async fn recv(&mut self) -> Result<Bytes, Error> {
         self.rx.recv().await.ok_or(Error::Closed)
     }


### PR DESCRIPTION
Follow-ups from reviewing the qmux datagram + transport-split work being released. Two independent themes, one per commit.

## 1. `fix(qmux)`: close the session on datagram protocol violations (JS)

`max_datagram_frame_size` is **negotiated**, so a peer that sends a DATAGRAM larger than we advertised — or *any* DATAGRAM when we advertised `0` — has violated a limit we explicitly stated. [RFC 9221](https://www.rfc-editor.org/rfc/rfc9221) requires terminating the connection with `PROTOCOL_VIOLATION` in both cases.

The JS `@moq/qmux` was **silently dropping** such frames, diverging from the (spec-correct) Rust implementation and masking a contract-breaking peer.

- Inbound datagram branch now throws on both cases; the existing `#onData` catch turns that into a fatal `1002` close — matching Rust's `DatagramsUnsupported` / `FrameTooLarge`.
- `Datagrams.push` is now a silent no-op on a closed readable (a datagram racing session teardown) instead of throwing — matching Rust's `try_send`.
- Rewrote the "oversized is dropped" test to assert a fatal close; added an unnegotiated-datagram-is-fatal test.
- Bumped `@moq/qmux` → **0.2.0** (datagrams, in-band negotiation, Unix sockets since 0.1.3).

## 2. `refactor(qmux)`: rename transport half-traits + seal proto enums (Rust)

- `TransportWriter`/`TransportReader` → `transport::Writer`/`transport::Reader`. The `Transport`-prefix stutters inside the `transport` module, and the bare names match the existing `transport::Stream`. Dropped from the crate-root re-export (kept only under `transport::`) since `qmux::Writer`/`qmux::Reader` would be too generic. The split trait shipped this cycle, so no external code has adopted the old names yet.
- `#[non_exhaustive]` on `proto::Frame`, `proto::TransportParams`, and `proto::Datagram`. These are wire-format types that keep gaining variants/fields as the draft evolves (this release added `Frame::Datagram` and the `max_datagram_frame_size` param); sealing them makes future additions non-breaking instead of forcing a bump and breaking downstream matches.

## Verification
- Rust: `cargo fmt --check`, `cargo test -p qmux --all-features` (91 tests), `cargo clippy --all-features --all-targets` — all clean.
- JS: `bun test` (64 tests), `bun run check` (biome) — clean.

## Note for release-plz
The auto-generated release PR #276 references the old `TransportWriter`/`TransportReader` names and predates the `#[non_exhaustive]` additions. After this merges, let release-plz **regenerate** #276 so its changelog + semver report reflect these changes rather than hand-editing the bot's PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)