### PR TITLE
feat(qmux): add draft-ietf-quic-qmux-02 support

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -1,6 +1,6 @@
 # @moq/qmux
 
-A [WebTransport](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport_API) polyfill for browsers, using WebSockets as the underlying transport with [QMux](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-01.html) (draft-ietf-quic-qmux-01) framing.
+A [WebTransport](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport_API) polyfill for browsers, using WebSockets as the underlying transport with [QMux](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html) (draft-ietf-quic-qmux-02, negotiating down to draft-01 and draft-00) framing.
 
 QMux brings QUIC's multiplexed streams and flow control to reliable, ordered byte-stream transports like WebSockets. This allows WebTransport applications to seamlessly fall back when QUIC/UDP is blocked by network middleboxes.
 

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -2,7 +2,7 @@
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
 	"version": "0.2.0",
-	"description": "QMux protocol (draft-ietf-quic-qmux-01) over WebSockets",
+	"description": "QMux protocol (draft-ietf-quic-qmux-02) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/web-transport",

--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -140,6 +140,7 @@ describe("QMux01 record framing", () => {
 				maxDatagramFrameSize: 0n,
 				// Deliberately set to 0 — exercises the encoder's "skip-if-zero" + decoder's default seeding.
 				maxRecordSize: 0n,
+				resetStreamAt: false,
 			},
 		};
 		const bytes = Frame.encode(params, "qmux-01");
@@ -166,7 +167,7 @@ describe("QMux02 (draft-02)", () => {
 		}
 	});
 
-	test("RESET_STREAM_AT (0x24) decodes as a plain reset", () => {
+	test("RESET_STREAM_AT (0x24) decodes as a reset carrying reliableSize", () => {
 		// 0x24, id=4, code=42, final_size=128 (0x40 0x80), reliable_size=64 (0x40 0x40).
 		const wire = new Uint8Array([0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40]);
 		const decoded = Frame.decode(wire, "qmux-02");
@@ -174,6 +175,32 @@ describe("QMux02 (draft-02)", () => {
 		if (decoded?.type === "reset_stream") {
 			expect(decoded.id.value.value).toBe(4n);
 			expect(decoded.code.value).toBe(42n);
+			// reliableSize present marks it as RESET_STREAM_AT (vs a plain 0x04 reset,
+			// which leaves it undefined); the session uses this to gate on negotiation.
+			expect(decoded.reliableSize).toBe(64n);
+		}
+	});
+
+	test("reset_stream_at transport parameter round-trips (empty flag)", () => {
+		const on: Frame.Any = {
+			type: "transport_parameters",
+			params: { ...Frame.DEFAULT_TRANSPORT_PARAMS, initialMaxData: 1024n, resetStreamAt: true },
+		};
+		const decoded = Frame.decodeRecord(Frame.encode(on, "qmux-02"));
+		expect(decoded.length).toBe(1);
+		if (decoded[0].type === "transport_parameters") {
+			expect(decoded[0].params.resetStreamAt).toBe(true);
+			expect(decoded[0].params.initialMaxData).toBe(1024n);
+		}
+
+		// Omitted from the wire (and decodes false) when unset.
+		const off: Frame.Any = {
+			type: "transport_parameters",
+			params: { ...Frame.DEFAULT_TRANSPORT_PARAMS, initialMaxData: 1n },
+		};
+		const d2 = Frame.decodeRecord(Frame.encode(off, "qmux-02"));
+		if (d2[0].type === "transport_parameters") {
+			expect(d2[0].params.resetStreamAt).toBe(false);
 		}
 	});
 

--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -152,3 +152,50 @@ describe("QMux01 record framing", () => {
 		}
 	});
 });
+
+describe("QMux02 (draft-02)", () => {
+	test("qmux-02 shares the qmux-01 record wire format", () => {
+		const id = new Stream.Id(VarInt.from(4n));
+		const frames: Frame.Any[] = [
+			{ type: "stream", id, data: new Uint8Array([1, 2, 3]), fin: true },
+			{ type: "max_data", max: 1024n },
+			{ type: "datagram", data: new Uint8Array([9, 9]) },
+		];
+		for (const frame of frames) {
+			expect(Array.from(Frame.encode(frame, "qmux-02"))).toEqual(Array.from(Frame.encode(frame, "qmux-01")));
+		}
+	});
+
+	test("RESET_STREAM_AT (0x24) decodes as a plain reset", () => {
+		// 0x24, id=4, code=42, final_size=128 (0x40 0x80), reliable_size=64 (0x40 0x40).
+		const wire = new Uint8Array([0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40]);
+		const decoded = Frame.decode(wire, "qmux-02");
+		expect(decoded?.type).toBe("reset_stream");
+		if (decoded?.type === "reset_stream") {
+			expect(decoded.id.value.value).toBe(4n);
+			expect(decoded.code.value).toBe(42n);
+		}
+	});
+
+	test("RESET_STREAM_AT with reliable_size > final_size is rejected", () => {
+		// reliable_size=200 (0x40 0xc8) > final_size=128 (0x40 0x80).
+		const wire = new Uint8Array([0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0xc8]);
+		expect(() => Frame.decode(wire, "qmux-02")).toThrow();
+	});
+
+	test("RESET_STREAM_AT stops at its boundary inside a record", () => {
+		const resetAt = new Uint8Array([0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40]);
+		const stream = Frame.encode(
+			{ type: "stream", id: new Stream.Id(VarInt.from(8n)), data: new Uint8Array([1, 2]), fin: false },
+			"qmux-02",
+		);
+		const record = new Uint8Array(resetAt.byteLength + stream.byteLength);
+		record.set(resetAt, 0);
+		record.set(stream, resetAt.byteLength);
+
+		const decoded = Frame.decodeRecord(record);
+		expect(decoded.length).toBe(2);
+		expect(decoded[0].type).toBe("reset_stream");
+		expect(decoded[1].type).toBe("stream");
+	});
+});

--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -181,6 +181,29 @@ describe("QMux02 (draft-02)", () => {
 		}
 	});
 
+	test("a duplicate transport parameter is rejected", () => {
+		// QX_TRANSPORT_PARAMETERS carrying initial_max_data (0x04) twice — a
+		// protocol error, matching the Rust decoder's DuplicateParam.
+		const bytes = new Uint8Array([
+			0xff,
+			0x51,
+			0x53,
+			0x30,
+			0x0d,
+			0x0a,
+			0x0d,
+			0x0a, // frame type
+			0x06, // payload length
+			0x04,
+			0x01,
+			0x01, // id=0x04, len=1, value=1
+			0x04,
+			0x01,
+			0x01, // duplicate
+		]);
+		expect(() => Frame.decode(bytes, "qmux-02")).toThrow();
+	});
+
 	test("reset_stream_at transport parameter round-trips (empty flag)", () => {
 		const on: Frame.Any = {
 			type: "transport_parameters",

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -7,7 +7,7 @@ import { VarInt } from "./varint.ts";
  * `index.ts`) only includes the QMux drafts; `"webtransport"` is the
  * legacy fallback wire format and isn't a valid value for any public option.
  */
-export type WireFormat = "webtransport" | "qmux-00" | "qmux-01";
+export type WireFormat = "webtransport" | "qmux-00" | "qmux-01" | "qmux-02";
 
 /** Maximum size of a single QMux frame on the wire. */
 export const MAX_FRAME_SIZE = 16384;
@@ -181,12 +181,22 @@ export function encode(frame: Any, version: WireFormat = "webtransport"): Uint8A
 
 /** Returns true if the version uses QMux framing (draft-00 or later). */
 export function isQmux(version: WireFormat): boolean {
-	return version === "qmux-00" || version === "qmux-01";
+	return version === "qmux-00" || version === "qmux-01" || version === "qmux-02";
+}
+
+/** Returns true if the version uses the QMux Record framing layer and the
+ * features introduced alongside it (QX_PING keep-alive, PADDING, datagrams,
+ * max_record_size) — draft-01 and later. */
+export function usesRecords(version: WireFormat): boolean {
+	return version === "qmux-01" || version === "qmux-02";
 }
 
 // QX_PING frame type constants (draft-01)
 const QX_PING_REQUEST = 0x348c67529ef8c7bdn;
 const QX_PING_RESPONSE = 0x348c67529ef8c7ben;
+// RESET_STREAM_AT (draft-ietf-quic-reliable-stream-reset), permitted by QMux
+// draft-02. Decode-only: accepted, validated, and treated as a plain reset.
+const RESET_STREAM_AT = 0x24n;
 // max_record_size transport parameter ID
 const MAX_RECORD_SIZE_ID = 0x0571c59429cd0845n;
 // application_protocols transport parameter ID (QMux-specific, non-TLS ALPN).
@@ -638,6 +648,24 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		return { type: "reset_stream", id, code };
 	}
 
+	// RESET_STREAM_AT (draft-02). On a reliable, ordered transport all stream data
+	// up to final_size has already arrived, so we treat it as a plain reset;
+	// reliable_size > final_size is a FRAME_ENCODING_ERROR.
+	if (frameType === RESET_STREAM_AT) {
+		[v, buffer] = VarInt.decode(buffer);
+		const id = new Stream.Id(v);
+		[v, buffer] = VarInt.decode(buffer);
+		const code = v;
+		[v, buffer] = VarInt.decode(buffer);
+		const finalSize = v.value;
+		[v, buffer] = VarInt.decode(buffer);
+		const reliableSize = v.value;
+		if (reliableSize > finalSize) {
+			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
+		}
+		return { type: "reset_stream", id, code };
+	}
+
 	// STOP_SENDING
 	if (frameType === 0x05n) {
 		[v, buffer] = VarInt.decode(buffer);
@@ -807,6 +835,22 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 		[v, buffer] = VarInt.decode(buffer); // final_size
+		return [{ type: "reset_stream", id, code }, buffer];
+	}
+
+	// RESET_STREAM_AT (draft-02); see the single-frame decoder for the semantics.
+	if (frameType === RESET_STREAM_AT) {
+		[v, buffer] = VarInt.decode(buffer);
+		const id = new Stream.Id(v);
+		[v, buffer] = VarInt.decode(buffer);
+		const code = v;
+		[v, buffer] = VarInt.decode(buffer);
+		const finalSize = v.value;
+		[v, buffer] = VarInt.decode(buffer);
+		const reliableSize = v.value;
+		if (reliableSize > finalSize) {
+			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
+		}
 		return [{ type: "reset_stream", id, code }, buffer];
 	}
 

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -26,6 +26,11 @@ export interface ResetStream {
 	type: "reset_stream";
 	id: Stream.Id;
 	code: VarInt;
+	/** Set (to the frame's Reliable Size) when this was decoded from a
+	 * RESET_STREAM_AT frame (0x24, draft-02); absent for a plain RESET_STREAM.
+	 * The session uses its presence to enforce that RESET_STREAM_AT is only
+	 * accepted when we advertised the `reset_stream_at` transport parameter. */
+	reliableSize?: bigint;
 }
 
 export interface StopSending {
@@ -110,6 +115,10 @@ export interface TransportParams {
 	/** RFC 9221 max_datagram_frame_size (ID 0x20); 0 = datagrams unsupported. */
 	maxDatagramFrameSize: bigint;
 	maxRecordSize: bigint;
+	/** Whether we advertise support for *receiving* RESET_STREAM_AT frames, via
+	 * the empty-valued `reset_stream_at` transport parameter (ID 0x1d). Only set
+	 * on QMux draft-02. */
+	resetStreamAt: boolean;
 }
 
 /** Default max_record_size per draft-01. */
@@ -125,6 +134,7 @@ export const DEFAULT_TRANSPORT_PARAMS: TransportParams = {
 	initialMaxStreamsUni: 0n,
 	maxDatagramFrameSize: 0n,
 	maxRecordSize: DEFAULT_MAX_RECORD_SIZE,
+	resetStreamAt: false,
 };
 
 export const RECOMMENDED_TRANSPORT_PARAMS: TransportParams = {
@@ -137,6 +147,7 @@ export const RECOMMENDED_TRANSPORT_PARAMS: TransportParams = {
 	initialMaxStreamsUni: 100n,
 	maxDatagramFrameSize: DEFAULT_MAX_RECORD_SIZE,
 	maxRecordSize: DEFAULT_MAX_RECORD_SIZE,
+	resetStreamAt: false,
 };
 
 export interface Padding {
@@ -203,6 +214,9 @@ const MAX_RECORD_SIZE_ID = 0x0571c59429cd0845n;
 // This implementation only runs over WebSocket, which negotiates the protocol
 // via its subprotocol (ALPN), so receiving this parameter is a protocol error.
 const APPLICATION_PROTOCOLS_ID = 0x3d4f9c2a8b1e6075n;
+// reset_stream_at transport parameter ID (draft-ietf-quic-reliable-stream-reset):
+// empty value, presence advertises support for receiving RESET_STREAM_AT.
+const RESET_STREAM_AT_PARAM_ID = 0x1dn;
 
 function encodeWebTransport(frame: Any): Uint8Array {
 	switch (frame.type) {
@@ -418,8 +432,8 @@ function encodeQMux(frame: Any): Uint8Array {
 
 function encodeTransportParams(params: TransportParams): Uint8Array<ArrayBuffer> {
 	// Each param: id(varint) + length(varint) + value(varint)
-	// Max 9 params * 24 bytes each
-	let buffer = new Uint8Array(new ArrayBuffer(216), 0, 0);
+	// Max 9 varint params * 24 bytes each + the 2-byte reset_stream_at flag.
+	let buffer = new Uint8Array(new ArrayBuffer(256), 0, 0);
 
 	function writeParam(buf: Uint8Array<ArrayBuffer>, id: number | bigint, value: bigint): Uint8Array<ArrayBuffer> {
 		if (value === 0n) return buf;
@@ -439,6 +453,13 @@ function encodeTransportParams(params: TransportParams): Uint8Array<ArrayBuffer>
 	buffer = writeParam(buffer, 0x09, params.initialMaxStreamsUni);
 	buffer = writeParam(buffer, 0x20, params.maxDatagramFrameSize);
 	buffer = writeParam(buffer, MAX_RECORD_SIZE_ID, params.maxRecordSize);
+
+	// reset_stream_at: an empty-valued flag. Presence advertises that we accept
+	// RESET_STREAM_AT frames; absence means we don't.
+	if (params.resetStreamAt) {
+		buffer = VarInt.from(RESET_STREAM_AT_PARAM_ID).encode(buffer);
+		buffer = VarInt.from(0).encode(buffer);
+	}
 
 	return buffer;
 }
@@ -466,6 +487,16 @@ function decodeTransportParams(buffer: Uint8Array): TransportParams {
 		// negotiates via its subprotocol, so the parameter must never appear.
 		if (id === APPLICATION_PROTOCOLS_ID) {
 			throw new Error("unexpected application_protocols parameter over WebSocket");
+		}
+
+		// reset_stream_at: presence-only. A non-empty value is a
+		// TRANSPORT_PARAMETER_ERROR per the extension spec.
+		if (id === RESET_STREAM_AT_PARAM_ID) {
+			if (paramData.byteLength !== 0) {
+				throw new Error("reset_stream_at transport parameter must be empty");
+			}
+			params.resetStreamAt = true;
+			continue;
 		}
 
 		if (paramData.byteLength < 1) {
@@ -663,7 +694,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		if (reliableSize > finalSize) {
 			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
 		}
-		return { type: "reset_stream", id, code };
+		return { type: "reset_stream", id, code, reliableSize };
 	}
 
 	// STOP_SENDING
@@ -851,7 +882,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		if (reliableSize > finalSize) {
 			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
 		}
-		return [{ type: "reset_stream", id, code }, buffer];
+		return [{ type: "reset_stream", id, code, reliableSize }, buffer];
 	}
 
 	// STOP_SENDING

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -218,6 +218,23 @@ const APPLICATION_PROTOCOLS_ID = 0x3d4f9c2a8b1e6075n;
 // empty value, presence advertises support for receiving RESET_STREAM_AT.
 const RESET_STREAM_AT_PARAM_ID = 0x1dn;
 
+// The transport-parameter IDs we recognize. A repeat of any of these is a
+// protocol error (matching the Rust decoder's DuplicateParam); unknown IDs are
+// skipped and may repeat, per RFC 9000.
+const RECOGNIZED_PARAM_IDS = new Set<bigint>([
+	0x01n,
+	0x04n,
+	0x05n,
+	0x06n,
+	0x07n,
+	0x08n,
+	0x09n,
+	0x20n,
+	MAX_RECORD_SIZE_ID,
+	APPLICATION_PROTOCOLS_ID,
+	RESET_STREAM_AT_PARAM_ID,
+]);
+
 function encodeWebTransport(frame: Any): Uint8Array {
 	switch (frame.type) {
 		case "stream": {
@@ -466,6 +483,7 @@ function encodeTransportParams(params: TransportParams): Uint8Array<ArrayBuffer>
 
 function decodeTransportParams(buffer: Uint8Array): TransportParams {
 	const params = { ...DEFAULT_TRANSPORT_PARAMS };
+	const seen = new Set<bigint>();
 	let v: VarInt;
 
 	while (buffer.byteLength > 0) {
@@ -481,6 +499,15 @@ function decodeTransportParams(buffer: Uint8Array): TransportParams {
 
 		const paramData = buffer.slice(0, len);
 		buffer = buffer.slice(len);
+
+		// A repeated recognized parameter is a protocol error (mirrors Rust's
+		// DuplicateParam). Unknown IDs fall through and may repeat.
+		if (RECOGNIZED_PARAM_IDS.has(id)) {
+			if (seen.has(id)) {
+				throw new Error(`duplicate transport parameter 0x${id.toString(16)}`);
+			}
+			seen.add(id);
+		}
 
 		// In-band ALPN negotiation is only valid on transports without their own
 		// (TCP, Unix sockets). This implementation only runs over WebSocket, which

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -169,6 +169,17 @@ describe("Session integration (scripted peer)", () => {
 		expect(info.closeCode).toBe(1003);
 	});
 
+	test("an unnegotiated RESET_STREAM_AT closes the session", async () => {
+		// The peer negotiates qmux-01, which never advertises `reset_stream_at`, so
+		// a RESET_STREAM_AT (0x24) frame is a protocol violation. Hand-built bytes:
+		// type=0x24, id=3, code=0, final_size=0, reliable_size=0.
+		const { session, peer } = connect();
+		await session.ready;
+		peer.sendRaw(new Uint8Array([0x24, 0x03, 0x00, 0x00, 0x00]));
+		const info = await session.closed;
+		expect(info.closeCode).toBe(1002);
+	});
+
 	test("datagrams: an app write produces a DATAGRAM frame on the wire", async () => {
 		const { session, peer } = connect();
 		await session.ready;

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -99,6 +99,7 @@ function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
 		initialMaxStreamsUni: 100n,
 		maxDatagramFrameSize: DEFAULT_MAX_RECORD_SIZE,
 		maxRecordSize: DEFAULT_MAX_RECORD_SIZE,
+		resetStreamAt: false,
 		...overrides,
 	};
 }

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -70,6 +70,8 @@ function configToTransportParams(config: Required<Config>): TransportParams {
 		maxDatagramFrameSize:
 			config.maxDatagramFrameSize < config.maxRecordSize ? config.maxDatagramFrameSize : config.maxRecordSize,
 		maxRecordSize: config.maxRecordSize,
+		// Version-gated in #startSession (only advertised on qmux-02).
+		resetStreamAt: false,
 	};
 }
 
@@ -532,10 +534,14 @@ export default class Session implements WebTransport {
 
 		// Datagrams rely on the record layer for framing, so don't advertise the
 		// parameter — or accept datagrams — on any non-record wire format. The recv
-		// path gates on #ourParams.maxDatagramFrameSize.
-		if (!usesRecords(version)) {
-			this.#ourParams = { ...this.#ourParams, maxDatagramFrameSize: 0n };
-		}
+		// path gates on #ourParams.maxDatagramFrameSize. RESET_STREAM_AT is only
+		// permitted on draft-02, so advertise `reset_stream_at` there and nowhere
+		// else; the recv path gates on #ourParams.resetStreamAt.
+		this.#ourParams = {
+			...this.#ourParams,
+			maxDatagramFrameSize: usesRecords(version) ? this.#ourParams.maxDatagramFrameSize : 0n,
+			resetStreamAt: version === "qmux-02",
+		};
 
 		this.#scheduler = new SendScheduler(sink, {
 			onActivity: () => {
@@ -1031,6 +1037,14 @@ export default class Session implements WebTransport {
 	}
 
 	#handleResetStream(frame: Frame.ResetStream) {
+		// A RESET_STREAM_AT frame (reliableSize present, draft-02) is only legal if
+		// we advertised the `reset_stream_at` transport parameter. Receiving it
+		// otherwise — or on an earlier draft, which never advertises it — is a
+		// PROTOCOL_VIOLATION. Plain RESET_STREAM is always allowed.
+		if (frame.reliableSize !== undefined && !this.#ourParams.resetStreamAt) {
+			throw new Error("RESET_STREAM_AT received without advertising reset_stream_at");
+		}
+
 		const streamId = frame.id.value.value;
 		const recv = this.#recvStreams.get(streamId);
 		if (!recv) return;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -754,7 +754,10 @@ export default class Session implements WebTransport {
 		// of the timeout. Any frame counts as activity, so this only fires when truly idle.
 		if (now - this.#lastSendAt > timeoutMs / 3) {
 			const seq = this.#nextPingSeq;
-			this.#nextPingSeq = (this.#nextPingSeq + 1) >>> 0;
+			// Monotonic (never wraps within a session's life): the draft-02
+			// strictly-increasing rule requires it, and it must not wrap earlier
+			// than the Rust peer's u64 counter or a valid ping would be rejected.
+			this.#nextPingSeq += 1;
 			try {
 				this.#sendPriorityFrame({ type: "ping_request", sequence: BigInt(seq) });
 			} catch (e) {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -2,7 +2,7 @@ import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-s
 import { Credit, replenishWindow } from "./credit.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
-import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD } from "./frame.ts";
+import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
 import { RecvStream } from "./recv.ts";
 import { DEFAULT_SEND_ORDER, SendScheduler, type SendSink, WritableStreamSink } from "./scheduler.ts";
 import * as Stream from "./stream.ts";
@@ -38,8 +38,8 @@ export interface Config {
 	 *  willingness to receive; 0 disables datagrams. This is a frame size, not a
 	 *  payload size — {@link Datagrams.maxDatagramSize} reports the usable payload
 	 *  (this value less framing overhead). Keep it at or below `maxRecordSize`.
-	 *  Datagrams are a QMux01 feature; this is ignored on qmux-00. Defaults to a
-	 *  full record. */
+	 *  Datagrams are a record-framed-draft feature (qmux-01+); this is ignored on
+	 *  qmux-00. Defaults to a full record. */
 	maxDatagramFrameSize?: bigint;
 }
 
@@ -172,8 +172,8 @@ export interface SessionOptions extends WebTransportOptions {
 	 *  - `Version[]`: advertise one `{v}.{alpn}` per array entry in order.
 	 *    Lets the server pick across multiple QMux drafts.
 	 *  - `null`: advertise the ALPN under every QMux version this polyfill
-	 *    knows about (currently qmux-01, then qmux-00). Useful when the app
-	 *    doesn't care which draft and wants forward compatibility.
+	 *    knows about (currently qmux-02, qmux-01, then qmux-00). Useful when the
+	 *    app doesn't care which draft and wants forward compatibility.
 	 *
 	 * The legacy `webtransport.{alpn}` pair form was used briefly during the
 	 * web-transport-ws -> qmux transition; no production client depended on
@@ -214,6 +214,8 @@ const DEFAULT_SEND_BUFFER_SIZE = 64 * 1024;
 /** Get the subprotocol prefix for a QMux wire-format version. */
 function versionPrefix(version: Version): string {
 	switch (version) {
+		case "qmux-02":
+			return "qmux-02.";
 		case "qmux-01":
 			return "qmux-01.";
 		case "qmux-00":
@@ -222,7 +224,7 @@ function versionPrefix(version: Version): string {
 }
 
 /** QMux versions recognized as prefixed ALPNs, newest first. */
-const QMUX_VERSIONS = ["qmux-01", "qmux-00"] as const satisfies readonly Version[];
+const QMUX_VERSIONS = ["qmux-02", "qmux-01", "qmux-00"] as const satisfies readonly Version[];
 
 /** Convert `http(s)://` to `ws(s)://`. Pass-through for `ws(s)://` URLs. */
 function toWebSocketUrl(url: string | URL): string {
@@ -244,7 +246,7 @@ function toWebSocketUrl(url: string | URL): string {
 }
 
 /** Bare version ALPNs appended unless `requireProtocol` is set. Newest first. */
-const BARE_ALPNS = ["qmux-01", "qmux-00", "webtransport"] as const;
+const BARE_ALPNS = ["qmux-02", "qmux-01", "qmux-00", "webtransport"] as const;
 
 /** Resolve a `protocols` + `versions` pair to the wire subprotocol list.
  *
@@ -397,6 +399,9 @@ export default class Session implements WebTransport {
 	#lastRecvAt = Date.now();
 	#lastSendAt = Date.now();
 	#nextPingSeq = 0;
+	// Highest sequence seen in a received QX_PING request (draft-02 requires them
+	// to strictly increase). Undefined until the first request arrives.
+	#lastPingRecv?: bigint;
 	#idleTimer?: ReturnType<typeof setInterval>;
 
 	/** Open a QMux session over WebSocket against `url`.
@@ -525,10 +530,10 @@ export default class Session implements WebTransport {
 		this.#version = version;
 		this.#protocol = parseProtocol(rawProtocol, version);
 
-		// Datagrams are a QMux01 feature (they rely on the record layer for
-		// framing): don't advertise the parameter — or accept datagrams — on any
-		// other wire format. The recv path gates on #ourParams.maxDatagramFrameSize.
-		if (version !== "qmux-01") {
+		// Datagrams rely on the record layer for framing, so don't advertise the
+		// parameter — or accept datagrams — on any non-record wire format. The recv
+		// path gates on #ourParams.maxDatagramFrameSize.
+		if (!usesRecords(version)) {
 			this.#ourParams = { ...this.#ourParams, maxDatagramFrameSize: 0n };
 		}
 
@@ -557,8 +562,8 @@ export default class Session implements WebTransport {
 	#onData(data: Uint8Array) {
 		this.#lastRecvAt = Date.now();
 		try {
-			if (this.#version === "qmux-01") {
-				// QMux01: each WS message is a record containing one or more frames
+			if (usesRecords(this.#version)) {
+				// Record-framed drafts: each WS message is a record with one or more frames
 				const frames = Frame.decodeRecord(data);
 				for (const frame of frames) {
 					this.#recvFrame(frame);
@@ -577,6 +582,16 @@ export default class Session implements WebTransport {
 	}
 
 	#recvFrame(frame: Frame.Any) {
+		// Draft-02: QX_TRANSPORT_PARAMETERS MUST be the first frame, and only the
+		// first. A non-params frame before params, or a second params frame, is a
+		// PROTOCOL_VIOLATION. (decodeRecord drops leading PADDING before we get here.)
+		if (this.#version === "qmux-02") {
+			const isParams = frame.type === "transport_parameters";
+			if (isParams === this.#paramsReceived) {
+				throw new Error("QX_TRANSPORT_PARAMETERS must be the first frame");
+			}
+		}
+
 		if (frame.type === "stream") {
 			this.#handleStreamFrame(frame);
 		} else if (frame.type === "reset_stream") {
@@ -621,10 +636,20 @@ export default class Session implements WebTransport {
 			}
 			this.datagrams.push(frame.data);
 		} else if (frame.type === "ping_request") {
+			// Draft-02: request sequence numbers must strictly increase.
+			if (this.#version === "qmux-02") {
+				if (this.#lastPingRecv !== undefined && frame.sequence <= this.#lastPingRecv) {
+					throw new Error("QX_PING request sequence must strictly increase");
+				}
+				this.#lastPingRecv = frame.sequence;
+			}
 			// Respond to ping requests
 			this.#sendPriorityFrame({ type: "ping_response", sequence: frame.sequence });
 		} else if (frame.type === "ping_response") {
-			// Ping response received, no action needed
+			// Draft-02: a response must echo a sequence we actually sent (0..nextPingSeq).
+			if (this.#version === "qmux-02" && frame.sequence >= BigInt(this.#nextPingSeq)) {
+				throw new Error("QX_PING response echoed a sequence we never sent");
+			}
 		} else if (
 			frame.type === "data_blocked" ||
 			frame.type === "stream_data_blocked" ||
@@ -637,6 +662,12 @@ export default class Session implements WebTransport {
 
 	#handleTransportParameters(params: TransportParams) {
 		if (this.#paramsReceived) return;
+		// Draft-02: an advertised max_record_size MUST NOT go below the default
+		// minimum. Omitted values decode to the default, so only an explicit
+		// smaller value trips this (TRANSPORT_PARAMETER_ERROR).
+		if (this.#version === "qmux-02" && params.maxRecordSize < Frame.DEFAULT_MAX_RECORD_SIZE) {
+			throw new Error("max_record_size below the default minimum");
+		}
 		this.#paramsReceived = true;
 		this.#peerParams = params;
 
@@ -648,7 +679,7 @@ export default class Session implements WebTransport {
 		// they stay disabled on any other wire format. Otherwise whether we may
 		// *send* depends solely on the peer's willingness to receive (RFC 9221):
 		// 0 means unsupported.
-		if (this.#version === "qmux-01" && params.maxDatagramFrameSize > 0n) {
+		if (usesRecords(this.#version) && params.maxDatagramFrameSize > 0n) {
 			// A datagram must fit in one record, so the frame is capped by the
 			// smaller of the peer's datagram-frame limit and its record size.
 			const cap =
@@ -682,7 +713,7 @@ export default class Session implements WebTransport {
 	 * (or the single non-zero one). If both are zero, idle timeouts are disabled.
 	 */
 	#effectiveIdleTimeoutMs(): bigint {
-		if (this.#version !== "qmux-01") return 0n;
+		if (!usesRecords(this.#version)) return 0n;
 		const a = this.#ourParams.maxIdleTimeout;
 		const b = this.#peerParams.maxIdleTimeout;
 		if (a === 0n && b === 0n) return 0n;
@@ -1037,9 +1068,9 @@ export default class Session implements WebTransport {
 		this.#sendPriorityFrame({ type: "transport_parameters", params: this.#ourParams });
 	}
 
-	/** Validate an encoded record against the peer's max_record_size (QMux01). */
+	/** Validate an encoded record against the peer's max_record_size (QMux01+). */
 	#validateRecordSize(bytes: Uint8Array) {
-		if (this.#version === "qmux-01") {
+		if (usesRecords(this.#version)) {
 			// Before the peer's TRANSPORT_PARAMETERS arrive, use the draft-01 default
 			// (16382) so we don't accidentally send something the peer will reject.
 			const limit = this.#paramsReceived ? this.#peerParams.maxRecordSize : Frame.DEFAULT_MAX_RECORD_SIZE;
@@ -1065,7 +1096,7 @@ export default class Session implements WebTransport {
 			// (qmux-01 only — once params are received). Leave 32 bytes of headroom for
 			// the STREAM frame header (frame type + stream id + length varints).
 			let chunkMax = Math.min(remaining, MAX_FRAME_PAYLOAD);
-			if (this.#version === "qmux-01" && this.#paramsReceived) {
+			if (usesRecords(this.#version) && this.#paramsReceived) {
 				const peerLimit = Number(this.#peerParams.maxRecordSize) - 32;
 				if (peerLimit > 0) {
 					chunkMax = Math.min(chunkMax, peerLimit);

--- a/js/qmux/src/subprotocol.test.ts
+++ b/js/qmux/src/subprotocol.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { resolveSubprotocols } from "./session.ts";
 
 // The bare version ALPNs the polyfill appends when `requireProtocol` is false.
-const BARE = ["qmux-01", "qmux-00", "webtransport"];
+const BARE = ["qmux-02", "qmux-01", "qmux-00", "webtransport"];
 
 describe("resolveSubprotocols", () => {
 	test("no protocols still offers the bare version ALPNs by default", () => {
@@ -31,6 +31,7 @@ describe("resolveSubprotocols", () => {
 
 	test("null version expands to every qmux draft, newest first", () => {
 		expect(resolveSubprotocols(["moq-lite-04"], { "moq-lite-04": null }, true)).toEqual([
+			"qmux-02.moq-lite-04",
 			"qmux-01.moq-lite-04",
 			"qmux-00.moq-lite-04",
 		]);

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmux"
-description = "QMux protocol (draft-ietf-quic-qmux-01) over reliable transports"
+description = "QMux protocol (draft-ietf-quic-qmux-02) over reliable transports"
 authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"

--- a/rs/qmux/README.md
+++ b/rs/qmux/README.md
@@ -1,6 +1,6 @@
 # qmux
 
-A Rust implementation of the [QMux protocol](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-01.html) (draft-ietf-quic-qmux-01).
+A Rust implementation of the [QMux protocol](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html) (draft-ietf-quic-qmux-02, negotiating down to draft-01 and draft-00).
 
 QMux brings QUIC's multiplexed streams and flow control to reliable, ordered byte-stream transports like TCP and WebSockets. It allows applications built for QUIC to seamlessly fall back to TCP/TLS when UDP is blocked by network middleboxes, without maintaining separate protocol implementations.
 

--- a/rs/qmux/src/alpn.rs
+++ b/rs/qmux/src/alpn.rs
@@ -5,10 +5,10 @@
 //! is emitted once per version, in order. An empty `versions` slice means
 //! "every QMux draft this crate knows about" (see [`QMUX_VERSIONS`]).
 //!
-//! Bare version ALPNs (`qmux-01`, `qmux-00`, `webtransport`, no app protocol
-//! attached) are advertised/accepted by default, so a peer that only knows a
-//! wire-format version can still connect. Set the `require_protocol` flag to
-//! suppress them and advertise/accept only the configured prefixed pairs.
+//! Bare version ALPNs (`qmux-02`, `qmux-01`, `qmux-00`, `webtransport`, no app
+//! protocol attached) are advertised/accepted by default, so a peer that only
+//! knows a wire-format version can still connect. Set the `require_protocol`
+//! flag to suppress them and advertise/accept only the configured prefixed pairs.
 //!
 //! [`parse`] recovers `(Version, Option<String>)` from a negotiated wire-format
 //! ALPN. Only the QMux drafts appear in `{prefix}{alpn}` form; the legacy
@@ -18,12 +18,16 @@
 use crate::Version;
 
 /// QMux versions that can ride under a `{prefix}{alpn}` pair, newest first.
-pub(crate) const QMUX_VERSIONS: &[Version] = &[Version::QMux01, Version::QMux00];
+pub(crate) const QMUX_VERSIONS: &[Version] = &[Version::QMux02, Version::QMux01, Version::QMux00];
 
 /// Bare version ALPNs added (offered by clients, accepted by servers) unless
 /// the caller opts out via `require_protocol`. Newest first.
-pub(crate) const BARE_ALPNS: &[Version] =
-    &[Version::QMux01, Version::QMux00, Version::WebTransport];
+pub(crate) const BARE_ALPNS: &[Version] = &[
+    Version::QMux02,
+    Version::QMux01,
+    Version::QMux00,
+    Version::WebTransport,
+];
 
 /// Resolve an entry's `versions` slice: empty falls back to every supported
 /// QMux draft, mirroring JS's `null` value.
@@ -38,9 +42,9 @@ pub(crate) fn expand_versions(versions: &[Version]) -> &[Version] {
 /// Build the ALPN list from `(alpn, versions)` entries.
 ///
 /// Each entry emits `{v.prefix()}{alpn}` per version in `expand_versions(versions)`.
-/// Unless `require_protocol` is set, the bare version ALPNs (`qmux-01`,
-/// `qmux-00`, `webtransport`) are appended after the prefixed pairs as a
-/// fallback for peers that don't want to commit to an app protocol.
+/// Unless `require_protocol` is set, the bare version ALPNs (`qmux-02`,
+/// `qmux-01`, `qmux-00`, `webtransport`) are appended after the prefixed pairs
+/// as a fallback for peers that don't want to commit to an app protocol.
 ///
 /// Suitable for TLS ALPN or WebSocket `Sec-WebSocket-Protocol`.
 ///
@@ -107,7 +111,13 @@ mod tests {
         let out = build([("moq-lite-04", &[Version::QMux01][..])], false);
         assert_eq!(
             out,
-            vec!["qmux-01.moq-lite-04", "qmux-01", "qmux-00", "webtransport"]
+            vec![
+                "qmux-01.moq-lite-04",
+                "qmux-02",
+                "qmux-01",
+                "qmux-00",
+                "webtransport"
+            ]
         );
     }
 
@@ -126,7 +136,14 @@ mod tests {
     #[test]
     fn build_expands_empty_versions_to_all_qmux_drafts() {
         let out = build([("moq-lite-04", &[][..])], true);
-        assert_eq!(out, vec!["qmux-01.moq-lite-04", "qmux-00.moq-lite-04"]);
+        assert_eq!(
+            out,
+            vec![
+                "qmux-02.moq-lite-04",
+                "qmux-01.moq-lite-04",
+                "qmux-00.moq-lite-04"
+            ]
+        );
     }
 
     #[test]
@@ -142,7 +159,7 @@ mod tests {
     fn build_empty_by_default_emits_only_bare_alpns() {
         let entries: [(&str, &[Version]); 0] = [];
         let out = build(entries, false);
-        assert_eq!(out, vec!["qmux-01", "qmux-00", "webtransport"]);
+        assert_eq!(out, vec!["qmux-02", "qmux-01", "qmux-00", "webtransport"]);
     }
 
     #[test]
@@ -155,6 +172,10 @@ mod tests {
     #[test]
     fn parse_recognises_prefixed_pairs() {
         assert_eq!(
+            parse(Some("qmux-02.moq-lite-04")),
+            (Version::QMux02, Some("moq-lite-04".to_string()))
+        );
+        assert_eq!(
             parse(Some("qmux-01.moq-lite-04")),
             (Version::QMux01, Some("moq-lite-04".to_string()))
         );
@@ -166,6 +187,7 @@ mod tests {
 
     #[test]
     fn parse_recognises_bare_versions() {
+        assert_eq!(parse(Some("qmux-02")), (Version::QMux02, None));
         assert_eq!(parse(Some("qmux-01")), (Version::QMux01, None));
         assert_eq!(parse(Some("qmux-00")), (Version::QMux00, None));
         assert_eq!(parse(Some("webtransport")), (Version::WebTransport, None));

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -148,6 +148,10 @@ impl Config {
                 0
             },
             max_record_size: self.max_record_size,
+            // Advertise willingness to receive RESET_STREAM_AT only on draft-02,
+            // the version that permits the extension. A peer may then send it, and
+            // our receive path (gated on this same flag) accepts it.
+            reset_stream_at: self.version == Version::QMux02,
             // Only advertise protocols when negotiating in-band; TLS/WS already
             // chose one via ALPN and must not send this parameter.
             protocols: match &self.protocol {

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -55,9 +55,10 @@ pub struct Config {
     /// Per-stream receive window for uni streams.
     pub max_stream_data_uni: u64,
 
-    /// Idle timeout in milliseconds (0 = disabled). Only used in QMux01.
+    /// Idle timeout in milliseconds (0 = disabled). Only used by the
+    /// record-framed drafts (QMux01+).
     pub max_idle_timeout: u64,
-    /// Maximum QMux Record size in bytes (draft-01). Default: 16382.
+    /// Maximum QMux Record size in bytes (draft-01+). Default: 16382.
     pub max_record_size: u64,
 
     /// Largest DATAGRAM *frame* (RFC 9221: frame type + length + payload) we
@@ -68,8 +69,8 @@ pub struct Config {
     /// [`max_datagram_size`](web_transport_trait::Session::max_datagram_size) is
     /// this value less the per-frame overhead. A datagram must fit within a
     /// single record, so keep it at or below
-    /// [`max_record_size`](Config::max_record_size). Datagrams are a QMux01
-    /// feature (they rely on the record layer); this is ignored on QMux00 and the
+    /// [`max_record_size`](Config::max_record_size). Datagrams are a
+    /// record-framed-draft feature (QMux01+); this is ignored on QMux00 and the
     /// legacy `webtransport` format. Default:
     /// [`DEFAULT_MAX_RECORD_SIZE`](crate::proto::DEFAULT_MAX_RECORD_SIZE).
     pub max_datagram_frame_size: u64,
@@ -86,7 +87,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            version: Version::QMux01,
+            version: Version::QMux02,
             protocol: Protocol::None,
             max_streams_bidi: 100,
             max_streams_uni: 100,
@@ -135,12 +136,13 @@ impl Config {
             initial_max_stream_data_uni: self.max_stream_data_uni,
             initial_max_streams_bidi: self.max_streams_bidi,
             initial_max_streams_uni: self.max_streams_uni,
-            // Datagrams are a QMux01 feature (they rely on the record layer to be
-            // framed): only advertise the parameter on QMux01. Elsewhere it stays
-            // 0 — "unsupported" — which the encoder omits. Clamp to max_record_size
-            // so we never invite a datagram larger than our record layer accepts
-            // (recv_record would reject it as FrameTooLarge and kill the session).
-            max_datagram_frame_size: if self.version == Version::QMux01 {
+            // Datagrams rely on the record layer to be framed, so only advertise
+            // the parameter on the record-framed drafts (draft-01+). Elsewhere it
+            // stays 0 — "unsupported" — which the encoder omits. Clamp to
+            // max_record_size so we never invite a datagram larger than our record
+            // layer accepts (recv_record would reject it as FrameTooLarge and kill
+            // the session).
+            max_datagram_frame_size: if self.version.uses_records() {
                 self.max_datagram_frame_size.min(self.max_record_size)
             } else {
                 0

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -30,6 +30,24 @@ pub enum Error {
     #[error("flow control error")]
     FlowControlError,
 
+    /// A frame was malformed on the wire — QMux's FRAME_ENCODING_ERROR. Draft-02
+    /// raises this e.g. when a RESET_STREAM_AT frame's Reliable Size exceeds its
+    /// Final Size.
+    #[error("frame encoding error")]
+    FrameEncoding,
+
+    /// The peer broke a protocol rule — QMux's PROTOCOL_VIOLATION. Draft-02
+    /// raises this for QX_TRANSPORT_PARAMETERS sent out of order (or twice) and
+    /// for invalid QX_PING sequence numbers.
+    #[error("protocol violation")]
+    ProtocolViolation,
+
+    /// A transport parameter carried an illegal value — QMux's
+    /// TRANSPORT_PARAMETER_ERROR. Draft-02 raises this when a peer advertises a
+    /// `max_record_size` below the default minimum.
+    #[error("transport parameter error")]
+    TransportParameter,
+
     #[error("stream limit exceeded")]
     StreamLimitExceeded,
 

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -1,7 +1,8 @@
-//! QMux protocol (draft-ietf-quic-qmux-01) over reliable transports.
+//! QMux protocol (draft-ietf-quic-qmux-02) over reliable transports.
 //!
-//! Provides QUIC-style multiplexed streams over TCP, TLS, and WebSocket,
-//! with backwards compatibility for the legacy `webtransport` wire format.
+//! Provides QUIC-style multiplexed streams over TCP, TLS, and WebSocket.
+//! Speaks draft-02 by default, negotiating down to draft-01 or draft-00, with
+//! backwards compatibility for the legacy `webtransport` wire format.
 
 // ALPN/subprotocol negotiation is only used by the TLS and WebSocket transports.
 #[cfg(any(feature = "tls", feature = "ws"))]
@@ -60,4 +61,4 @@ pub use transport::Transport;
 ///
 /// Use this when configuring TLS to advertise QMux support.
 /// For version-specific ALPNs, use [`Version::alpn()`].
-pub const ALPNS: &[&str] = &["qmux-01", "qmux-00", "webtransport"];
+pub const ALPNS: &[&str] = &["qmux-02", "qmux-01", "qmux-00", "webtransport"];

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -5,6 +5,11 @@ use crate::{Error, StreamId, TransportParams, Version};
 
 // QMux frame type IDs (QUIC v1 compatible)
 const RESET_STREAM: VarInt = VarInt::from_u32(0x04);
+// RESET_STREAM_AT (draft-ietf-quic-reliable-stream-reset), permitted by QMux
+// draft-02. Decode-only: we accept and validate it, then treat it as a plain
+// reset (see the decode arms for why the reliable-delivery guarantee is
+// automatically satisfied on a reliable, ordered transport).
+const RESET_STREAM_AT: u64 = 0x24;
 const STOP_SENDING: VarInt = VarInt::from_u32(0x05);
 const STREAM_BASE: u32 = 0x08;
 const MAX_DATA: VarInt = VarInt::from_u32(0x10);
@@ -178,9 +183,10 @@ impl Frame {
     /// the transport layer is responsible for delimiting records (size
     /// varint on TCP/TLS; implicit on WebSocket message boundaries).
     pub fn encode(&self, version: Version) -> Result<Bytes, Error> {
-        // Reject QMux01-only frames for older versions so a misrouted call
-        // can't accidentally emit draft-01 wire bytes on a draft-00 session.
-        if version != Version::QMux01 {
+        // Reject record-layer frames (PADDING, QX_PING, DATAGRAM) for versions
+        // that don't use records, so a misrouted call can't accidentally emit
+        // draft-01+ wire bytes on a draft-00 / webtransport session.
+        if !version.uses_records() {
             match self {
                 Frame::Padding | Frame::Ping(_) | Frame::Datagram(_) => {
                     return Err(Error::InvalidFrameType(0))
@@ -193,7 +199,7 @@ impl Frame {
 
         match version {
             Version::WebTransport => self.encode_wt(&mut buf)?,
-            Version::QMux00 | Version::QMux01 => self.encode_qmux(&mut buf)?,
+            Version::QMux00 | Version::QMux01 | Version::QMux02 => self.encode_qmux(&mut buf)?,
         }
 
         Ok(buf.freeze())
@@ -263,6 +269,25 @@ impl Frame {
                 let id = StreamId(VarInt::decode(data)?);
                 let code = VarInt::decode(data)?;
                 let final_size = VarInt::decode(data)?.into_inner();
+                Ok(Some(Frame::ResetStream(ResetStream {
+                    id,
+                    code,
+                    final_size,
+                })))
+            }
+            // RESET_STREAM_AT (draft-02). QMux runs on a reliable, ordered
+            // transport, so every STREAM frame up to `final_size` has already
+            // been delivered by the time this frame arrives — the Reliable Size
+            // guarantee is automatically satisfied and we treat it as a plain
+            // reset. `reliable_size > final_size` is a FRAME_ENCODING_ERROR.
+            RESET_STREAM_AT => {
+                let id = StreamId(VarInt::decode(data)?);
+                let code = VarInt::decode(data)?;
+                let final_size = VarInt::decode(data)?.into_inner();
+                let reliable_size = VarInt::decode(data)?.into_inner();
+                if reliable_size > final_size {
+                    return Err(Error::FrameEncoding);
+                }
                 Ok(Some(Frame::ResetStream(ResetStream {
                     id,
                     code,
@@ -514,7 +539,7 @@ impl Frame {
 
         match version {
             Version::WebTransport => Self::decode_wt(data).map(Some),
-            Version::QMux00 | Version::QMux01 => Self::decode_qmux(data),
+            Version::QMux00 | Version::QMux01 | Version::QMux02 => Self::decode_qmux(data),
         }
     }
 
@@ -602,6 +627,22 @@ impl Frame {
                 let id = StreamId(VarInt::decode(&mut data)?);
                 let code = VarInt::decode(&mut data)?;
                 let final_size = VarInt::decode(&mut data)?.into_inner();
+                Ok(Some(Frame::ResetStream(ResetStream {
+                    id,
+                    code,
+                    final_size,
+                })))
+            }
+            // RESET_STREAM_AT (draft-02); see the record-decoder arm for why we
+            // treat it as a plain reset.
+            RESET_STREAM_AT => {
+                let id = StreamId(VarInt::decode(&mut data)?);
+                let code = VarInt::decode(&mut data)?;
+                let final_size = VarInt::decode(&mut data)?.into_inner();
+                let reliable_size = VarInt::decode(&mut data)?.into_inner();
+                if reliable_size > final_size {
+                    return Err(Error::FrameEncoding);
+                }
                 Ok(Some(Frame::ResetStream(ResetStream {
                     id,
                     code,

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -76,6 +76,12 @@ pub struct ResetStream {
     pub code: VarInt,
     /// Total bytes sent on the stream before the reset (for flow control accounting).
     pub final_size: u64,
+    /// `Some(reliable_size)` when this was decoded from a RESET_STREAM_AT frame
+    /// (`0x24`, draft-02); `None` for a plain RESET_STREAM (`0x04`). The session
+    /// uses this to enforce that RESET_STREAM_AT is only accepted when we
+    /// advertised the `reset_stream_at` transport parameter. We never emit
+    /// RESET_STREAM_AT, so the encoder ignores this field.
+    pub reliable_size: Option<u64>,
 }
 
 /// Requests that the peer stop sending on a stream.
@@ -273,13 +279,15 @@ impl Frame {
                     id,
                     code,
                     final_size,
+                    reliable_size: None,
                 })))
             }
             // RESET_STREAM_AT (draft-02). QMux runs on a reliable, ordered
             // transport, so every STREAM frame up to `final_size` has already
             // been delivered by the time this frame arrives — the Reliable Size
             // guarantee is automatically satisfied and we treat it as a plain
-            // reset. `reliable_size > final_size` is a FRAME_ENCODING_ERROR.
+            // reset. `reliable_size > final_size` is a FRAME_ENCODING_ERROR; the
+            // session additionally rejects it unless we advertised reset_stream_at.
             RESET_STREAM_AT => {
                 let id = StreamId(VarInt::decode(data)?);
                 let code = VarInt::decode(data)?;
@@ -292,6 +300,7 @@ impl Frame {
                     id,
                     code,
                     final_size,
+                    reliable_size: Some(reliable_size),
                 })))
             }
             // STOP_SENDING
@@ -555,6 +564,7 @@ impl Frame {
                     id,
                     code,
                     final_size: 0,
+                    reliable_size: None,
                 }))
             }
             0x05 => {
@@ -631,6 +641,7 @@ impl Frame {
                     id,
                     code,
                     final_size,
+                    reliable_size: None,
                 })))
             }
             // RESET_STREAM_AT (draft-02); see the record-decoder arm for why we
@@ -647,6 +658,7 @@ impl Frame {
                     id,
                     code,
                     final_size,
+                    reliable_size: Some(reliable_size),
                 })))
             }
             // STOP_SENDING

--- a/rs/qmux/src/proto/params.rs
+++ b/rs/qmux/src/proto/params.rs
@@ -23,6 +23,13 @@ pub struct TransportParams {
     pub max_datagram_frame_size: u64,             // ID 0x20 (RFC 9221; 0 = datagrams unsupported)
     pub max_record_size: u64,                     // ID 0x0571c59429cd0845 (default 16382)
 
+    /// Whether we advertise support for *receiving* RESET_STREAM_AT frames, via
+    /// the empty-valued `reset_stream_at` transport parameter (ID 0x1d, from
+    /// draft-ietf-quic-reliable-stream-reset). Only meaningful on QMux draft-02,
+    /// which permits the extension. A peer may send us RESET_STREAM_AT only once
+    /// we've advertised this.
+    pub reset_stream_at: bool,
+
     /// Application protocols advertised for negotiation (preference order).
     ///
     /// QMux-specific (ID 0x3d4f9c2a8b1e6075). This is the non-TLS substitute
@@ -66,6 +73,8 @@ impl TransportParams {
     const INITIAL_MAX_STREAMS_BIDI: VarInt = VarInt::from_u32(0x08);
     const INITIAL_MAX_STREAMS_UNI: VarInt = VarInt::from_u32(0x09);
     const MAX_DATAGRAM_FRAME_SIZE: VarInt = VarInt::from_u32(0x20);
+    // reset_stream_at (draft-ietf-quic-reliable-stream-reset): empty value.
+    const RESET_STREAM_AT: VarInt = VarInt::from_u32(0x1d);
 
     /// Encode transport parameters as a series of ID-length-value tuples.
     pub fn encode(&self) -> Result<Bytes, Error> {
@@ -118,6 +127,13 @@ impl TransportParams {
         )?;
         write_param(&mut buf, MAX_RECORD_SIZE_ID_VI, self.max_record_size)?;
 
+        // reset_stream_at: an empty-valued flag. Presence advertises that we
+        // accept RESET_STREAM_AT frames; absence means we don't.
+        if self.reset_stream_at {
+            Self::RESET_STREAM_AT.encode(&mut buf);
+            VarInt::from_u32(0).encode(&mut buf);
+        }
+
         // application_protocols: a list of length-prefixed UTF-8 names. Omitted
         // entirely when empty so peers that don't negotiate stay byte-identical.
         if !self.protocols.is_empty() {
@@ -160,6 +176,17 @@ impl TransportParams {
                         return Err(Error::DuplicateParam(id));
                     }
                     params.protocols = decode_protocols(&mut param_data)?;
+                }
+                0x1d => {
+                    // reset_stream_at: presence-only. A non-empty value is a
+                    // TRANSPORT_PARAMETER_ERROR per the extension spec.
+                    if !seen.insert(id) {
+                        return Err(Error::DuplicateParam(id));
+                    }
+                    if param_data.has_remaining() {
+                        return Err(Error::TransportParameter);
+                    }
+                    params.reset_stream_at = true;
                 }
                 0x01 | 0x04..=0x09 | 0x20 | MAX_RECORD_SIZE_ID => {
                     if !seen.insert(id) {
@@ -286,6 +313,38 @@ mod tests {
                 .max_datagram_frame_size,
             0
         );
+    }
+
+    #[test]
+    fn reset_stream_at_round_trips() {
+        let params = TransportParams {
+            reset_stream_at: true,
+            ..TransportParams::default()
+        };
+        assert!(
+            TransportParams::decode(params.encode().unwrap())
+                .unwrap()
+                .reset_stream_at
+        );
+        // Omitted from the wire when unset, so a peer that doesn't support the
+        // extension stays byte-identical.
+        let bytes = TransportParams::default().encode().unwrap();
+        assert!(!bytes.contains(&0x1d));
+        assert!(!TransportParams::decode(bytes).unwrap().reset_stream_at);
+    }
+
+    #[test]
+    fn reset_stream_at_non_empty_rejected() {
+        // id=0x1d, len=1, one value byte — a non-empty value is a
+        // TRANSPORT_PARAMETER_ERROR per the extension spec.
+        let mut buf = BytesMut::new();
+        VarInt::from_u32(0x1d).encode(&mut buf);
+        VarInt::from_u32(1).encode(&mut buf);
+        buf.put_u8(0x00);
+        assert!(matches!(
+            TransportParams::decode(buf.freeze()),
+            Err(Error::TransportParameter)
+        ));
     }
 
     #[test]

--- a/rs/qmux/src/proto/version.rs
+++ b/rs/qmux/src/proto/version.rs
@@ -11,12 +11,25 @@ pub enum Version {
     /// QMux draft-01 wire format (any transport).
     /// Adds QMux Records framing, QX_PING, PADDING, max_idle_timeout, max_record_size.
     QMux01,
+    /// QMux draft-02 wire format (any transport).
+    /// Wire-compatible with draft-01, adds the RESET_STREAM_AT frame and the
+    /// stricter QX_TRANSPORT_PARAMETERS / QX_PING / max_record_size rules.
+    QMux02,
 }
 
 impl Version {
     /// Returns true if the version uses QMux framing (draft-00 or later).
     pub fn is_qmux(self) -> bool {
-        matches!(self, Version::QMux00 | Version::QMux01)
+        matches!(self, Version::QMux00 | Version::QMux01 | Version::QMux02)
+    }
+
+    /// Returns true if the version uses the QMux Record framing layer and the
+    /// features introduced alongside it — the size-prefixed record on byte
+    /// streams, QX_PING keep-alive, PADDING, datagrams, `max_idle_timeout`, and
+    /// `max_record_size`. True for draft-01 and later; false for draft-00 and the
+    /// legacy `webtransport` format, which speak bare frames.
+    pub fn uses_records(self) -> bool {
+        matches!(self, Version::QMux01 | Version::QMux02)
     }
 
     /// The bare ALPN identifier for this version (e.g. `"qmux-01"`).
@@ -25,6 +38,7 @@ impl Version {
             Version::WebTransport => "webtransport",
             Version::QMux00 => "qmux-00",
             Version::QMux01 => "qmux-01",
+            Version::QMux02 => "qmux-02",
         }
     }
 
@@ -34,9 +48,15 @@ impl Version {
             Version::WebTransport => "webtransport.",
             Version::QMux00 => "qmux-00.",
             Version::QMux01 => "qmux-01.",
+            Version::QMux02 => "qmux-02.",
         }
     }
 
     /// All supported versions, in preference order (newest first).
-    pub const ALL: &[Version] = &[Version::QMux01, Version::QMux00, Version::WebTransport];
+    pub const ALL: &[Version] = &[
+        Version::QMux02,
+        Version::QMux01,
+        Version::QMux00,
+        Version::WebTransport,
+    ];
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -258,6 +258,13 @@ struct SessionState<R: Reader> {
     // parameters arrive.
     record_limit: Arc<AtomicU64>,
     idle_timeout_ms: Arc<AtomicU64>,
+
+    // Draft-02 QX_PING sequence validation. `last_ping_recv` is the highest
+    // sequence seen in a received QX_PING *request*, so we can enforce that they
+    // strictly increase. `pings_sent` (shared with the timer) is how many
+    // requests we've sent, bounding the sequence a received *response* may echo.
+    last_ping_recv: Option<u64>,
+    pings_sent: Arc<AtomicU64>,
 }
 
 /// Pick the next outbound frame in strict priority order: control (lossless,
@@ -478,7 +485,7 @@ impl<W: Writer> WriterState<W> {
         }
 
         let bytes = frame.encode(self.version)?;
-        if self.version == Version::QMux01 {
+        if self.version.uses_records() {
             // `record_limit` holds the draft-01 default until the peer's params
             // arrive, then the peer's `max_record_size`.
             let limit = self.record_limit.load(Ordering::Acquire);
@@ -504,7 +511,8 @@ impl<W: Writer> WriterState<W> {
     }
 }
 
-/// Timer task: the sole owner of the QMux01 idle timeout and keep-alive ping.
+/// Timer task: the sole owner of the record-framed-draft idle timeout and
+/// keep-alive ping (QMux01+).
 ///
 /// Runs on its own task, decoupled from where the reader and writer are parked, so
 /// neither transport backpressure (writer wedged in `send`) nor application
@@ -519,8 +527,8 @@ impl<W: Writer> WriterState<W> {
 ///    backpressured — that's evidence the peer is alive and we simply can't get a
 ///    keep-alive through (or aren't reading its replies).
 ///
-/// Only meaningful for QMux01 — the sole version that negotiates an idle timeout —
-/// so it isn't spawned otherwise.
+/// Only meaningful for the record-framed drafts (QMux01+) — the versions that
+/// negotiate an idle timeout — so it isn't spawned otherwise.
 struct TimerState {
     // Origin shared with the reader/writer for interpreting the millis timestamps.
     base: tokio::time::Instant,
@@ -535,6 +543,11 @@ struct TimerState {
     closed: watch::Sender<Option<Error>>,
     // Gates arming: the idle timeout only applies once params are exchanged.
     established: watch::Receiver<bool>,
+
+    // Count of QX_PING requests we've enqueued (i.e. sequences 0..pings_sent).
+    // Published for the reader task, which rejects (draft-02) a QX_PING response
+    // echoing a sequence we never sent.
+    pings_sent: Arc<AtomicU64>,
 }
 
 impl TimerState {
@@ -607,6 +620,9 @@ impl TimerState {
                         response: false,
                     });
                     next_ping_seq = next_ping_seq.wrapping_add(1);
+                    // Publish before the enqueue is observable so the reader never
+                    // sees a response to a ping it hasn't been told about.
+                    self.pings_sent.store(next_ping_seq, Ordering::Release);
                     if self.control.send(ping).is_err() {
                         return; // writer gone
                     }
@@ -665,8 +681,8 @@ impl<R: Reader> SessionState<R> {
                         millis_since(self.base, tokio::time::Instant::now()),
                         Ordering::Release,
                     );
-                    if self.config.version == Version::QMux01 {
-                        // QMux01: data is a record containing one or more frames
+                    if self.config.version.uses_records() {
+                        // Record-framed drafts: data is a record containing one or more frames
                         for frame in Frame::decode_record(data)? {
                             self.recv_frame(frame).await?;
                         }
@@ -690,6 +706,17 @@ impl<R: Reader> SessionState<R> {
     }
 
     async fn recv_frame(&mut self, frame: Frame) -> Result<(), Error> {
+        // Draft-02: QX_TRANSPORT_PARAMETERS MUST be the first frame, and only the
+        // first. A non-params frame before params, or a second params frame, is a
+        // PROTOCOL_VIOLATION. (`decode_record` drops leading PADDING before we get
+        // here, so it never trips this.)
+        if self.config.version == Version::QMux02 {
+            let is_params = matches!(frame, Frame::TransportParameters(_));
+            if is_params == self.params_received {
+                return Err(Error::ProtocolViolation);
+            }
+        }
+
         match frame {
             Frame::TransportParameters(params) => {
                 self.recv_transport_parameters(params)?;
@@ -966,8 +993,27 @@ impl<R: Reader> SessionState<R> {
             | Frame::StreamsBlockedUni(_) => {}
             // PADDING is a no-op
             Frame::Padding => {}
-            // QX_PING: respond to requests, ignore responses
+            // QX_PING: respond to requests, ignore responses.
             Frame::Ping(ping) => {
+                // Draft-02 tightens the sequence-number rules.
+                if self.config.version == Version::QMux02 {
+                    if ping.response {
+                        // A response must echo a sequence we actually sent — i.e.
+                        // one of 0..pings_sent. Anything else is a violation.
+                        if ping.sequence >= self.pings_sent.load(Ordering::Acquire) {
+                            return Err(Error::ProtocolViolation);
+                        }
+                    } else {
+                        // Request sequence numbers must strictly increase.
+                        if self
+                            .last_ping_recv
+                            .is_some_and(|prev| ping.sequence <= prev)
+                        {
+                            return Err(Error::ProtocolViolation);
+                        }
+                        self.last_ping_recv = Some(ping.sequence);
+                    }
+                }
                 if !ping.response {
                     let response = Frame::Ping(crate::Ping {
                         sequence: ping.sequence,
@@ -1002,10 +1048,20 @@ impl<R: Reader> SessionState<R> {
 
     fn recv_transport_parameters(&mut self, params: TransportParams) -> Result<(), Error> {
         if self.params_received {
-            // Duplicate transport parameters
+            // Duplicate transport parameters. (Draft-02 additionally forbids this
+            // as a PROTOCOL_VIOLATION before we get here — see `recv_frame`.)
             return Err(Error::FlowControlError);
         }
         self.params_received = true;
+
+        // Draft-02: a peer that advertises `max_record_size` MUST NOT go below the
+        // default minimum. Values omit to the default (decode seeds it), so only an
+        // explicit smaller value trips this. Earlier drafts didn't enforce it.
+        if self.config.version == Version::QMux02
+            && params.max_record_size < crate::proto::DEFAULT_MAX_RECORD_SIZE
+        {
+            return Err(Error::TransportParameter);
+        }
 
         // Resolve / validate the application protocol now the peer's offer is known.
         match &self.config.protocol {
@@ -1072,7 +1128,7 @@ impl<R: Reader> SessionState<R> {
         // the outbound record-size limit (QMux01 only) and the effective idle
         // timeout for its keep-alive ping. `record_limit` was seeded with the
         // draft-01 default; raise it to the peer's advertised size.
-        let idle_ms = if self.config.version == Version::QMux01 {
+        let idle_ms = if self.config.version.uses_records() {
             self.record_limit
                 .store(params.max_record_size, Ordering::Release);
             negotiated_idle_timeout_ms(self.our_params.max_idle_timeout, params.max_idle_timeout)
@@ -1081,13 +1137,13 @@ impl<R: Reader> SessionState<R> {
         };
         self.idle_timeout_ms.store(idle_ms, Ordering::Release);
 
-        // Resolve the datagram send limit. Datagrams are a QMux01-only feature
-        // (they rely on the record layer for framing), so they stay disabled on
-        // any other wire format. Otherwise whether we may *send* depends solely on
-        // the peer's willingness to receive (RFC 9221): 0 means the peer omitted
-        // (or zeroed) max_datagram_frame_size.
+        // Resolve the datagram send limit. Datagrams are a record-framed-draft
+        // feature (they rely on the record layer for framing), so they stay
+        // disabled on any other wire format. Otherwise whether we may *send*
+        // depends solely on the peer's willingness to receive (RFC 9221): 0 means
+        // the peer omitted (or zeroed) max_datagram_frame_size.
         let datagram_max =
-            if self.config.version != Version::QMux01 || params.max_datagram_frame_size == 0 {
+            if !self.config.version.uses_records() || params.max_datagram_frame_size == 0 {
                 0
             } else {
                 // A datagram must fit in one record, so the frame is capped by the
@@ -1214,6 +1270,9 @@ impl Session {
         let streams: Arc<Mutex<Streams>> = Arc::new(Mutex::new(Streams::default()));
         let record_limit = Arc::new(AtomicU64::new(crate::proto::DEFAULT_MAX_RECORD_SIZE));
         let idle_timeout_ms = Arc::new(AtomicU64::new(0));
+        // Count of keep-alive pings the timer has sent; the reader consults it to
+        // validate draft-02 QX_PING responses. Shared between the two tasks.
+        let pings_sent = Arc::new(AtomicU64::new(0));
 
         // Last-activity clocks for the timer task. `base` is the shared origin; the
         // reader/writer publish their progress as millis since it (see
@@ -1327,12 +1386,15 @@ impl Session {
             datagram_max_size: datagram_max_size.clone(),
             record_limit: record_limit.clone(),
             idle_timeout_ms: idle_timeout_ms.clone(),
+            last_ping_recv: None,
+            pings_sent: pings_sent.clone(),
         };
 
-        // Timer task: owns the QMux01 idle timeout + keep-alive ping, reading the
-        // last-activity clocks the reader/writer publish. Only QMux01 negotiates an
-        // idle timeout, so there's nothing for it to do on other wire formats.
-        if version == Version::QMux01 {
+        // Timer task: owns the record-framed-draft idle timeout + keep-alive ping,
+        // reading the last-activity clocks the reader/writer publish. Only the
+        // record-framed drafts (QMux01+) negotiate an idle timeout, so there's
+        // nothing for it to do on other wire formats.
+        if version.uses_records() {
             let timer = TimerState {
                 base,
                 last_recv_at: last_recv_at.clone(),
@@ -1343,6 +1405,7 @@ impl Session {
                 control: control_tx.clone(),
                 closed: closed.clone(),
                 established: established_rx.clone(),
+                pings_sent: pings_sent.clone(),
             };
             tokio::spawn(timer.run());
         }
@@ -2098,6 +2161,7 @@ mod timer_tests {
             control,
             closed: closed.clone(),
             established,
+            pings_sent: Arc::new(AtomicU64::new(0)),
         };
         tokio::spawn(timer.run());
 
@@ -2491,6 +2555,175 @@ mod datagram_recv_tests {
         raw.flush().await.unwrap();
 
         assert_eq!(server.recv_datagram().await.unwrap().as_ref(), &payload[..]);
+    }
+}
+
+// Draft-02 receive-side validation. Like `datagram_recv_tests`, these drive a
+// real server `Session` from a hand-crafted raw peer that injects records a
+// conforming client never would.
+#[cfg(all(test, feature = "tcp"))]
+mod qmux02_recv_tests {
+    use super::*;
+    use crate::transport::Stream as ByteStream;
+    use tokio::io::{AsyncWriteExt, DuplexStream};
+    use web_transport_trait::Session as _;
+
+    /// Wrap a QMux02 frame (or hand-built frame bytes) in its size-prefixed record.
+    fn record(frame: &[u8]) -> Bytes {
+        let mut buf = bytes::BytesMut::new();
+        VarInt::try_from(frame.len()).unwrap().encode(&mut buf);
+        buf.extend_from_slice(frame);
+        buf.freeze()
+    }
+
+    fn qmux02_params() -> Bytes {
+        Frame::TransportParameters(Config::new(Version::QMux02).to_transport_params())
+            .encode(Version::QMux02)
+            .unwrap()
+    }
+
+    /// Spawn a server `Session::accept` opposite a raw duplex write half, without
+    /// sending anything — the caller drives the (possibly malformed) handshake.
+    fn raw_accept(
+        server_cfg: Config,
+    ) -> (
+        tokio::task::JoinHandle<Result<Session, Error>>,
+        DuplexStream,
+    ) {
+        let (server_io, raw) = tokio::io::duplex(1024 * 1024);
+        let transport = ByteStream::new(server_io, Version::QMux02, server_cfg.max_record_size);
+        (tokio::spawn(Session::accept(transport, server_cfg)), raw)
+    }
+
+    /// Establish a real QMux02 server opposite a raw peer that sent valid params
+    /// first, returning the server plus the raw write half.
+    async fn established_peer() -> (Session, DuplexStream) {
+        let (accept, mut raw) = raw_accept(Config::new(Version::QMux02));
+        raw.write_all(&record(&qmux02_params())).await.unwrap();
+        raw.flush().await.unwrap();
+        (accept.await.unwrap().unwrap(), raw)
+    }
+
+    /// A first frame that isn't QX_TRANSPORT_PARAMETERS is a PROTOCOL_VIOLATION,
+    /// so the handshake never establishes.
+    #[tokio::test]
+    async fn transport_parameters_must_be_first() {
+        let (accept, mut raw) = raw_accept(Config::new(Version::QMux02));
+
+        // A STREAM frame ahead of any params.
+        let stream = Frame::Stream(Stream {
+            id: StreamId::new(0, StreamDir::Uni, false),
+            data: Bytes::from_static(b"hi"),
+            fin: false,
+        })
+        .encode(Version::QMux02)
+        .unwrap();
+        raw.write_all(&record(&stream)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(
+            accept.await.unwrap(),
+            Err(Error::ProtocolViolation)
+        ));
+    }
+
+    /// A `max_record_size` below the default minimum is a TRANSPORT_PARAMETER_ERROR.
+    #[tokio::test]
+    async fn max_record_size_below_default_rejected() {
+        let (accept, mut raw) = raw_accept(Config::new(Version::QMux02));
+
+        let mut params = Config::new(Version::QMux02).to_transport_params();
+        params.max_record_size = 100; // below DEFAULT_MAX_RECORD_SIZE (16382)
+        let frame = Frame::TransportParameters(params)
+            .encode(Version::QMux02)
+            .unwrap();
+        raw.write_all(&record(&frame)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(
+            accept.await.unwrap(),
+            Err(Error::TransportParameter)
+        ));
+    }
+
+    /// A QX_PING response echoing a sequence we never sent is a PROTOCOL_VIOLATION.
+    #[tokio::test]
+    async fn ping_response_for_unsent_sequence_closes() {
+        let (server, mut raw) = established_peer().await;
+
+        let ping = Frame::Ping(crate::Ping {
+            sequence: 5,
+            response: true,
+        })
+        .encode(Version::QMux02)
+        .unwrap();
+        raw.write_all(&record(&ping)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::ProtocolViolation));
+    }
+
+    /// QX_PING request sequence numbers must strictly increase.
+    #[tokio::test]
+    async fn ping_request_not_increasing_closes() {
+        let (server, mut raw) = established_peer().await;
+
+        for _ in 0..2 {
+            let ping = Frame::Ping(crate::Ping {
+                sequence: 5, // same value twice → not strictly increasing
+                response: false,
+            })
+            .encode(Version::QMux02)
+            .unwrap();
+            raw.write_all(&record(&ping)).await.unwrap();
+        }
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::ProtocolViolation));
+    }
+
+    /// A RESET_STREAM_AT frame (draft-02, hand-built — we never emit it) is
+    /// delivered to the accepted stream as a reset, after its data.
+    #[tokio::test]
+    async fn reset_stream_at_resets_accepted_stream() {
+        use web_transport_trait::RecvStream as _;
+
+        let (server, mut raw) = established_peer().await;
+
+        let id = StreamId::new(0, StreamDir::Uni, false);
+        let stream = Frame::Stream(Stream {
+            id,
+            data: Bytes::from_static(b"hi"),
+            fin: false,
+        })
+        .encode(Version::QMux02)
+        .unwrap();
+        raw.write_all(&record(&stream)).await.unwrap();
+
+        // Hand-build RESET_STREAM_AT (0x24): id, code=0, final_size=2, reliable_size=0.
+        let mut reset_at = bytes::BytesMut::new();
+        reset_at.put_u8(0x24);
+        id.0.encode(&mut reset_at);
+        VarInt::from_u32(0).encode(&mut reset_at); // code
+        VarInt::from_u32(2).encode(&mut reset_at); // final_size = len("hi")
+        VarInt::from_u32(0).encode(&mut reset_at); // reliable_size
+        raw.write_all(&record(&reset_at)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        // The reset is delivered like a plain RESET_STREAM. Data and reset race on
+        // the two inbound channels, so read until the stream ends: any bytes must
+        // be "hi" and it must terminate with a reset, never a clean FIN.
+        let mut recv = server.accept_uni().await.unwrap();
+        loop {
+            match recv.read_chunk(64).await {
+                Ok(Some(data)) => assert_eq!(data.as_ref(), b"hi"),
+                Ok(None) => panic!("stream finished cleanly instead of resetting"),
+                Err(err) => {
+                    assert!(matches!(err, Error::StreamReset(_)), "got {err:?}");
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -911,6 +911,16 @@ impl<R: Reader> SessionState<R> {
                 }
             }
             Frame::ResetStream(reset) => {
+                // A RESET_STREAM_AT frame (draft-02) is only legal if we
+                // advertised the `reset_stream_at` transport parameter — i.e. told
+                // the peer we accept the extension. Receiving it otherwise (or on
+                // an earlier draft, which never advertises it) is a
+                // PROTOCOL_VIOLATION. Plain RESET_STREAM (`reliable_size == None`)
+                // is always allowed.
+                if reset.reliable_size.is_some() && !self.our_params.reset_stream_at {
+                    return Err(Error::ProtocolViolation);
+                }
+
                 if !reset.id.can_recv(self.is_server) {
                     return Err(Error::InvalidStreamId);
                 }
@@ -1738,6 +1748,7 @@ impl SendStream {
                 id: self.id,
                 code,
                 final_size: self.offset,
+                reliable_size: None,
             };
             // Flush queued STREAM data so none trails the RESET_STREAM on the wire.
             self.outbound.remove(self.id);
@@ -1893,6 +1904,7 @@ impl generic::SendStream for SendStream {
             id: self.id,
             code,
             final_size: self.offset,
+            reliable_size: None,
         };
 
         // Flush any STREAM data still queued for this stream: it must not go out
@@ -2358,6 +2370,7 @@ mod recv_open_tests {
             id: StreamId::new(index, StreamDir::Uni, true),
             code: VarInt::from_u32(0),
             final_size: 0,
+            reliable_size: None,
         })
         .encode(Version::QMux01)
         .unwrap()
@@ -2724,6 +2737,38 @@ mod qmux02_recv_tests {
                 }
             }
         }
+    }
+
+    /// RESET_STREAM_AT is only legal once we've advertised `reset_stream_at`. A
+    /// draft-01 peer never advertises it, so a RESET_STREAM_AT on a draft-01
+    /// session is a PROTOCOL_VIOLATION. (The positive path is covered by
+    /// `reset_stream_at_resets_accepted_stream`, whose draft-02 server advertises it.)
+    #[tokio::test]
+    async fn reset_stream_at_without_negotiation_rejected() {
+        let server_cfg = Config::new(Version::QMux01);
+        let (server_io, mut raw) = tokio::io::duplex(1024 * 1024);
+        let transport = ByteStream::new(server_io, Version::QMux01, server_cfg.max_record_size);
+        let accept = tokio::spawn(Session::accept(transport, server_cfg));
+
+        let params = Frame::TransportParameters(Config::new(Version::QMux01).to_transport_params())
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(&params)).await.unwrap();
+        raw.flush().await.unwrap();
+        let server = accept.await.unwrap().unwrap();
+
+        // Hand-built RESET_STREAM_AT (0x24) on a client uni stream.
+        let id = StreamId::new(0, StreamDir::Uni, false);
+        let mut reset_at = bytes::BytesMut::new();
+        reset_at.put_u8(0x24);
+        id.0.encode(&mut reset_at);
+        VarInt::from_u32(0).encode(&mut reset_at); // code
+        VarInt::from_u32(0).encode(&mut reset_at); // final_size
+        VarInt::from_u32(0).encode(&mut reset_at); // reliable_size
+        raw.write_all(&record(&reset_at)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::ProtocolViolation));
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -2640,6 +2640,18 @@ mod qmux02_recv_tests {
         ));
     }
 
+    /// A second QX_TRANSPORT_PARAMETERS frame after establishment is a
+    /// PROTOCOL_VIOLATION (the "exactly once" half of the first-frame rule).
+    #[tokio::test]
+    async fn duplicate_transport_parameters_rejected() {
+        let (server, mut raw) = established_peer().await;
+
+        raw.write_all(&record(&qmux02_params())).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::ProtocolViolation));
+    }
+
     /// A `max_record_size` below the default minimum is a TRANSPORT_PARAMETER_ERROR.
     #[tokio::test]
     async fn max_record_size_below_default_rejected() {

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -155,9 +155,10 @@ mod stream_transport {
 
     impl<T: AsyncWrite + Send + 'static> Writer for StreamWriter<T> {
         async fn send(&mut self, data: Bytes) -> Result<(), Error> {
-            // QMux01 frames travel inside size-prefixed records on byte streams.
-            // (Records are implicit on WebSocket, where the message boundary delimits them.)
-            if self.version == Version::QMux01 {
+            // Record-framed drafts (QMux01+) travel inside size-prefixed records
+            // on byte streams. (Records are implicit on WebSocket, where the
+            // message boundary delimits them.)
+            if self.version.uses_records() {
                 let mut size_buf = BytesMut::with_capacity(8);
                 VarInt::try_from(data.len())?.encode(&mut size_buf);
                 self.writer.write_all(&size_buf).await?;
@@ -193,7 +194,9 @@ mod stream_transport {
     ) {
         loop {
             let result = match version {
-                Version::QMux01 => recv_record(&mut reader, our_max_record_size).await,
+                Version::QMux01 | Version::QMux02 => {
+                    recv_record(&mut reader, our_max_record_size).await
+                }
                 Version::QMux00 | Version::WebTransport => recv_qmux00_frame(&mut reader).await,
             };
             let stop = result.is_err();

--- a/rs/qmux/tests/qmux02.rs
+++ b/rs/qmux/tests/qmux02.rs
@@ -1,0 +1,83 @@
+//! Integration tests for QMux draft-02 over a real TCP socket.
+//!
+//! Draft-02 shares the draft-01 record wire format, so this focuses on the
+//! end-to-end happy path; the draft-02-specific validation rules (RESET_STREAM_AT,
+//! QX_TRANSPORT_PARAMETERS ordering, QX_PING sequence numbers, max_record_size
+//! minimum) are covered by in-crate raw-peer tests in `src/session.rs` and
+//! byte-level fixtures in `tests/wire_format.rs`.
+
+#![cfg(feature = "tcp")]
+
+use qmux::Version;
+use tokio::net::TcpListener;
+use web_transport_trait::{RecvStream, SendStream, Session as _};
+
+/// End-to-end QMux02 over TCP: open a stream, echo it back, close.
+#[tokio::test]
+async fn qmux02_tcp_stream_round_trip() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let session = qmux::tcp::Config::new(Version::QMux02)
+            .accept(sock)
+            .await
+            .unwrap();
+
+        let mut recv = session.accept_uni().await.unwrap();
+        let payload = recv.read_all().await.unwrap();
+
+        let mut send = session.open_uni().await.unwrap();
+        send.write(&payload).await.unwrap();
+        send.finish().unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    });
+
+    let session = qmux::tcp::Config::new(Version::QMux02)
+        .connect(addr)
+        .await
+        .unwrap();
+    let mut send = session.open_uni().await.unwrap();
+    send.write(b"qmux02").await.unwrap();
+    send.finish().unwrap();
+
+    let mut recv = session.accept_uni().await.unwrap();
+    let echoed = recv.read_all().await.unwrap();
+    assert_eq!(echoed.as_ref(), b"qmux02");
+
+    session.close(0, "done");
+    server.await.unwrap();
+}
+
+/// A default-config session negotiates QMux02: `Config::default()` selects the
+/// newest draft, and two defaulted peers interoperate over TCP.
+#[tokio::test]
+async fn default_config_uses_qmux02() {
+    assert_eq!(qmux::Config::default().version, Version::QMux02);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let session = qmux::tcp::Config::new(qmux::Config::default().version)
+            .accept(sock)
+            .await
+            .unwrap();
+        let mut recv = session.accept_uni().await.unwrap();
+        assert_eq!(recv.read_all().await.unwrap().as_ref(), b"default");
+    });
+
+    let session = qmux::tcp::Config::new(qmux::Config::default().version)
+        .connect(addr)
+        .await
+        .unwrap();
+    let mut send = session.open_uni().await.unwrap();
+    send.write(b"default").await.unwrap();
+    send.finish().unwrap();
+
+    server.await.unwrap();
+    session.close(0, "done");
+}

--- a/rs/qmux/tests/qmux02.rs
+++ b/rs/qmux/tests/qmux02.rs
@@ -8,6 +8,8 @@
 
 #![cfg(feature = "tcp")]
 
+use std::time::Duration;
+
 use qmux::Version;
 use tokio::net::TcpListener;
 use web_transport_trait::{RecvStream, SendStream, Session as _};
@@ -80,4 +82,47 @@ async fn default_config_uses_qmux02() {
 
     server.await.unwrap();
     session.close(0, "done");
+}
+
+/// Two idle QMux02 peers keep each other alive with QX_PING, exercising the
+/// draft-02 sequence validation end-to-end: each side's timer emits strictly
+/// increasing requests and echoes the peer's, and neither the strict-increase
+/// (requests) nor the echo-bound (responses) check wrongly closes the session.
+/// A regression here would surface as a spurious PROTOCOL_VIOLATION close.
+#[tokio::test]
+async fn qmux02_ping_keeps_idle_session_alive() {
+    use qmux::transport::Stream;
+    use qmux::{Config, Session};
+
+    let (a, b) = tokio::io::duplex(64 * 1024);
+    let mut config = Config::new(Version::QMux02);
+    config.max_idle_timeout = 150; // short window; ping cadence is a third of it
+
+    let ta = Stream::new(a, config.version, config.max_record_size);
+    let tb = Stream::new(b, config.version, config.max_record_size);
+    let (client, server) = tokio::join!(
+        Session::connect(ta, config.clone()),
+        Session::accept(tb, config),
+    );
+    let client = client.unwrap();
+    let server = server.unwrap();
+
+    let (c, s) = (client.clone(), server.clone());
+    let client_closed = tokio::spawn(async move { c.closed().await });
+    let server_closed = tokio::spawn(async move { s.closed().await });
+
+    // Idle for well over 2× the window: without keep-alive both would idle-close,
+    // and a broken ping-sequence check would PROTOCOL_VIOLATION-close instead.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(!client_closed.is_finished(), "client closed while idle");
+    assert!(!server_closed.is_finished(), "server closed while idle");
+
+    // Still genuinely usable.
+    let mut send = client.open_uni().await.unwrap();
+    send.write(b"alive").await.unwrap();
+    send.finish().unwrap();
+    let mut recv = server.accept_uni().await.unwrap();
+    assert_eq!(recv.read_all().await.unwrap().as_ref(), b"alive");
+
+    client.close(0, "done");
 }

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -317,6 +317,92 @@ fn record_datagram_then_stream_decodes_both() {
     }
 }
 
+// --------------------------------------------------------------------------
+// QMux draft-02: RESET_STREAM_AT + wire compatibility with draft-01
+// --------------------------------------------------------------------------
+
+#[test]
+fn qmux02_reset_stream_at_decodes_as_reset() {
+    // 0x24 RESET_STREAM_AT: id=4, code=42, final_size=128 (0x40 0x80),
+    // reliable_size=64 (0x40 0x40). QMux runs on a reliable, ordered transport, so
+    // this decodes to a plain reset carrying final_size; reliable_size is validated
+    // (<= final_size) and dropped.
+    let bytes = [0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40];
+    let decoded = Frame::decode(Bytes::copy_from_slice(&bytes), Version::QMux02)
+        .expect("decode succeeds")
+        .expect("reset_stream_at is not an ignored frame");
+    match decoded {
+        Frame::ResetStream(r) => {
+            assert_eq!(r.id.0.into_inner(), 4, "reset id");
+            assert_eq!(r.code.into_inner(), 42, "reset code");
+            assert_eq!(r.final_size, 128, "reset final_size");
+        }
+        other => panic!("expected reset_stream, got {other:?}"),
+    }
+}
+
+#[test]
+fn qmux02_reset_stream_at_reliable_over_final_rejected() {
+    // reliable_size (200 = 0x40 0xc8) > final_size (128 = 0x40 0x80) is a
+    // FRAME_ENCODING_ERROR per draft-ietf-quic-reliable-stream-reset.
+    let bytes = [0x24, 0x04, 0x2a, 0x40, 0x80, 0x40, 0xc8];
+    let err = Frame::decode(Bytes::copy_from_slice(&bytes), Version::QMux02)
+        .expect_err("reliable_size > final_size must be rejected");
+    assert!(matches!(err, Error::FrameEncoding), "got {err:?}");
+}
+
+#[test]
+fn qmux02_reset_stream_at_in_record() {
+    // The same frame decodes through the record path (draft-01+ framing), stopping
+    // at its own boundary so a following frame in the record still decodes.
+    let reset_at = [0x24u8, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40];
+    let stream = Frame::Stream(Stream {
+        id: sid(8),
+        data: Bytes::from_static(b"bye"),
+        fin: false,
+    })
+    .encode(Version::QMux02)
+    .unwrap();
+
+    let mut record = reset_at.to_vec();
+    record.extend_from_slice(&stream);
+
+    let frames = Frame::decode_record(Bytes::from(record)).expect("record decodes");
+    assert_eq!(frames.len(), 2, "both frames decode");
+    match &frames[0] {
+        Frame::ResetStream(r) => assert_eq!(r.final_size, 128),
+        other => panic!("expected reset_stream, got {other:?}"),
+    }
+    match &frames[1] {
+        Frame::Stream(s) => assert_eq!(s.data.as_ref(), b"bye"),
+        other => panic!("expected stream, got {other:?}"),
+    }
+}
+
+#[test]
+fn qmux02_wire_matches_qmux01() {
+    // Draft-02 shares the draft-01 record wire format: the same frames must encode
+    // byte-for-byte identically under both versions.
+    let frames: Vec<Frame> = vec![
+        Frame::Stream(Stream {
+            id: sid(4),
+            data: Bytes::from_static(b"hi"),
+            fin: true,
+        }),
+        Frame::MaxData(1024),
+        Frame::Datagram(Bytes::from_static(b"hi").into()),
+    ];
+    for frame in &frames {
+        let a = frame.encode(Version::QMux01).unwrap();
+        let b = frame.encode(Version::QMux02).unwrap();
+        assert_eq!(
+            a.as_ref(),
+            b.as_ref(),
+            "qmux-02 must match qmux-01 for {frame:?}"
+        );
+    }
+}
+
 #[test]
 fn qmux00_application_close() {
     // 0x1d (APPLICATION_CLOSE) + code(=42) + frame_type(=0) + reason_len(=3) + "bye".

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -164,6 +164,7 @@ fn webtransport_reset_stream() {
         id: sid(4),
         code: code(42),
         final_size: 0,
+        reliable_size: None,
     });
     assert_round_trip(Version::WebTransport, &bytes, &frame);
 }
@@ -226,6 +227,7 @@ fn qmux00_reset_stream() {
         id: sid(4),
         code: code(42),
         final_size: 128,
+        reliable_size: None,
     });
     assert_round_trip(Version::QMux00, &bytes, &frame);
 }


### PR DESCRIPTION
## Summary

Adds QMux [draft-ietf-quic-qmux-02](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.txt) as a new negotiable wire-format version alongside the existing draft-01 and draft-00, in **both** the Rust (`rs/qmux`) and TypeScript (`js/qmux`) implementations.

draft-02 is now the **default** and is preferred in ALPN / `Sec-WebSocket-Protocol` negotiation (newest-first), falling back to `qmux-01` → `qmux-00` → `webtransport` for older peers.

draft-02 is wire-compatible with draft-01's record framing, so the version-gated record / idle-timeout / datagram / `max_record_size` logic now keys off a new `Version::uses_records()` predicate (Rust) / `usesRecords()` helper (TS) covering draft-01 and later, instead of an exact draft-01 check. Existing draft-01 behavior is unchanged byte-for-byte.

## What draft-02 adds

- **RESET_STREAM_AT frame (`0x24`)** — decoded and accepted, and properly **negotiated**. We advertise the empty-valued `reset_stream_at` transport parameter (ID `0x1d`, from draft-ietf-quic-reliable-stream-reset) on draft-02, telling peers we accept the extension; a non-empty value is a `TRANSPORT_PARAMETER_ERROR`. On receive, RESET_STREAM_AT is accepted **only when we advertised the parameter** — otherwise `PROTOCOL_VIOLATION` (this also correctly rejects it on draft-01, which never advertises it). Because QMux runs on a reliable, ordered transport, all stream data up to `Final Size` has already been delivered before the frame arrives, so it's treated as a plain reset; `reliable_size > final_size` is a `FRAME_ENCODING_ERROR`. Receive-side only — no public API to *initiate* a reliable reset yet (left as a follow-up).
- **QX_TRANSPORT_PARAMETERS ordering** — must be the first frame, exactly once; otherwise `PROTOCOL_VIOLATION`.
- **QX_PING sequence numbers** — received requests must strictly increase, and a received response must echo a sequence we actually sent; otherwise `PROTOCOL_VIOLATION`.
- **`max_record_size` minimum** — an advertised value below the default (16382) is a `TRANSPORT_PARAMETER_ERROR`.

The stricter validations are gated to draft-02 so draft-01 stays exactly as before.

## Scope decisions

- **Additive + new default**, mirroring how draft-01 was added over draft-00.
- **RESET_STREAM_AT is receive-side + negotiated** (advertise `reset_stream_at`, accept only when advertised); no send-side `reset_at()` API yet — natural follow-up.
- **Both Rust and TypeScript** kept in sync.

## Tests

- Rust: `tests/qmux02.rs` (end-to-end TCP round trip, default-config negotiation), byte-level RESET_STREAM_AT + wire-equivalence fixtures in `tests/wire_format.rs`, `reset_stream_at` transport-parameter round-trip + non-empty-rejection unit tests, and in-crate raw-peer validation tests (`transport_parameters_must_be_first`, `max_record_size_below_default_rejected`, `ping_response_for_unsent_sequence_closes`, `ping_request_not_increasing_closes`, `reset_stream_at_resets_accepted_stream`, `reset_stream_at_without_negotiation_rejected`), plus updated ALPN unit tests.
- TypeScript: draft-02 block in `frame.test.ts` (record equivalence, RESET_STREAM_AT decode + `reliableSize` marker + validation + boundary, `reset_stream_at` param round-trip) and updated `subprotocol.test.ts`.
- All Rust + JS qmux tests pass; `cargo fmt`/`clippy`, `tsc --noEmit`, and `biome` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGtEFbU2SV8cWrwHm5oNGn