### PR TITLE
fix(qmux): stream-close race + propagate close reason to blocked Credit.claim() waiters (JS)

### DIFF
--- a/js/qmux/src/credit.test.ts
+++ b/js/qmux/src/credit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { Credit } from "./credit.ts";
+
+/** Settle a claim() to its value or its rejection error, without leaking an
+ *  unhandled rejection. */
+function settle<T>(p: Promise<T>): Promise<T | Error> {
+	return p.then(
+		(v) => v,
+		(e) => e,
+	);
+}
+
+describe("Credit basics still work", () => {
+	test("claim() resolves and clamps to remaining credit", async () => {
+		const credit = new Credit(10n);
+		expect(await credit.claim(4n)).toBe(4n);
+		expect(await credit.claim(100n)).toBe(6n);
+	});
+
+	test("zero-limit claim resolves to 0n even after close", async () => {
+		const credit = new Credit(0n);
+		credit.close(new Error("Connection closed: 0 "));
+		expect(await credit.claim(0n)).toBe(0n);
+	});
+});
+
+describe("Credit.close reason propagation", () => {
+	test("claim() after close(reason) rejects with the exact reason instance", async () => {
+		const credit = new Credit(0n);
+		const reason = new Error("Connection closed: 42 bye");
+		credit.close(reason);
+
+		expect(await settle(credit.claim(1n))).toBe(reason);
+	});
+
+	test("a claim() pending at close(reason) rejects with the exact reason instance", async () => {
+		const credit = new Credit(0n); // no credit available -> claim parks on a waiter
+		const reason = new Error("Connection closed: 7 gone");
+
+		const settled = settle(credit.claim(1n));
+		credit.close(reason);
+		expect(await settled).toBe(reason);
+	});
+
+	test("close() with no reason rejects with a generic Error('closed')", async () => {
+		const credit = new Credit(0n);
+		const pending = settle(credit.claim(1n));
+		credit.close();
+
+		const pendingErr = await pending;
+		expect(pendingErr).toBeInstanceOf(Error);
+		expect((pendingErr as Error).message).toBe("closed");
+
+		// A claim() made *after* a reason-less close also gets the generic Error.
+		const afterErr = await settle(credit.claim(1n));
+		expect(afterErr).toBeInstanceOf(Error);
+		expect((afterErr as Error).message).toBe("closed");
+	});
+
+	test("first close(reason) wins; later close() calls do not overwrite it", async () => {
+		const credit = new Credit(0n);
+		const first = new Error("Connection closed: 1 first");
+		credit.close(first);
+		credit.close(new Error("Connection closed: 2 second"));
+		credit.close(); // reason-less close after a reasoned one
+
+		expect(await settle(credit.claim(1n))).toBe(first);
+	});
+});

--- a/js/qmux/src/credit.ts
+++ b/js/qmux/src/credit.ts
@@ -26,6 +26,7 @@ export class Credit {
 	#max: bigint;
 	#released = 0n;
 	#closed = false;
+	#closeReason?: Error;
 	#waiters: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
 
 	constructor(max: bigint) {
@@ -49,7 +50,7 @@ export class Credit {
 		if (limit === 0n) return 0n;
 
 		while (true) {
-			if (this.#closed) throw new Error("closed");
+			if (this.#closed) throw this.#closeReason ?? new Error("closed");
 
 			const claimed = this.tryClaim(limit);
 			if (claimed > 0n) return claimed;
@@ -75,13 +76,14 @@ export class Credit {
 		return true;
 	}
 
-	/** Close the credit, rejecting all pending and future `claim()` calls. */
-	close(): void {
+	/** Close the credit, rejecting all pending and future `claim()` calls.
+	 *  `reason` (if provided) becomes the rejection error; the first reason wins. */
+	close(reason?: Error): void {
 		this.#closed = true;
+		this.#closeReason ??= reason ?? new Error("closed");
 		const waiters = this.#waiters;
 		this.#waiters = [];
-		const err = new Error("closed");
-		for (const { reject } of waiters) reject(err);
+		for (const { reject } of waiters) reject(this.#closeReason);
 	}
 
 	/** Set used to max(used, value). Returns false if value > max (flow control violation). */

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -3,6 +3,7 @@ import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
 import * as Stream from "./stream.ts";
+import { VarInt } from "./varint.ts";
 
 // A scripted peer standing in for the `WebSocketStream` transport. The test
 // plays the remote end: it injects frames into the Session's readable and
@@ -94,6 +95,21 @@ async function settle(turns = 5): Promise<void> {
 	for (let i = 0; i < turns; i++) {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
+}
+
+/** Drain queued microtasks so a just-issued claim() reaches its parked state.
+ *  Parking is pure-microtask work (no I/O), so a bounded drain is deterministic. */
+async function flushMicrotasks(turns = 10): Promise<void> {
+	for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+/** Settle a promise to its value or its rejection error, without leaking an
+ *  unhandled rejection while the test arranges the teardown that resolves it. */
+function settleTo<T>(p: Promise<T>): Promise<T | Error> {
+	return p.then(
+		(v) => v,
+		(e) => e,
+	);
 }
 
 function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
@@ -514,5 +530,95 @@ describe("Session integration (scripted peer)", () => {
 			expect(peer.has("max_data")).toBe(true);
 			session.close();
 		});
+	});
+
+	describe("close threads its reason into blocked Credit.claim() waiters", () => {
+		test("a uni stream blocked on stream-count credit rejects with the graceful close reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			// Peer grants zero uni stream-count credit, so createUnidirectionalStream parks on claim().
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsUni: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settleTo(session.createUnidirectionalStream());
+			await flushMicrotasks(); // let the call reach its parked claim()
+
+			session.close({ closeCode: 42, reason: "bye" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 42 bye");
+		});
+
+		test("a bidi stream blocked on stream-count credit rejects with a CONNECTION_CLOSE frame's reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsBidi: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settleTo(session.createBidirectionalStream());
+			await flushMicrotasks();
+
+			// The peer aborts the connection; the frame's code/reason must reach the waiter.
+			peer.send({ type: "connection_close", code: VarInt.from(7n), reason: "peer gone" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 7 peer gone");
+		});
+
+		test("a stream write blocked on send credit rejects with the close reason", async () => {
+			// Tiny per-stream send window: the first chunk drains it, the next write parks.
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamDataUni: 5n }) });
+
+			const writable = await session.createUnidirectionalStream();
+			const writer = writable.getWriter();
+			const wrote = settleTo(writer.write(new Uint8Array(8)));
+
+			// The first 5 bytes flush to the wire, so the write is now parked on the remaining 3.
+			await waitFor(() => peer.has("stream"));
+
+			session.close({ closeCode: 9, reason: "credit gone" });
+
+			const err = await wrote;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 9 credit gone");
+		});
+
+		test("a blocked claim rejects with the reason from a WebSocket-level close", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsUni: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settleTo(session.createUnidirectionalStream());
+			await flushMicrotasks();
+
+			// The transport closes underneath the session (no CONNECTION_CLOSE frame).
+			peer.close({ closeCode: 1001, reason: "going away" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 1001 going away");
+		});
+	});
+
+	test("createBidirectionalStream on an already-closed session rejects with the descriptive reason", async () => {
+		const { session } = connect();
+		await session.ready;
+
+		// Graceful app-initiated close leaves #closeReason unset, so the synchronous
+		// already-closed throw must fall back to #closed's "Connection closed: <code> <reason>",
+		// not a generic "Connection closed".
+		session.close({ closeCode: 5, reason: "done" });
+
+		const err = await settleTo(session.createBidirectionalStream());
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error).message).toBe("Connection closed: 5 done");
 	});
 });

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
@@ -84,6 +84,14 @@ async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
 	const start = Date.now();
 	while (!check()) {
 		if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+/** Yield a few macrotask turns so queued reads and any pending promise rejections
+ * settle (an unhandled rejection surfaces at the end of the current turn). */
+async function settle(turns = 5): Promise<void> {
+	for (let i = 0; i < turns; i++) {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
 }
@@ -337,5 +345,174 @@ describe("Session integration (scripted peer)", () => {
 		// Delivering the buffered bytes replenishes the window.
 		await waitFor(() => peer.count("max_stream_data") > 0);
 		session.close();
+	});
+
+	// Regression: a STREAM frame delivered by the read loop after the session has
+	// closed used to hit the already-closed incoming-stream controllers, and the
+	// throw escaped as an unhandled rejection because #handleStreamFrame was an
+	// unawaited async call. These tests capture process-level unhandled rejections
+	// so the failure mode is asserted, not just observed in logs.
+	describe("STREAM frame vs session teardown", () => {
+		const rejections: unknown[] = [];
+		const onRejection = (err: unknown) => {
+			rejections.push(err);
+		};
+
+		beforeEach(async () => {
+			process.on("unhandledRejection", onRejection);
+			// Drain any late async work from earlier tests before arming the capture,
+			// so a stray rejection from another test's teardown can't be misattributed
+			// to the test about to run.
+			await settle();
+			rejections.length = 0;
+		});
+		afterEach(() => {
+			process.off("unhandledRejection", onRejection);
+		});
+
+		test("a STREAM frame arriving after close() is dropped without an unhandled rejection", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			session.close({ closeCode: 42, reason: "bye" });
+
+			// Peer-initiated streams still in flight when the session closed: one uni,
+			// one bidi — both would hit the now-closed incoming-stream controllers.
+			// The third targets a stream id that could only exist pre-close (#recvStreams
+			// was cleared by close), so it also takes the new-stream branch.
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+				data: new Uint8Array(3),
+				fin: false,
+			});
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Bi, true),
+				data: new Uint8Array(3),
+				fin: false,
+			});
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+				data: new Uint8Array(3),
+				fin: true,
+			});
+
+			await settle();
+			expect(rejections).toEqual([]);
+			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
+		});
+
+		test("a STREAM frame on a send-only stream ID closes the session with 1002", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			// A client-initiated uni stream is send-only from our (client) perspective;
+			// the peer writing to it is a protocol violation. Now that #handleStreamFrame
+			// is synchronous, the throw propagates to #onData and closes with 1002 —
+			// previously it leaked as a rejection while the session limped on.
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Uni, false),
+				data: new Uint8Array([1]),
+				fin: false,
+			});
+
+			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+			await settle();
+			expect(rejections).toEqual([]);
+		});
+
+		test("a stream arriving after the app cancelled the acceptor is refused, not fatal", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			// App stops accepting incoming uni streams while the session stays open.
+			await session.incomingUnidirectionalStreams.cancel();
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+				data: new Uint8Array(3),
+				fin: false,
+			});
+
+			// Ping barrier: once the pong is seen the STREAM frame above has been fully
+			// processed. The session must still be alive — an app-local cancel is not a
+			// peer protocol violation.
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"), 5000);
+
+			await settle();
+			expect(rejections).toEqual([]);
+			expect(peer.has("connection_close")).toBe(false);
+			session.close();
+		});
+
+		test("repeated frames on a refused stream id do not amplify STOP_SENDING or re-credit stream count", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			await session.incomingUnidirectionalStreams.cancel();
+
+			// One peer-initiated uni stream, its payload split across several in-flight
+			// STREAM frames (all before the peer could honor any STOP_SENDING). Deleting
+			// the stream on refusal would make each later frame re-open it, re-crediting
+			// MAX_STREAMS and emitting a STOP_SENDING per frame; keeping it registered
+			// means exactly one refusal.
+			const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+			for (let i = 0; i < 8; i++) {
+				peer.send({ type: "stream", id, data: new Uint8Array(3), fin: false });
+			}
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"), 5000);
+
+			await settle();
+			expect(rejections).toEqual([]);
+			// No per-frame amplification: the refused stream never sends STOP_SENDING and
+			// never re-credits the peer's stream-count limit.
+			expect(peer.count("stop_sending")).toBe(0);
+			expect(peer.has("max_streams_uni")).toBe(false);
+			expect(peer.has("connection_close")).toBe(false);
+			session.close();
+		});
+
+		test("refused streams do not leak connection flow-control credit", async () => {
+			// Tight connection window (300B). Each refused stream's bytes advance the
+			// connection recv offset; if they aren't also counted as consumed, the
+			// advertised window never replenishes and the peer is wrongly starved /
+			// eventually tripped into a 1002 flow-control close.
+			const { session, peer } = connect({ maxData: 300n });
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			await session.incomingUnidirectionalStreams.cancel();
+
+			// Five distinct refused uni streams carrying 500B total — well past the 300B
+			// window. With correct accounting the window keeps pace (MAX_DATA is emitted)
+			// and the session stays healthy; the buggy refuse path froze `consumed` and
+			// closed with a spurious flow-control error by the 4th stream.
+			for (let i = 0n; i < 5n; i++) {
+				peer.send({
+					type: "stream",
+					id: Stream.Id.create(i, Stream.Dir.Uni, true),
+					data: new Uint8Array(100),
+					fin: false,
+				});
+			}
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"), 5000);
+
+			await settle();
+			expect(rejections).toEqual([]);
+			expect(peer.has("connection_close")).toBe(false);
+			// The connection window advanced, proving refused bytes were credited back.
+			expect(peer.has("max_data")).toBe(true);
+			session.close();
+		});
 	});
 });

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -904,7 +904,12 @@ export default class Session implements WebTransport {
 		}
 	}
 
-	async #handleStreamFrame(frame: Frame.Data) {
+	#handleStreamFrame(frame: Frame.Data) {
+		// The read loop can still deliver frames after #close() has torn down the
+		// incoming-stream controllers and #recvStreams; drop them, matching the
+		// #sendDatagram/#sendPriorityFrame post-close guards.
+		if (this.#closed) return;
+
 		if (frame.data.byteLength > MAX_FRAME_PAYLOAD) {
 			this.close({ closeCode: 1002, reason: "frame too large" });
 			return;
@@ -1010,9 +1015,28 @@ export default class Session implements WebTransport {
 				});
 				this.#attachSendOrder(writer, streamId, DEFAULT_SEND_ORDER);
 
-				this.#incomingBidirectionalStreams.enqueue({ readable: reader, writable: writer });
+				try {
+					this.#incomingBidirectionalStreams.enqueue({ readable: reader, writable: writer });
+				} catch {
+					// The app cancelled the incoming-bidi acceptor while the session is
+					// still open (a closed session already returned at the #closed guard
+					// above). Keep the stream registered in #recvStreams — as in <=0.2.0 —
+					// so later in-flight frames for this id take the existing-stream path
+					// below instead of re-opening it (which would re-credit stream-count
+					// and re-emit STOP_SENDING per frame). Error the orphaned recv buffer
+					// so we don't retain bytes no reader can drain, then fall through so
+					// connection flow control is still accounted for this frame.
+					recv.error(new Error("incoming stream acceptor cancelled"));
+				}
 			} else {
-				this.#incomingUnidirectionalStreams.enqueue(reader);
+				try {
+					this.#incomingUnidirectionalStreams.enqueue(reader);
+				} catch {
+					// Acceptor cancelled mid-session; see the bidi branch. Keep the stream
+					// registered, drop its orphaned buffer, and fall through to account
+					// connection flow control below.
+					recv.error(new Error("incoming stream acceptor cancelled"));
+				}
 			}
 		} else {
 			// Existing stream — validate recv flow control

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -605,7 +605,7 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
-			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value}: ${frame.reason}`);
+			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
 			this.#close(Number(frame.code.value), frame.reason);
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
@@ -776,7 +776,7 @@ export default class Session implements WebTransport {
 			// 1. Try stream credit
 			const streamClaimed = flow.sendCredit.tryClaim(desired);
 			if (streamClaimed === 0n) {
-				if (this.#closed) throw this.#closeReason || new Error("Connection closed");
+				if (this.#closed) throw this.#closed;
 				// Wait for stream credit, then release and retry to coordinate with conn credit
 				const claimed = await flow.sendCredit.claim(desired);
 				flow.sendCredit.release(claimed);
@@ -787,7 +787,7 @@ export default class Session implements WebTransport {
 			const connClaimed = this.#connCredit.tryClaim(streamClaimed);
 			if (connClaimed === 0n) {
 				flow.sendCredit.release(streamClaimed);
-				if (this.#closed) throw this.#closeReason || new Error("Connection closed");
+				if (this.#closed) throw this.#closed;
 				const claimed = await this.#connCredit.claim(1n);
 				this.#connCredit.release(claimed);
 				continue;
@@ -1227,7 +1227,7 @@ export default class Session implements WebTransport {
 		await this.ready;
 
 		if (this.#closed) {
-			throw this.#closeReason || new Error("Connection closed");
+			throw this.#closed;
 		}
 
 		const sendOrder = options?.sendOrder ?? DEFAULT_SEND_ORDER;
@@ -1400,18 +1400,20 @@ export default class Session implements WebTransport {
 		this.#sendStreams.clear();
 		this.#recvStreams.clear();
 
-		// Close per-stream credits before clearing the map
+		// Close per-stream credits before clearing the map. Pass the rich close
+		// reason so writes parked in Credit.claim() reject with the same
+		// "Connection closed: <code> <reason>" error as every other teardown path.
 		for (const flow of this.#streamFlow.values()) {
-			flow.sendCredit.close();
+			flow.sendCredit.close(closeErr);
 		}
 		this.#streamFlow.clear();
 
 		// Close global credits so blocked claim() calls reject.
-		this.#connCredit.close();
-		this.#bidiStreamCredit.close();
-		this.#uniStreamCredit.close();
-		this.#recvBiCredit.close();
-		this.#recvUniCredit.close();
+		this.#connCredit.close(closeErr);
+		this.#bidiStreamCredit.close(closeErr);
+		this.#uniStreamCredit.close(closeErr);
+		this.#recvBiCredit.close(closeErr);
+		this.#recvUniCredit.close(closeErr);
 
 		// Reject pending stream writes; already-queued control (e.g. CONNECTION_CLOSE)
 		// still flushes before the socket is torn down.


### PR DESCRIPTION
> [!NOTE]
> **This PR bundles two independent `js/qmux` session-teardown fixes.** They were opened separately (this PR + #286), but both touch `session.ts`/`session.test.ts`, so keeping them as two PRs would force a `session.test.ts` merge conflict on whichever landed second. Consolidating here keeps the merge clean — **#286 is closed in favor of this PR, and all of its commits are included.** The two fixes are independent (disjoint `session.ts` regions) and are written up as separate concerns below.

---

# 1. STREAM frame racing session close

## Symptom

On Safari and Firefox (which fall back to qmux over WebSocket), reliably reproduced when a publisher/peer reloads while a consumer is connected:

```
[error] Unhandled rejection: TypeError: ReadableStreamDefaultController is not in a state where chunk can be enqueued
    enqueue@[native code]
    #handleStreamFrame  (session.js)
    #recvFrame          (session.js)
    #onData             (session.js)
    #readLoop           (session.js)
```

Affects every published `@moq/qmux` ≤ 0.3.1 (the code path is identical from 0.1.3 through HEAD). The Rust crate is unaffected — its recv path is awaited and `Result`-based, so a closed accept channel becomes a clean `Error::Closed`.

## Root cause (three layers)

1. **Unguarded enqueues.** `#handleStreamFrame` enqueues newly opened streams onto the incoming-stream controllers with no closed-state check, while `#close()` closes both controllers **and clears `#recvStreams`** — so a post-close STREAM frame for *any* stream (new or previously established) takes the new-stream branch and `enqueue()` throws.
2. **Unawaited async handler.** `#handleStreamFrame` was `async` with **no top-level `await`** in its body, and `#recvFrame` called it without `await`/`.catch()`. Every throw inside it escaped `#onData`'s try/catch as an unhandled rejection — including the *intentional* protocol-violation throws ("Invalid stream ID direction"), which therefore never worked: an invalid frame leaked a rejection and the session limped on instead of closing with 1002.
3. **The read loop outlives `#close()`**, so in-flight frames keep arriving after teardown. Draft-02 explicitly blesses discarding them ("QMux endpoints SHOULD discard any data they receive without processing it"), but there was no discard path. #280 fixed this exact enqueue-after-close class for datagrams only (`Datagrams.push` guard); this PR covers the stream controllers.

## Fix

- `if (this.#closed) return;` at the top of `#handleStreamFrame`, matching the existing `#sendDatagram`/`#sendPriorityFrame` post-close guards.
- Remove `async` from `#handleStreamFrame`. Zero timing change (no top-level await existed); protocol-violation throws now reach `#onData` and close the session with 1002 as RFC 9000 §19.8 requires (a STREAM frame for a send-only stream MUST terminate the connection), matching the Rust implementation and the datagram-violation idiom.
- Wrap both `enqueue()` sites in a try/catch that handles the one remaining throw path: the app cancelled an acceptor while the session is open. The catch errors the orphaned recv buffer and **falls through** — deliberately no `reader.cancel()` and no early `return`:
  - the refused stream stays registered, so later in-flight frames for the same id take the existing-stream path instead of re-opening it (re-opening re-credits MAX_STREAMS and emits one STOP_SENDING per frame — a live probe with 200 frames on one refused id emitted 200 STOP_SENDINGs and inflated MAX_STREAMS_UNI from 100 to 225);
  - falling through keeps connection-level flow control balanced (`#accountRecv` charges at receipt per RFC 9000 §4, so skipping `#accountConnConsumed` leaks receive-window credit — a probe with `maxData=100` and three refused 40-byte streams spuriously closed with `1002 flow control error`).
  - The peer is bounded by the never-replenished per-stream window — identical to slow-reader semantics; STOP_SENDING is a SHOULD, not a MUST. Orphaned bidi send-controllers are cleaned by `#close()`.

## Intentional behavior changes

- An invalid-direction STREAM frame now closes the session with 1002 instead of leaking a rejection (spec-mandated; matches Rust).
- A fatal throw stops processing of remaining frames in the same record.
- A refused stream (cancelled acceptor) no longer implies STOP_SENDING; per-stream flow control bounds the peer instead.

## Tests

Five regression tests under `describe("STREAM frame vs session teardown")`, each asserting a `process`-level `unhandledRejection` capture (armed after a macrotask drain so late work from earlier tests can't be misattributed):

1. post-close STREAM frames (new uni, new bidi, previously-established id) are dropped without a rejection and `closed` still resolves with the app's close code;
2. a STREAM frame on a send-only stream ID closes with `{1002, "Protocol violation"}`;
3. a stream arriving after the app cancelled the acceptor is refused without killing the session;
4. 8 in-flight frames on one refused id: zero STOP_SENDING, no MAX_STREAMS re-credit;
5. `maxData: 300` with five refused 100-byte streams: session stays alive and MAX_DATA is emitted, proving refused bytes are credited back.

Each test fails against the code it guards: 1–3 against HEAD (reproducing the reported stack exactly), 4–5 against the `reader.cancel(); return` variant of the catch.

---

# 2. Propagate session close reason to blocked `Credit.claim()` waiters

## Summary

When a `qmux.Session` closes (gracefully via `session.close()`, on a `CONNECTION_CLOSE` frame, or on a WebSocket-level failure), any caller awaiting flow-control or stream-count credit in `Credit.claim()` was rejected with a bare `new Error("closed")` — instead of the rich `Connection closed: <code> <reason>` error that **every other teardown path in `Session#close` already threads through** (`ready`/`closed` rejections, `recv.error(...)`, `scheduler.close(...)`).

That makes an expected teardown indistinguishable from a real fault to consumers that classify close errors by message. This surfaced in `moq-dev/moq`'s `js/net`, which routes Firefox and Safari onto the qmux WebSocket transport (Chrome uses native `WebTransport` and never hits this path): every normal page reload / unsubscribe / route change logged at `error` level with `Error: closed`.

## Root cause

`Session#close` already computes the well-formed close error (`closeErr` / `this.#closed`) and passes it to `readyReject`, `recv.error(...)`, and `scheduler.close(...)` — but the six `Credit.close()` calls a few lines above it dropped it, because `Credit.close()` took no reason argument and always synthesized its own `new Error("closed")`.

## Changes

- **`credit.ts`** — `Credit.close(reason?: Error)` now accepts an optional reason and stores it (first reason wins, matching `Session`'s `#closeReason ??=` convention); `claim()` throws the stored reason on both the pending-waiter and already-closed paths. A reason-less `close()` still rejects with a generic `Error("closed")`, so the two non-teardown callers are unaffected.
- **`session.ts`** — `Session#close` passes its already-computed `closeErr` to all six `Credit.close()` call sites (five global credits + per-stream send credit). The two non-teardown closes (`#startSession` credit reset, `#maybeDeleteStreamFlow` per-stream cleanup) intentionally stay reason-less.
- **`session.ts`** — align the three *synchronous already-closed* throws (`#claimSendCredit` ×2, `createBidirectionalStream`) to `throw this.#closed`, so a graceful close (where `#closeReason` is unset) also throws the descriptive `Connection closed: <code> <reason>` instead of a generic message — matching `createUnidirectionalStream`.
- **`session.ts`** — normalize the `CONNECTION_CLOSE`-frame message format from `Connection closed: <code>: <reason>` to `Connection closed: <code> <reason>`, matching the WebSocket-close and `#close` fallback sites.

## Tests

- New **`credit.test.ts`** (was missing): `claim()` rejects with the *exact* `Error` instance passed to `close(reason)` on both the pending and already-closed paths; first-reason-wins; and the reason-less backward-compat path still yields a generic `Error("closed")`.
- Five new **`session.test.ts`** regression tests: a uni/bidi stream blocked on stream-count credit and a stream write blocked on send credit each reject with the rich reason, exercised across the teardown paths (graceful `close()`, a `CONNECTION_CLOSE` frame, a WebSocket-level close), plus a `createBidirectionalStream`-on-already-closed test asserting the graceful close reason.

## Compatibility

`Credit` is not exported from `index.ts` — it is a fully internal class, so adding an optional parameter is not a public API change and needs no major bump. `Session#close` is private. The only observable change is that a rejection from an operation blocked on internal flow control now carries a descriptive message instead of `"closed"`, which only makes existing "is this an expected close?" heuristics (including moq's `/^Connection closed/`) *more* accurate. No coordinated release with consumers is required.

## Notes

The Rust `rs/qmux` has the analogous information loss (`Credit::close()` takes no reason; `claim` returns a bare `Error::Closed`). Left out of scope here — it needs separate enum/API work and mirrors this JS change.

---

## Combined verification

- `bun test`: **87 pass / 0 fail** — 5 STREAM-race tests + 5 close-reason tests + new `credit.test.ts` (6) + pre-existing.
- `bun run check` (tsc): clean.
- Biome: clean.
- Merges into `main` conflict-free (verified via `git merge-tree` against the current `main` tip).

_Consolidation note: #285 and #286 each defined a module-level `settle` test helper with different signatures; this PR keeps #285's delay helper and renames #286's promise-settling helper to `settleTo` (5 call sites) — the only adjustment made while merging the two._
