### PR TITLE
fix(qmux): propagate session close reason to blocked Credit.claim() waiters (JS)

### DIFF
--- a/js/qmux/src/credit.test.ts
+++ b/js/qmux/src/credit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { Credit } from "./credit.ts";
+
+/** Settle a claim() to its value or its rejection error, without leaking an
+ *  unhandled rejection. */
+function settle<T>(p: Promise<T>): Promise<T | Error> {
+	return p.then(
+		(v) => v,
+		(e) => e,
+	);
+}
+
+describe("Credit basics still work", () => {
+	test("claim() resolves and clamps to remaining credit", async () => {
+		const credit = new Credit(10n);
+		expect(await credit.claim(4n)).toBe(4n);
+		expect(await credit.claim(100n)).toBe(6n);
+	});
+
+	test("zero-limit claim resolves to 0n even after close", async () => {
+		const credit = new Credit(0n);
+		credit.close(new Error("Connection closed: 0 "));
+		expect(await credit.claim(0n)).toBe(0n);
+	});
+});
+
+describe("Credit.close reason propagation", () => {
+	test("claim() after close(reason) rejects with the exact reason instance", async () => {
+		const credit = new Credit(0n);
+		const reason = new Error("Connection closed: 42 bye");
+		credit.close(reason);
+
+		expect(await settle(credit.claim(1n))).toBe(reason);
+	});
+
+	test("a claim() pending at close(reason) rejects with the exact reason instance", async () => {
+		const credit = new Credit(0n); // no credit available -> claim parks on a waiter
+		const reason = new Error("Connection closed: 7 gone");
+
+		const settled = settle(credit.claim(1n));
+		credit.close(reason);
+		expect(await settled).toBe(reason);
+	});
+
+	test("close() with no reason rejects with a generic Error('closed')", async () => {
+		const credit = new Credit(0n);
+		const pending = settle(credit.claim(1n));
+		credit.close();
+
+		const pendingErr = await pending;
+		expect(pendingErr).toBeInstanceOf(Error);
+		expect((pendingErr as Error).message).toBe("closed");
+
+		// A claim() made *after* a reason-less close also gets the generic Error.
+		const afterErr = await settle(credit.claim(1n));
+		expect(afterErr).toBeInstanceOf(Error);
+		expect((afterErr as Error).message).toBe("closed");
+	});
+
+	test("first close(reason) wins; later close() calls do not overwrite it", async () => {
+		const credit = new Credit(0n);
+		const first = new Error("Connection closed: 1 first");
+		credit.close(first);
+		credit.close(new Error("Connection closed: 2 second"));
+		credit.close(); // reason-less close after a reasoned one
+
+		expect(await settle(credit.claim(1n))).toBe(first);
+	});
+});

--- a/js/qmux/src/credit.ts
+++ b/js/qmux/src/credit.ts
@@ -26,6 +26,7 @@ export class Credit {
 	#max: bigint;
 	#released = 0n;
 	#closed = false;
+	#closeReason?: Error;
 	#waiters: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
 
 	constructor(max: bigint) {
@@ -49,7 +50,7 @@ export class Credit {
 		if (limit === 0n) return 0n;
 
 		while (true) {
-			if (this.#closed) throw new Error("closed");
+			if (this.#closed) throw this.#closeReason ?? new Error("closed");
 
 			const claimed = this.tryClaim(limit);
 			if (claimed > 0n) return claimed;
@@ -75,13 +76,14 @@ export class Credit {
 		return true;
 	}
 
-	/** Close the credit, rejecting all pending and future `claim()` calls. */
-	close(): void {
+	/** Close the credit, rejecting all pending and future `claim()` calls.
+	 *  `reason` (if provided) becomes the rejection error; the first reason wins. */
+	close(reason?: Error): void {
 		this.#closed = true;
+		this.#closeReason ??= reason ?? new Error("closed");
 		const waiters = this.#waiters;
 		this.#waiters = [];
-		const err = new Error("closed");
-		for (const { reject } of waiters) reject(err);
+		for (const { reject } of waiters) reject(this.#closeReason);
 	}
 
 	/** Set used to max(used, value). Returns false if value > max (flow control violation). */

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -430,4 +430,18 @@ describe("Session integration (scripted peer)", () => {
 			expect((err as Error).message).toBe("Connection closed: 1001 going away");
 		});
 	});
+
+	test("createBidirectionalStream on an already-closed session rejects with the descriptive reason", async () => {
+		const { session } = connect();
+		await session.ready;
+
+		// Graceful app-initiated close leaves #closeReason unset, so the synchronous
+		// already-closed throw must fall back to #closed's "Connection closed: <code> <reason>",
+		// not a generic "Connection closed".
+		session.close({ closeCode: 5, reason: "done" });
+
+		const err = await settle(session.createBidirectionalStream());
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error).message).toBe("Connection closed: 5 done");
+	});
 });

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -3,6 +3,7 @@ import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
 import * as Stream from "./stream.ts";
+import { VarInt } from "./varint.ts";
 
 // A scripted peer standing in for the `WebSocketStream` transport. The test
 // plays the remote end: it injects frames into the Session's readable and
@@ -86,6 +87,21 @@ async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
 		if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
+}
+
+/** Drain queued microtasks so a just-issued claim() reaches its parked state.
+ *  Parking is pure-microtask work (no I/O), so a bounded drain is deterministic. */
+async function flushMicrotasks(turns = 10): Promise<void> {
+	for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+/** Settle a promise to its value or its rejection error, without leaking an
+ *  unhandled rejection while the test arranges the teardown that resolves it. */
+function settle<T>(p: Promise<T>): Promise<T | Error> {
+	return p.then(
+		(v) => v,
+		(e) => e,
+	);
 }
 
 function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
@@ -337,5 +353,81 @@ describe("Session integration (scripted peer)", () => {
 		// Delivering the buffered bytes replenishes the window.
 		await waitFor(() => peer.count("max_stream_data") > 0);
 		session.close();
+	});
+
+	describe("close threads its reason into blocked Credit.claim() waiters", () => {
+		test("a uni stream blocked on stream-count credit rejects with the graceful close reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			// Peer grants zero uni stream-count credit, so createUnidirectionalStream parks on claim().
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsUni: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settle(session.createUnidirectionalStream());
+			await flushMicrotasks(); // let the call reach its parked claim()
+
+			session.close({ closeCode: 42, reason: "bye" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 42 bye");
+		});
+
+		test("a bidi stream blocked on stream-count credit rejects with a CONNECTION_CLOSE frame's reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsBidi: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settle(session.createBidirectionalStream());
+			await flushMicrotasks();
+
+			// The peer aborts the connection; the frame's code/reason must reach the waiter.
+			peer.send({ type: "connection_close", code: VarInt.from(7n), reason: "peer gone" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 7 peer gone");
+		});
+
+		test("a stream write blocked on send credit rejects with the close reason", async () => {
+			// Tiny per-stream send window: the first chunk drains it, the next write parks.
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamDataUni: 5n }) });
+
+			const writable = await session.createUnidirectionalStream();
+			const writer = writable.getWriter();
+			const wrote = settle(writer.write(new Uint8Array(8)));
+
+			// The first 5 bytes flush to the wire, so the write is now parked on the remaining 3.
+			await waitFor(() => peer.has("stream"));
+
+			session.close({ closeCode: 9, reason: "credit gone" });
+
+			const err = await wrote;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 9 credit gone");
+		});
+
+		test("a blocked claim rejects with the reason from a WebSocket-level close", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams({ initialMaxStreamsUni: 0n }) });
+			peer.send({ type: "ping_request", sequence: 1n });
+			await waitFor(() => peer.has("ping_response"));
+
+			const created = settle(session.createUnidirectionalStream());
+			await flushMicrotasks();
+
+			// The transport closes underneath the session (no CONNECTION_CLOSE frame).
+			peer.close({ closeCode: 1001, reason: "going away" });
+
+			const err = await created;
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).message).toBe("Connection closed: 1001 going away");
+		});
 	});
 });

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -605,7 +605,7 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
-			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value}: ${frame.reason}`);
+			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
 			this.#close(Number(frame.code.value), frame.reason);
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
@@ -1376,18 +1376,20 @@ export default class Session implements WebTransport {
 		this.#sendStreams.clear();
 		this.#recvStreams.clear();
 
-		// Close per-stream credits before clearing the map
+		// Close per-stream credits before clearing the map. Pass the rich close
+		// reason so writes parked in Credit.claim() reject with the same
+		// "Connection closed: <code> <reason>" error as every other teardown path.
 		for (const flow of this.#streamFlow.values()) {
-			flow.sendCredit.close();
+			flow.sendCredit.close(closeErr);
 		}
 		this.#streamFlow.clear();
 
 		// Close global credits so blocked claim() calls reject.
-		this.#connCredit.close();
-		this.#bidiStreamCredit.close();
-		this.#uniStreamCredit.close();
-		this.#recvBiCredit.close();
-		this.#recvUniCredit.close();
+		this.#connCredit.close(closeErr);
+		this.#bidiStreamCredit.close(closeErr);
+		this.#uniStreamCredit.close(closeErr);
+		this.#recvBiCredit.close(closeErr);
+		this.#recvUniCredit.close(closeErr);
 
 		// Reject pending stream writes; already-queued control (e.g. CONNECTION_CLOSE)
 		// still flushes before the socket is torn down.

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -776,7 +776,7 @@ export default class Session implements WebTransport {
 			// 1. Try stream credit
 			const streamClaimed = flow.sendCredit.tryClaim(desired);
 			if (streamClaimed === 0n) {
-				if (this.#closed) throw this.#closeReason || new Error("Connection closed");
+				if (this.#closed) throw this.#closed;
 				// Wait for stream credit, then release and retry to coordinate with conn credit
 				const claimed = await flow.sendCredit.claim(desired);
 				flow.sendCredit.release(claimed);
@@ -787,7 +787,7 @@ export default class Session implements WebTransport {
 			const connClaimed = this.#connCredit.tryClaim(streamClaimed);
 			if (connClaimed === 0n) {
 				flow.sendCredit.release(streamClaimed);
-				if (this.#closed) throw this.#closeReason || new Error("Connection closed");
+				if (this.#closed) throw this.#closed;
 				const claimed = await this.#connCredit.claim(1n);
 				this.#connCredit.release(claimed);
 				continue;
@@ -1203,7 +1203,7 @@ export default class Session implements WebTransport {
 		await this.ready;
 
 		if (this.#closed) {
-			throw this.#closeReason || new Error("Connection closed");
+			throw this.#closed;
 		}
 
 		const sendOrder = options?.sendOrder ?? DEFAULT_SEND_ORDER;


### PR DESCRIPTION
## Summary

When a `qmux.Session` closes (gracefully via `session.close()`, on a `CONNECTION_CLOSE` frame, or on a WebSocket-level failure), any caller awaiting flow-control or stream-count credit in `Credit.claim()` was rejected with a bare `new Error("closed")` — instead of the rich `Connection closed: <code> <reason>` error that **every other teardown path in `Session#close` already threads through** (`ready`/`closed` rejections, `recv.error(...)`, `scheduler.close(...)`).

That makes an expected teardown indistinguishable from a real fault to consumers that classify close errors by message. This surfaced in `moq-dev/moq`'s `js/net`, which routes Firefox and Safari onto the qmux WebSocket transport (Chrome uses native `WebTransport` and never hits this path): every normal page reload / unsubscribe / route change logged at `error` level with `Error: closed`.

## Root cause

`Session#close` already computes the well-formed close error (`closeErr` / `this.#closed`) and passes it to `readyReject`, `recv.error(...)`, and `scheduler.close(...)` — but the six `Credit.close()` calls a few lines above it dropped it, because `Credit.close()` took no reason argument and always synthesized its own `new Error("closed")`. (`#claimSendCredit` already worked around this with a manual `throw this.#closeReason || ...`, which was the tell that `Credit` was the oversight.)

## Changes

- **`credit.ts`** — `Credit.close(reason?: Error)` now accepts an optional reason and stores it (first reason wins, matching `Session`'s `#closeReason ??=` convention); `claim()` throws the stored reason on both the pending-waiter and already-closed paths. A reason-less `close()` still rejects with a generic `Error("closed")`, so the two non-teardown callers are unaffected.
- **`session.ts`** — `Session#close` passes its already-computed `closeErr` to all six `Credit.close()` call sites (five global credits + per-stream send credit). The two non-teardown closes (`#startSession` credit reset, `#maybeDeleteStreamFlow` per-stream cleanup) intentionally stay reason-less.
- **`session.ts`** — normalize the `CONNECTION_CLOSE`-frame message format from `Connection closed: <code>: <reason>` to `Connection closed: <code> <reason>`, matching the WebSocket-close and `#close` fallback sites (the report's noted inconsistency).

## Tests

- New **`credit.test.ts`** (was missing): `claim()` rejects with the *exact* `Error` instance passed to `close(reason)` on both the pending and already-closed paths; first-reason-wins; and the reason-less backward-compat path still yields a generic `Error("closed")`.
- Four new **`session.test.ts`** regression tests: a uni/bidi stream blocked on stream-count credit and a stream write blocked on send credit each reject with the rich reason, exercised across all three teardown paths (graceful `close()`, a `CONNECTION_CLOSE` frame, and a WebSocket-level close).
- Full suite green: `81 pass / 0 fail`, `tsc --noEmit` clean, Biome clean. Empirically flip-checked: reverting the `Credit` fix flips exactly these 7 assertions from pass → fail (the backward-compat test correctly stays green).

## Compatibility

`Credit` is not exported from `index.ts` — it is a fully internal class, so adding an optional parameter is not a public API change and needs no major bump. `Session#close` is private. The only observable change is that a rejection from an operation blocked on internal flow control now carries a descriptive message instead of `"closed"`, which only makes existing "is this an expected close?" heuristics (including moq's `/^Connection closed/`) *more* accurate. No coordinated release with consumers is required.

## Notes

The Rust `rs/qmux` has the analogous information loss (`Credit::close()` takes no reason; `claim` returns a bare `Error::Closed`). Left out of scope here — it needs separate enum/API work and mirrors this JS change.
