### PR TITLE
fix(qmux): reject `closed` on abnormal termination (JS)

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -25,9 +25,13 @@ const stream = await transport.createBidirectionalStream()
 
 ### Detecting a dropped session
 
-`closed` follows the WebTransport contract: it **fulfills** with `{ closeCode, reason }` when the
-session ends gracefully — either side calling `close()` — and **rejects** when it ends abnormally:
-the socket dropped, the peer went idle, or either end detected a protocol violation.
+`closed` follows the WebTransport contract:
+
+- **Fulfills** with `{ closeCode, reason }` when the session ends gracefully — a `CONNECTION_CLOSE`
+  arrived, from either side calling `close()`. That includes a peer that closes because *it* caught
+  a protocol violation: it told us why, so you get its close code and reason.
+- **Rejects** when the session ends abnormally, with no `CONNECTION_CLOSE`: the socket dropped, the
+  peer went idle, or *this* endpoint caught the peer violating the protocol.
 
 ```ts
 try {

--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -23,6 +23,25 @@ await transport.ready
 const stream = await transport.createBidirectionalStream()
 ```
 
+### Detecting a dropped session
+
+`closed` follows the WebTransport contract: it **fulfills** with `{ closeCode, reason }` when the
+session ends gracefully — either side calling `close()` — and **rejects** when it ends abnormally:
+the socket dropped, the peer went idle, or either end detected a protocol violation.
+
+```ts
+try {
+	const info = await transport.closed
+	console.log("closed gracefully", info.closeCode, info.reason)
+} catch (err) {
+	// err is a WebTransportError-shaped SessionError: err.source === "session"
+	console.warn("session dropped, reconnecting", err)
+}
+```
+
+Don't reach for `closeCode` to tell the two apart — close codes are application-defined, so an app
+closing with `1006` is indistinguishable from a dropped socket. The settled state is the signal.
+
 ### Polyfill
 
 Install as a global `WebTransport` polyfill:

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "QMux protocol (draft-ietf-quic-qmux-02) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/qmux/src/error.ts
+++ b/js/qmux/src/error.ts
@@ -1,0 +1,20 @@
+/** A session-level failure, shaped like the `WebTransportError` that the
+ *  WebTransport spec requires `WebTransport.closed` to reject with.
+ *
+ *  The native `WebTransportError` constructor only exists where the browser
+ *  already implements WebTransport — which is precisely where this polyfill is
+ *  not used — so mint our own rather than feature-detect a global that will not
+ *  be there. `name`, `source`, and `streamErrorCode` match the interface, so a
+ *  consumer branching on `err.source === "session"` works against the native API
+ *  and this polyfill alike; `cause` carries the underlying failure (idle timeout,
+ *  socket error, decode failure, ...).
+ */
+export class SessionError extends Error implements Pick<WebTransportError, "source" | "streamErrorCode"> {
+	readonly source = "session" as const;
+	readonly streamErrorCode = null;
+
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "WebTransportError";
+	}
+}

--- a/js/qmux/src/index.ts
+++ b/js/qmux/src/index.ts
@@ -1,6 +1,7 @@
 import type { Version } from "./session.ts";
 import Session from "./session.ts";
 
+export { SessionError } from "./error.ts";
 export type { Config, SessionOptions, Version } from "./session.ts";
 
 /** Options forwarded to every `Session` constructed by [[install]]. */

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -232,6 +232,18 @@ describe("Session integration (scripted peer)", () => {
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
+		test("a peer CONNECTION_CLOSE fulfills even when it carries a violation code", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// The peer caught *us* violating the protocol and closed with 1002. It still
+			// said goodbye, so this is graceful and the app gets its code and reason —
+			// only a violation *we* detect (#abort) rejects. Same line rs/qmux draws:
+			// ConnectionClosed{code,reason} for a peer close, ProtocolViolation for ours.
+			peer.send({ type: "connection_close", code: VarInt.from(1002), reason: "Protocol violation" });
+			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		});
+
 		test("a socket drop with no CONNECTION_CLOSE rejects closed", async () => {
 			const { session, peer } = connect();
 			await session.ready;
@@ -244,12 +256,17 @@ describe("Session integration (scripted peer)", () => {
 			expect(err.message).toContain("Connection closed");
 		});
 
-		test("a socket error rejects closed", async () => {
+		test("a socket error rejects closed, preserving the underlying failure", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 
 			peer.error(new Error("connection reset"));
-			await expectSessionFailure(session);
+
+			// Why the transport died is the whole value of the rejection, so the socket's
+			// own error has to survive rather than be flattened into a fixed string.
+			const err = await expectSessionFailure(session);
+			expect(err.message).toBe("connection reset");
+			expect((err.cause as Error).message).toBe("connection reset");
 		});
 
 		test("an idle timeout rejects closed, rather than mimicking a graceful close", async () => {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { SessionError } from "./error.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
@@ -23,6 +24,7 @@ class FakePeer {
 	}>;
 	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
 	#closedResolve!: (info: { closeCode?: number; reason?: string }) => void;
+	#closedReject!: (err: Error) => void;
 	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
 
 	/** Raw chunks the Session has written. */
@@ -43,14 +45,22 @@ class FakePeer {
 			},
 		});
 		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
-		this.closed = new Promise((resolve) => {
+		this.closed = new Promise((resolve, reject) => {
 			this.#closedResolve = resolve;
+			this.#closedReject = reject;
 		});
+		// A real WebSocketStream's `closed` can reject; nothing may await it here
+		// until the test does, so keep that from surfacing as an unhandled rejection.
+		this.closed.catch(() => {});
 	}
 
 	close(info: { closeCode?: number; reason?: string } = {}) {
 		this.closeInfo = info;
 		this.#closedResolve(info);
+	}
+	/** The socket errored out, rather than closing — `WebSocketStream.closed` rejects. */
+	error(err = new Error("socket error")) {
+		this.#closedReject(err);
 	}
 	setHighWaterMark() {}
 
@@ -110,6 +120,28 @@ function settleTo<T>(p: Promise<T>): Promise<T | Error> {
 		(v) => v,
 		(e) => e,
 	);
+}
+
+/** The code on the CONNECTION_CLOSE the Session put on the wire, if any. A
+ *  locally-detected violation still owes the peer an explanation, even though it
+ *  settles `closed` as a failure on our side. */
+function sentCloseCode(peer: FakePeer): number | undefined {
+	const frame = peer.received().find((f) => f.type === "connection_close");
+	return frame?.type === "connection_close" ? Number(frame.code.value) : undefined;
+}
+
+/** Assert `closed` rejected the way the WebTransport contract requires of an
+ *  abnormal end, and hand the error back for further checks. A fulfilled `closed`
+ *  is the bug this guards: it makes a dropped session look like a clean shutdown. */
+async function expectSessionFailure(session: Session): Promise<SessionError> {
+	const settled = await settleTo(session.closed);
+	expect(settled).toBeInstanceOf(SessionError);
+	const err = settled as SessionError;
+	// Shaped like the native WebTransportError so consumers can branch on it.
+	expect(err.name).toBe("WebTransportError");
+	expect(err.source).toBe("session");
+	expect(err.streamErrorCode).toBeNull();
+	return err;
 }
 
 function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
@@ -185,23 +217,99 @@ describe("Session integration (scripted peer)", () => {
 		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 	});
 
-	test("a text frame closes the session with a protocol error", async () => {
+	// The WebTransport contract: `closed` fulfills only on a graceful end, and rejects
+	// with a WebTransportError (source "session") on an abnormal one. Without that
+	// split a consumer cannot tell a dropped session from a clean shutdown — the close
+	// code can't carry it, since codes are application-defined.
+	describe("closed settles graceful vs abnormal", () => {
+		test("a peer CONNECTION_CLOSE resolves closed with its code and reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// The peer closing the session deliberately is graceful, even though we
+			// didn't initiate it.
+			peer.send({ type: "connection_close", code: VarInt.from(42), reason: "bye" });
+			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
+		});
+
+		test("a socket drop with no CONNECTION_CLOSE rejects closed", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// Even a "clean" WebSocket status code is a drop at the session layer: the
+			// peer never said goodbye in QMux terms.
+			peer.close({ closeCode: 1000, reason: "" });
+
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("Connection closed");
+		});
+
+		test("a socket error rejects closed", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			peer.error(new Error("connection reset"));
+			await expectSessionFailure(session);
+		});
+
+		test("an idle timeout rejects closed, rather than mimicking a graceful close", async () => {
+			// The sharpest case: an idle timeout used to resolve with { closeCode: 0,
+			// reason: "idle timeout" }, while a graceful close() with no args resolves
+			// with { closeCode: 0, reason: "" }. A dead peer and a clean shutdown differed
+			// only by a free-text string.
+			const { session, peer } = connect({ maxIdleTimeout: 150n });
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			// ...and now the peer goes silent.
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("idle timeout");
+		});
+
+		test("the standard reconnect idiom sees a drop", async () => {
+			// The downstream bug this fixes (moq-dev/moq#2183): code written against the
+			// native API reconnects from the catch arm, which qmux could never reach.
+			const { session, peer } = connect();
+			await session.ready;
+
+			let reconnected = false;
+			const watch = (async () => {
+				try {
+					await session.closed;
+				} catch {
+					reconnected = true;
+				}
+			})();
+
+			peer.close({ closeCode: 1006, reason: "relay bounced" });
+			await watch;
+
+			expect(reconnected).toBe(true);
+		});
+	});
+
+	test("a text frame rejects closed and tells the peer why (1003)", async () => {
 		const { session, peer } = connect();
 		await session.ready;
 		peer.sendText("not binary");
-		const info = await session.closed;
-		expect(info.closeCode).toBe(1003);
+
+		const err = await expectSessionFailure(session);
+		expect(err.message).toContain("text frames are not valid for QMux");
+		await waitFor(() => sentCloseCode(peer) === 1003);
 	});
 
-	test("an unnegotiated RESET_STREAM_AT closes the session", async () => {
+	test("an unnegotiated RESET_STREAM_AT rejects closed and tells the peer why (1002)", async () => {
 		// The peer negotiates qmux-01, which never advertises `reset_stream_at`, so
 		// a RESET_STREAM_AT (0x24) frame is a protocol violation. Hand-built bytes:
 		// type=0x24, id=3, code=0, final_size=0, reliable_size=0.
 		const { session, peer } = connect();
 		await session.ready;
 		peer.sendRaw(new Uint8Array([0x24, 0x03, 0x00, 0x00, 0x00]));
-		const info = await session.closed;
-		expect(info.closeCode).toBe(1002);
+
+		const err = await expectSessionFailure(session);
+		// The decode failure itself is carried as the cause, not flattened away.
+		expect(err.cause).toBeInstanceOf(Error);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: an app write produces a DATAGRAM frame on the wire", async () => {
@@ -251,7 +359,8 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		peer.send({ type: "datagram", data: new Uint8Array(10) });
-		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		await expectSessionFailure(session);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: a DATAGRAM we never advertised support for is fatal", async () => {
@@ -262,7 +371,8 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		peer.send({ type: "datagram", data: new Uint8Array([1, 2, 3]) });
-		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		await expectSessionFailure(session);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: a no-length (0x30) DATAGRAM is sized without a length varint", async () => {
@@ -421,7 +531,7 @@ describe("Session integration (scripted peer)", () => {
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
-		test("a STREAM frame on a send-only stream ID closes the session with 1002", async () => {
+		test("a STREAM frame on a send-only stream ID fails the session with 1002", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 			peer.send({ type: "transport_parameters", params: peerParams() });
@@ -437,7 +547,8 @@ describe("Session integration (scripted peer)", () => {
 				fin: false,
 			});
 
-			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+			await expectSessionFailure(session);
+			await waitFor(() => sentCloseCode(peer) === 1002);
 			await settle();
 			expect(rejections).toEqual([]);
 		});

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1,5 +1,6 @@
 import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-stream";
 import { Credit, replenishWindow } from "./credit.ts";
+import { SessionError } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
@@ -359,6 +360,7 @@ export default class Session implements WebTransport {
 	#readyReject: (err: Error) => void;
 	readonly closed: Promise<WebTransportCloseInfo>;
 	#closedResolve: (info: WebTransportCloseInfo) => void;
+	#closedReject: (err: Error) => void;
 
 	readonly incomingBidirectionalStreams: ReadableStream<WebTransportBidirectionalStream>;
 	#incomingBidirectionalStreams!: ReadableStreamDefaultController<WebTransportBidirectionalStream>;
@@ -452,6 +454,11 @@ export default class Session implements WebTransport {
 		const closed = Promise.withResolvers<WebTransportCloseInfo>();
 		this.closed = closed.promise;
 		this.#closedResolve = closed.resolve;
+		this.#closedReject = closed.reject;
+		// Same guard as `ready`: an abnormal close rejects `closed`, and a consumer
+		// that only ever calls close() never attaches a handler. Real awaiters still
+		// observe the rejection.
+		this.closed.catch(() => {});
 
 		this.incomingBidirectionalStreams = new ReadableStream<WebTransportBidirectionalStream>({
 			start: (controller) => {
@@ -491,17 +498,21 @@ export default class Session implements WebTransport {
 			},
 			(err: unknown) => {
 				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream failed to open");
-				this.#close(1006, "WebSocketStream error");
+				this.#close(1006, "WebSocketStream error", false);
 			},
 		);
 		wss.closed.then(
 			(info) => {
+				// The socket went away without a CONNECTION_CLOSE. A peer close or a
+				// local close() would already have transitioned us (and #close is
+				// idempotent), so reaching here settled means the session dropped —
+				// even if the WebSocket itself closed with a "clean" status code.
 				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
-				this.#close(info.closeCode ?? 1006, info.reason ?? "");
+				this.#close(info.closeCode ?? 1006, info.reason ?? "", false);
 			},
 			() => {
 				this.#closeReason ??= new Error("WebSocketStream closed");
-				this.#close(1006, "WebSocketStream error");
+				this.#close(1006, "WebSocketStream error", false);
 			},
 		);
 	}
@@ -514,14 +525,14 @@ export default class Session implements WebTransport {
 				// QMux is binary-only; a text frame is a protocol error, not something
 				// to silently drop (which would desync the session).
 				if (typeof value === "string") {
-					this.close({ closeCode: 1003, reason: "text frames are not valid for QMux" });
+					this.#abort(1003, "text frames are not valid for QMux");
 					return;
 				}
 				this.#onData(value);
 			}
 		} catch (err) {
 			this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream read error");
-			this.#close(1006, "WebSocketStream read error");
+			this.#close(1006, "WebSocketStream read error", false);
 		}
 	}
 
@@ -583,7 +594,7 @@ export default class Session implements WebTransport {
 		} catch (error) {
 			// A decode failure or a frame that violates a negotiated limit is fatal.
 			console.error("Protocol violation:", error);
-			this.close({ closeCode: 1002, reason: "Protocol violation" });
+			this.#abort(1002, "Protocol violation", error);
 		}
 	}
 
@@ -605,8 +616,11 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
+			// The peer closed the session deliberately: graceful, so `closed`
+			// fulfills with its code/reason. Only a termination with *no*
+			// CONNECTION_CLOSE is a drop.
 			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
-			this.#close(Number(frame.code.value), frame.reason);
+			this.#close(Number(frame.code.value), frame.reason, true);
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
 			this.#handleTransportParameters(frame.params);
@@ -744,9 +758,11 @@ export default class Session implements WebTransport {
 		}
 		const now = Date.now();
 		if (now - this.#lastRecvAt > timeoutMs) {
-			// Peer has gone silent past the negotiated limit.
+			// Peer has gone silent past the negotiated limit. Abnormal: without a
+			// rejection this is indistinguishable from a graceful close(), which also
+			// settles with closeCode 0.
 			this.#closeReason ??= new Error("idle timeout");
-			this.#close(0, "idle timeout");
+			this.#close(0, "idle timeout", false);
 			this.#transportClose();
 			return;
 		}
@@ -911,7 +927,7 @@ export default class Session implements WebTransport {
 		if (this.#closed) return;
 
 		if (frame.data.byteLength > MAX_FRAME_PAYLOAD) {
-			this.close({ closeCode: 1002, reason: "frame too large" });
+			this.#abort(1002, "frame too large");
 			return;
 		}
 
@@ -937,7 +953,7 @@ export default class Session implements WebTransport {
 			if (isQmux(this.#version)) {
 				const credit = frame.id.dir === Stream.Dir.Bi ? this.#recvBiCredit : this.#recvUniCredit;
 				if (!credit.receiveUpTo(frame.id.index + 1n)) {
-					this.close({ closeCode: 1002, reason: "stream limit exceeded" });
+					this.#abort(1002, "stream limit exceeded");
 					return;
 				}
 			}
@@ -962,7 +978,7 @@ export default class Session implements WebTransport {
 
 			// Validate recv flow control before accepting
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
-				this.close({ closeCode: 1002, reason: "flow control error" });
+				this.#abort(1002, "flow control error");
 				return;
 			}
 
@@ -1041,7 +1057,7 @@ export default class Session implements WebTransport {
 		} else {
 			// Existing stream — validate recv flow control
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
-				this.close({ closeCode: 1002, reason: "flow control error" });
+				this.#abort(1002, "flow control error");
 				return;
 			}
 		}
@@ -1356,8 +1372,17 @@ export default class Session implements WebTransport {
 
 	/** The single, idempotent close transition: marks the session closed, settles
 	 *  `ready`/`closed`, and tears down streams, credits, and the scheduler.
-	 *  Protocol-close paths route through here before/while closing the socket. */
-	#close(code: number, reason: string) {
+	 *  Protocol-close paths route through here before/while closing the socket.
+	 *
+	 *  `graceful` decides how `closed` settles, and it is the only signal a
+	 *  consumer has to tell a dropped session from a clean shutdown. Per the
+	 *  WebTransport contract `closed` fulfills only when the session ends
+	 *  cleanly — a local `close()` or a peer CONNECTION_CLOSE — and rejects with
+	 *  a `WebTransportError` on everything else: socket failure, read error,
+	 *  locally-detected protocol violation, idle timeout. Close codes cannot carry
+	 *  that distinction, since they are application-defined (an app closing with
+	 *  1006 must not look like a dropped socket). */
+	#close(code: number, reason: string, graceful: boolean) {
 		if (this.#closed) return;
 		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
 
@@ -1369,10 +1394,14 @@ export default class Session implements WebTransport {
 		// Settle the WebTransport promises. Rejecting `ready` is a no-op once it
 		// has resolved (i.e. after a successful open).
 		this.#readyReject(this.#closed);
-		this.#closedResolve({
-			closeCode: code,
-			reason,
-		});
+		if (graceful) {
+			this.#closedResolve({
+				closeCode: code,
+				reason,
+			});
+		} else {
+			this.#closedReject(new SessionError(this.#closed.message, { cause: this.#closed }));
+		}
 
 		// Fail active streams so consumers unblock
 		try {
@@ -1429,11 +1458,12 @@ export default class Session implements WebTransport {
 		} catch {}
 	}
 
-	close(info?: { closeCode?: number; reason?: string }) {
+	/** Emit CONNECTION_CLOSE, transition, and give the queued frame a moment to
+	 *  flush before actually closing the socket. Shared by the app-initiated
+	 *  `close()` and the locally-detected failure path `#abort()`, which differ
+	 *  only in how they settle `closed`. */
+	#closeWithFrame(code: number, reason: string, graceful: boolean) {
 		if (this.#closed) return;
-
-		const code = info?.closeCode ?? 0;
-		const reason = info?.reason ?? "";
 
 		this.#sendPriorityFrame({
 			type: "connection_close",
@@ -1441,12 +1471,25 @@ export default class Session implements WebTransport {
 			reason,
 		});
 
-		// Transition state and tear down now; give the queued CONNECTION_CLOSE a
-		// moment to flush before actually closing the socket.
-		this.#close(code, reason);
+		this.#close(code, reason, graceful);
 		setTimeout(() => {
 			this.#transportClose();
 		}, 100);
+	}
+
+	/** A failure we detected ourselves (protocol violation, unsupported frame).
+	 *  It borrows the same wire path as `close()` — the peer still deserves a
+	 *  CONNECTION_CLOSE saying why — but it is not an app-initiated close, so
+	 *  `closed` rejects rather than fulfilling. */
+	#abort(code: number, reason: string, cause?: unknown) {
+		if (cause !== undefined) {
+			this.#closeReason ??= cause instanceof Error ? cause : new Error(String(cause));
+		}
+		this.#closeWithFrame(code, reason, false);
+	}
+
+	close(info?: { closeCode?: number; reason?: string }) {
+		this.#closeWithFrame(info?.closeCode ?? 0, info?.reason ?? "", true);
 	}
 
 	/** Resize the send-buffer high-water mark (bytes) used for write

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -510,8 +510,10 @@ export default class Session implements WebTransport {
 				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
 				this.#close(info.closeCode ?? 1006, info.reason ?? "", false);
 			},
-			() => {
-				this.#closeReason ??= new Error("WebSocketStream closed");
+			(err: unknown) => {
+				// Keep the socket failure itself — it becomes the SessionError's cause, and
+				// it's the only description of *why* the transport died.
+				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream closed");
 				this.#close(1006, "WebSocketStream error", false);
 			},
 		);


### PR DESCRIPTION
Fixes #290.

`Session.closed` was **resolve-only**. It's built with `Promise.withResolvers`, but only `resolve` was ever captured — there was no reject counterpart anywhere in the class — so *every* termination fulfilled it with a `WebTransportCloseInfo`: socket drop, read error, protocol violation, idle timeout.

The WebTransport contract is that `closed` fulfills on a graceful end and **rejects** with a `WebTransportError` (`source: "session"`) on an abnormal one. Without that split, a consumer has no way to tell a dropped session from a clean shutdown, and the standard reconnect idiom can never fire:

```ts
try {
	await session.closed;   // clean shutdown
} catch (err) {
	scheduleReconnect(err); // ← unreachable on qmux before this PR
}
```

### The parity argument

`rs/qmux` in this repo **already** draws this line. `rs/web-transport-trait/src/lib.rs:126` defines `fn closed(&self) -> impl Future<Output = Self::Error>`, and `rs/qmux/src/error.rs` separates `Closed` / `ConnectionClosed { code, reason }` from `IdleTimeout` / `ProtocolViolation` / `FlowControlError`, wired at `session.rs:66` (graceful), `:659` (idle timeout), `:975` (peer close). A Rust consumer can tell a dead peer from a clean shutdown; a JS consumer of the same protocol could not. This brings the JS port to parity.

### The sharpest case

An idle timeout resolved with `{ closeCode: 0, reason: "idle timeout" }`. A graceful `close()` with no args resolves with `{ closeCode: 0, reason: "" }`. A dead peer and a clean shutdown differed **only by a free-text string**.

And `closeCode` sniffing isn't a workaround: `session.ts` forwards raw WebSocket status codes into `WebTransportCloseInfo.closeCode`, but WebTransport close codes are application-defined — an app closing with `1006` is indistinguishable from a dropped socket. The settled state has to carry the signal.

## What changed

**`#close()` takes an explicit `graceful` flag** rather than inferring one. Worth calling out: `#closeReason` looks like a ready-made discriminator, but it's also set on the peer-CONNECTION_CLOSE path (`session.ts:608`), which is a *graceful* close — inferring from it would reject clean peer closes. Exactly two paths fulfill:

| | settles |
|---|---|
| local `close()` | **fulfill** `{closeCode, reason}` |
| peer CONNECTION_CLOSE | **fulfill** `{closeCode, reason}` |
| socket drop / open failure / socket error | reject |
| read-loop error | reject |
| protocol violation (1002/1003) | reject |
| idle timeout | reject |

**Locally-detected violations now route through a new `#abort()`.** Previously the text-frame, decode-failure, frame-too-large, stream-limit, and flow-control paths all called the *public* `this.close({ closeCode: 1002 })` — i.e. qmux gracefully closed itself upon detecting that the peer had violated the protocol. `#abort()` still sends CONNECTION_CLOSE (the peer deserves to know why) but settles `closed` as a failure.

**New `SessionError`** (`js/qmux/src/error.ts`), exported from the package root. The native `WebTransportError` constructor only exists where the browser implements WebTransport natively — which is precisely where this polyfill isn't used — so rather than feature-detect a global that won't be there, this mints a structurally identical error: `name === "WebTransportError"`, `source === "session"`, `streamErrorCode === null`, plus `cause` carrying the underlying failure. Consumers branching on `err.source === "session"` work against the native API and the polyfill alike.

## Tests

⚠️ **This rewrites five currently-green assertions** — flagging it so the diff doesn't read as deleting your own passing tests. They pinned the buggy contract (`expect(await session.closed).toEqual({ closeCode: 1002, … })` on a *protocol violation*, added in #280). They now assert the rejection **plus** the CONNECTION_CLOSE code still put on the wire, which the old assertions never checked. The graceful-close assertions are untouched.

New coverage for the full matrix: peer CONNECTION_CLOSE → fulfill, local `close()` → fulfill, socket drop → reject, socket error → reject, idle timeout → reject, and a regression test driving the reconnect idiom end to end. The test peer's `closed` gained a reject path, since a real `WebSocketStream.closed` can reject and nothing exercised that.

`bun test` → 92 pass / 0 fail. `tsc --noEmit` clean, biome clean.

**Verified end-to-end over a real WebSocket** (not the scripted peer): a Bun server negotiates qmux-01, the session comes up, then the server calls `terminate()` — a relay bouncing. Same harness, both trees:

```
before:  RESOLVED  closeCode=1006 reason="Connection ended"   → consumer sits on a dead session
after:   REJECTED  name=WebTransportError source=session      → consumer reconnects
```

## Notes

- **Version bumped to 0.3.0.** JS publishing is manual (`bun run release`), not release-plz, and `js/qmux/package.json` was still `0.2.0` — same as npm latest — so without the bump a merge wouldn't reach consumers. Happy to drop the bump if you'd rather handle it separately.
- This is a **behavioral change** for anyone currently doing a bare `await session.closed` with no `catch`. That's the point of the fix, but it's worth a line in the release notes.
- Out of scope, but the same bug exists independently in `js/web-transport` (the NAPI wrapper): `src/session.ts:124` calls `closed.resolve({ closeCode: 0, reason: String(err) })` inside a `.catch()`, so an outright error resolves `closed` with code 0. Happy to send a follow-up.
