### PR TITLE
fix(qmux): split APPLICATION_CLOSE (0x1d) from CONNECTION_CLOSE (0x1c)

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -25,9 +25,13 @@ const stream = await transport.createBidirectionalStream()
 
 ### Detecting a dropped session
 
-`closed` follows the WebTransport contract: it **fulfills** with `{ closeCode, reason }` when the
-session ends gracefully — either side calling `close()` — and **rejects** when it ends abnormally:
-the socket dropped, the peer went idle, or either end detected a protocol violation.
+`closed` follows the WebTransport contract:
+
+- **Fulfills** with `{ closeCode, reason }` when the session ends gracefully — a `CONNECTION_CLOSE`
+  arrived, from either side calling `close()`. That includes a peer that closes because *it* caught
+  a protocol violation: it told us why, so you get its close code and reason.
+- **Rejects** when the session ends abnormally, with no `CONNECTION_CLOSE`: the socket dropped, the
+  peer went idle, or *this* endpoint caught the peer violating the protocol.
 
 ```ts
 try {

--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -23,6 +23,25 @@ await transport.ready
 const stream = await transport.createBidirectionalStream()
 ```
 
+### Detecting a dropped session
+
+`closed` follows the WebTransport contract: it **fulfills** with `{ closeCode, reason }` when the
+session ends gracefully — either side calling `close()` — and **rejects** when it ends abnormally:
+the socket dropped, the peer went idle, or either end detected a protocol violation.
+
+```ts
+try {
+	const info = await transport.closed
+	console.log("closed gracefully", info.closeCode, info.reason)
+} catch (err) {
+	// err is a WebTransportError-shaped SessionError: err.source === "session"
+	console.warn("session dropped, reconnecting", err)
+}
+```
+
+Don't reach for `closeCode` to tell the two apart — close codes are application-defined, so an app
+closing with `1006` is indistinguishable from a dropped socket. The settled state is the signal.
+
 ### Polyfill
 
 Install as a global `WebTransport` polyfill:

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "QMux protocol (draft-ietf-quic-qmux-02) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/qmux/src/error.ts
+++ b/js/qmux/src/error.ts
@@ -1,0 +1,20 @@
+/** A session-level failure, shaped like the `WebTransportError` that the
+ *  WebTransport spec requires `WebTransport.closed` to reject with.
+ *
+ *  The native `WebTransportError` constructor only exists where the browser
+ *  already implements WebTransport — which is precisely where this polyfill is
+ *  not used — so mint our own rather than feature-detect a global that will not
+ *  be there. `name`, `source`, and `streamErrorCode` match the interface, so a
+ *  consumer branching on `err.source === "session"` works against the native API
+ *  and this polyfill alike; `cause` carries the underlying failure (idle timeout,
+ *  socket error, decode failure, ...).
+ */
+export class SessionError extends Error implements Pick<WebTransportError, "source" | "streamErrorCode"> {
+	readonly source = "session" as const;
+	readonly streamErrorCode = null;
+
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "WebTransportError";
+	}
+}

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -43,6 +43,14 @@ export interface ConnectionClose {
 	type: "connection_close";
 	code: VarInt;
 	reason: string;
+	/** Which QUIC close subtype this is, and how the receiver settles `closed`:
+	 *  - `true` → APPLICATION_CLOSE (0x1d): a graceful, app-initiated close; the
+	 *    receiver *fulfills* `closed` with `code`/`reason`.
+	 *  - `false` → CONNECTION_CLOSE (0x1c): a protocol violation or transport error
+	 *    the sender detected; the receiver *rejects* `closed`.
+	 *  The subtype, not the code, carries this distinction — codes are
+	 *  application-defined, so a graceful close may legitimately use any value. */
+	application: boolean;
 }
 
 export interface MaxData {
@@ -271,7 +279,8 @@ function encodeWebTransport(frame: Any): Uint8Array {
 			const body = new TextEncoder().encode(frame.reason);
 			let buffer = new Uint8Array(new ArrayBuffer(1 + 8 + body.length), 0, 1);
 
-			buffer[0] = 0x1d;
+			// APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c).
+			buffer[0] = frame.application ? 0x1d : 0x1c;
 			buffer = frame.code.encode(buffer);
 
 			buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength + body.length);
@@ -330,8 +339,9 @@ function encodeQMux(frame: Any): Uint8Array {
 		}
 
 		case "connection_close": {
-			// APPLICATION_CLOSE (0x1d)
-			const frameType = VarInt.from(0x1d);
+			// APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c). Both carry the
+			// causing-frame-type field in this draft, so only the type byte differs.
+			const frameType = VarInt.from(frame.application ? 0x1d : 0x1c);
 			const causingFrameType = VarInt.from(0);
 			const body = new TextEncoder().encode(frame.reason);
 			const reasonLength = VarInt.from(body.length);
@@ -636,13 +646,13 @@ function decodeWebTransport(buffer: Uint8Array): Any {
 		return { type: "stop_sending", id, code };
 	}
 
-	if (frameType === 0x1d) {
+	if (frameType === 0x1d || frameType === 0x1c) {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 
 		const reason = new TextDecoder().decode(buffer);
 
-		return { type: "connection_close", code, reason };
+		return { type: "connection_close", code, reason, application: frameType === 0x1d };
 	}
 
 	if (frameType === 0x08 || frameType === 0x09) {
@@ -750,7 +760,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		[reasonBytes, buffer] = take(buffer, reasonLen);
 		const reason = new TextDecoder().decode(reasonBytes);
 
-		return { type: "connection_close", code, reason };
+		return { type: "connection_close", code, reason, application: frameType === 0x1dn };
 	}
 
 	// MAX_DATA
@@ -931,7 +941,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		let reasonBytes: Uint8Array;
 		[reasonBytes, buffer] = take(buffer, reasonLen);
 		const reason = new TextDecoder().decode(reasonBytes);
-		return [{ type: "connection_close", code, reason }, buffer];
+		return [{ type: "connection_close", code, reason, application: frameType === 0x1dn }, buffer];
 	}
 
 	// MAX_DATA

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -39,18 +39,25 @@ export interface StopSending {
 	code: VarInt;
 }
 
+/** Transport CONNECTION_CLOSE (0x1c): a protocol violation or transport error the
+ *  sender detected. The receiver *rejects* `closed`. Per RFC 9000 §19.19 the
+ *  transport variant carries the Frame Type field (we always send 0). */
 export interface ConnectionClose {
 	type: "connection_close";
 	code: VarInt;
 	reason: string;
-	/** Which QUIC close subtype this is, and how the receiver settles `closed`:
-	 *  - `true` → APPLICATION_CLOSE (0x1d): a graceful, app-initiated close; the
-	 *    receiver *fulfills* `closed` with `code`/`reason`.
-	 *  - `false` → CONNECTION_CLOSE (0x1c): a protocol violation or transport error
-	 *    the sender detected; the receiver *rejects* `closed`.
-	 *  The subtype, not the code, carries this distinction — codes are
-	 *  application-defined, so a graceful close may legitimately use any value. */
-	application: boolean;
+}
+
+/** APPLICATION_CLOSE (0x1d): a graceful, app-initiated close carrying an
+ *  application code/reason. The receiver *fulfills* `closed`. Per RFC 9000 §19.19
+ *  the application variant omits the Frame Type field.
+ *
+ *  The close subtype, not the code, carries the fulfill/reject distinction —
+ *  codes are application-defined, so a graceful close may use any value. */
+export interface ApplicationClose {
+	type: "application_close";
+	code: VarInt;
+	reason: string;
 }
 
 export interface MaxData {
@@ -178,6 +185,7 @@ export type Any =
 	| ResetStream
 	| StopSending
 	| ConnectionClose
+	| ApplicationClose
 	| MaxData
 	| MaxStreamData
 	| MaxStreamsBidi
@@ -275,12 +283,14 @@ function encodeWebTransport(frame: Any): Uint8Array {
 			return buffer;
 		}
 
-		case "connection_close": {
+		// The legacy WebTransport format keeps the reason as the rest of the buffer
+		// (no Frame Type / length fields); only the type byte differs.
+		case "connection_close":
+		case "application_close": {
 			const body = new TextEncoder().encode(frame.reason);
 			let buffer = new Uint8Array(new ArrayBuffer(1 + 8 + body.length), 0, 1);
 
-			// APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c).
-			buffer[0] = frame.application ? 0x1d : 0x1c;
+			buffer[0] = frame.type === "application_close" ? 0x1d : 0x1c;
 			buffer = frame.code.encode(buffer);
 
 			buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength + body.length);
@@ -339,9 +349,9 @@ function encodeQMux(frame: Any): Uint8Array {
 		}
 
 		case "connection_close": {
-			// APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c). Both carry the
-			// causing-frame-type field in this draft, so only the type byte differs.
-			const frameType = VarInt.from(frame.application ? 0x1d : 0x1c);
+			// CONNECTION_CLOSE (0x1c) carries the Frame Type field (RFC 9000 §19.19).
+			// We don't track which frame tripped the error, so it's always 0 (PADDING).
+			const frameType = VarInt.from(0x1c);
 			const causingFrameType = VarInt.from(0);
 			const body = new TextEncoder().encode(frame.reason);
 			const reasonLength = VarInt.from(body.length);
@@ -351,6 +361,24 @@ function encodeQMux(frame: Any): Uint8Array {
 			buffer = frameType.encode(buffer);
 			buffer = frame.code.encode(buffer);
 			buffer = causingFrameType.encode(buffer);
+			buffer = reasonLength.encode(buffer);
+
+			buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength + body.length);
+			buffer.set(body, buffer.byteLength - body.length);
+
+			return buffer;
+		}
+
+		case "application_close": {
+			// APPLICATION_CLOSE (0x1d): no Frame Type field (RFC 9000 §19.19).
+			const frameType = VarInt.from(0x1d);
+			const body = new TextEncoder().encode(frame.reason);
+			const reasonLength = VarInt.from(body.length);
+
+			let buffer = new Uint8Array(new ArrayBuffer(8 + 8 + 8 + body.length), 0, 0);
+
+			buffer = frameType.encode(buffer);
+			buffer = frame.code.encode(buffer);
 			buffer = reasonLength.encode(buffer);
 
 			buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength + body.length);
@@ -650,9 +678,12 @@ function decodeWebTransport(buffer: Uint8Array): Any {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 
+		// Legacy format: the reason is the rest of the buffer (no Frame Type field).
 		const reason = new TextDecoder().decode(buffer);
 
-		return { type: "connection_close", code, reason, application: frameType === 0x1d };
+		return frameType === 0x1d
+			? { type: "application_close", code, reason }
+			: { type: "connection_close", code, reason };
 	}
 
 	if (frameType === 0x08 || frameType === 0x09) {
@@ -750,8 +781,11 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 
-		// Skip frame_type field
-		[v, buffer] = VarInt.decode(buffer);
+		// The Frame Type field is present only for CONNECTION_CLOSE (0x1c);
+		// APPLICATION_CLOSE (0x1d) omits it (RFC 9000 §19.19).
+		if (frameType === 0x1cn) {
+			[v, buffer] = VarInt.decode(buffer);
+		}
 
 		// reason_length + reason
 		[v, buffer] = VarInt.decode(buffer);
@@ -760,7 +794,9 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		[reasonBytes, buffer] = take(buffer, reasonLen);
 		const reason = new TextDecoder().decode(reasonBytes);
 
-		return { type: "connection_close", code, reason, application: frameType === 0x1dn };
+		return frameType === 0x1dn
+			? { type: "application_close", code, reason }
+			: { type: "connection_close", code, reason };
 	}
 
 	// MAX_DATA
@@ -935,13 +971,20 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 	if (frameType === 0x1cn || frameType === 0x1dn) {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
-		[v, buffer] = VarInt.decode(buffer); // frame_type
+		// Frame Type field present only for 0x1c; 0x1d omits it (RFC 9000 §19.19).
+		if (frameType === 0x1cn) {
+			[v, buffer] = VarInt.decode(buffer); // frame_type
+		}
 		[v, buffer] = VarInt.decode(buffer);
 		const reasonLen = Number(v.value);
 		let reasonBytes: Uint8Array;
 		[reasonBytes, buffer] = take(buffer, reasonLen);
 		const reason = new TextDecoder().decode(reasonBytes);
-		return [{ type: "connection_close", code, reason, application: frameType === 0x1dn }, buffer];
+		const close: Any =
+			frameType === 0x1dn
+				? { type: "application_close", code, reason }
+				: { type: "connection_close", code, reason };
+		return [close, buffer];
 	}
 
 	// MAX_DATA

--- a/js/qmux/src/index.ts
+++ b/js/qmux/src/index.ts
@@ -1,6 +1,7 @@
 import type { Version } from "./session.ts";
 import Session from "./session.ts";
 
+export { SessionError } from "./error.ts";
 export type { Config, SessionOptions, Version } from "./session.ts";
 
 /** Options forwarded to every `Session` constructed by [[install]]. */

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -232,6 +232,18 @@ describe("Session integration (scripted peer)", () => {
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
+		test("a peer CONNECTION_CLOSE fulfills even when it carries a violation code", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// The peer caught *us* violating the protocol and closed with 1002. It still
+			// said goodbye, so this is graceful and the app gets its code and reason —
+			// only a violation *we* detect (#abort) rejects. Same line rs/qmux draws:
+			// ConnectionClosed{code,reason} for a peer close, ProtocolViolation for ours.
+			peer.send({ type: "connection_close", code: VarInt.from(1002), reason: "Protocol violation" });
+			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		});
+
 		test("a socket drop with no CONNECTION_CLOSE rejects closed", async () => {
 			const { session, peer } = connect();
 			await session.ready;
@@ -244,12 +256,17 @@ describe("Session integration (scripted peer)", () => {
 			expect(err.message).toContain("Connection closed");
 		});
 
-		test("a socket error rejects closed", async () => {
+		test("a socket error rejects closed, preserving the underlying failure", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 
 			peer.error(new Error("connection reset"));
-			await expectSessionFailure(session);
+
+			// Why the transport died is the whole value of the rejection, so the socket's
+			// own error has to survive rather than be flattened into a fixed string.
+			const err = await expectSessionFailure(session);
+			expect(err.message).toBe("connection reset");
+			expect((err.cause as Error).message).toBe("connection reset");
 		});
 
 		test("an idle timeout rejects closed, rather than mimicking a graceful close", async () => {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -122,12 +122,18 @@ function settleTo<T>(p: Promise<T>): Promise<T | Error> {
 	);
 }
 
-/** The code on the CONNECTION_CLOSE the Session put on the wire, if any. A
- *  locally-detected violation still owes the peer an explanation, even though it
- *  settles `closed` as a failure on our side. */
-function sentCloseCode(peer: FakePeer): number | undefined {
+/** The session-close frame the Session put on the wire, if any. A locally-detected
+ *  violation still owes the peer an explanation, even though it settles `closed`
+ *  as a failure on our side. Its `application` flag distinguishes the graceful
+ *  APPLICATION_CLOSE a `close()` sends from the CONNECTION_CLOSE a violation sends. */
+function sentClose(peer: FakePeer): Frame.ConnectionClose | undefined {
 	const frame = peer.received().find((f) => f.type === "connection_close");
-	return frame?.type === "connection_close" ? Number(frame.code.value) : undefined;
+	return frame?.type === "connection_close" ? frame : undefined;
+}
+
+function sentCloseCode(peer: FakePeer): number | undefined {
+	const frame = sentClose(peer);
+	return frame ? Number(frame.code.value) : undefined;
 }
 
 /** Assert `closed` rejected the way the WebTransport contract requires of an
@@ -204,13 +210,15 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
-	test("close() sends CONNECTION_CLOSE, resolves closed, and is idempotent", async () => {
+	test("close() sends APPLICATION_CLOSE, resolves closed, and is idempotent", async () => {
 		const { session, peer } = connect();
 		await session.ready;
 
 		session.close({ closeCode: 42, reason: "bye" });
 		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		await waitFor(() => peer.has("connection_close"));
+		// A graceful close is an APPLICATION_CLOSE (0x1d), so the peer fulfills.
+		expect(sentClose(peer)?.application).toBe(true);
 
 		// Second close is a no-op: the resolved info is unchanged.
 		session.close({ closeCode: 7, reason: "again" });
@@ -222,26 +230,42 @@ describe("Session integration (scripted peer)", () => {
 	// split a consumer cannot tell a dropped session from a clean shutdown — the close
 	// code can't carry it, since codes are application-defined.
 	describe("closed settles graceful vs abnormal", () => {
-		test("a peer CONNECTION_CLOSE resolves closed with its code and reason", async () => {
+		test("a peer APPLICATION_CLOSE resolves closed with its code and reason", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 
-			// The peer closing the session deliberately is graceful, even though we
-			// didn't initiate it.
-			peer.send({ type: "connection_close", code: VarInt.from(42), reason: "bye" });
+			// The peer closing the session deliberately (APPLICATION_CLOSE / 0x1d) is
+			// graceful, even though we didn't initiate it.
+			peer.send({ type: "connection_close", application: true, code: VarInt.from(42), reason: "bye" });
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
-		test("a peer CONNECTION_CLOSE fulfills even when it carries a violation code", async () => {
+		test("a peer APPLICATION_CLOSE fulfills even when its code looks like a transport error", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 
-			// The peer caught *us* violating the protocol and closed with 1002. It still
-			// said goodbye, so this is graceful and the app gets its code and reason —
-			// only a violation *we* detect (#abort) rejects. Same line rs/qmux draws:
-			// ConnectionClosed{code,reason} for a peer close, ProtocolViolation for ours.
-			peer.send({ type: "connection_close", code: VarInt.from(1002), reason: "Protocol violation" });
-			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+			// 1002 is a transport-error code, but an APPLICATION_CLOSE is graceful by
+			// definition — the *subtype*, not the code, decides. Codes are
+			// application-defined, so the app still gets its code and reason.
+			peer.send({ type: "connection_close", application: true, code: VarInt.from(1002), reason: "bye" });
+			expect(await session.closed).toEqual({ closeCode: 1002, reason: "bye" });
+		});
+
+		test("a peer CONNECTION_CLOSE rejects closed", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// The peer detected a protocol violation / transport error and sent a
+			// CONNECTION_CLOSE (0x1c) — abnormal, so `closed` rejects rather than
+			// fulfilling. Mirrors the frame we emit from #abort.
+			peer.send({
+				type: "connection_close",
+				application: false,
+				code: VarInt.from(1002),
+				reason: "Protocol violation",
+			});
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("Protocol violation");
 		});
 
 		test("a socket drop with no CONNECTION_CLOSE rejects closed", async () => {
@@ -313,6 +337,8 @@ describe("Session integration (scripted peer)", () => {
 		const err = await expectSessionFailure(session);
 		expect(err.message).toContain("text frames are not valid for QMux");
 		await waitFor(() => sentCloseCode(peer) === 1003);
+		// A violation we detect is a CONNECTION_CLOSE (0x1c), so the peer rejects too.
+		expect(sentClose(peer)?.application).toBe(false);
 	});
 
 	test("an unnegotiated RESET_STREAM_AT rejects closed and tells the peer why (1002)", async () => {
@@ -327,6 +353,7 @@ describe("Session integration (scripted peer)", () => {
 		// The decode failure itself is carried as the cause, not flattened away.
 		expect(err.cause).toBeInstanceOf(Error);
 		await waitFor(() => sentCloseCode(peer) === 1002);
+		expect(sentClose(peer)?.application).toBe(false);
 	});
 
 	test("datagrams: an app write produces a DATAGRAM frame on the wire", async () => {
@@ -689,8 +716,9 @@ describe("Session integration (scripted peer)", () => {
 			const created = settleTo(session.createBidirectionalStream());
 			await flushMicrotasks();
 
-			// The peer aborts the connection; the frame's code/reason must reach the waiter.
-			peer.send({ type: "connection_close", code: VarInt.from(7n), reason: "peer gone" });
+			// The peer aborts the connection (CONNECTION_CLOSE / 0x1c); the frame's
+			// code/reason must reach the waiter.
+			peer.send({ type: "connection_close", application: false, code: VarInt.from(7n), reason: "peer gone" });
 
 			const err = await created;
 			expect(err).toBeInstanceOf(Error);

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -23,8 +23,8 @@ class FakePeer {
 		extensions: string;
 	}>;
 	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
-	#closedResolve!: (info: { closeCode?: number; reason?: string }) => void;
-	#closedReject!: (err: Error) => void;
+	#closedResolve: (info: { closeCode?: number; reason?: string }) => void;
+	#closedReject: (err: Error) => void;
 	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
 
 	/** Raw chunks the Session has written. */
@@ -45,10 +45,10 @@ class FakePeer {
 			},
 		});
 		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
-		this.closed = new Promise((resolve, reject) => {
-			this.#closedResolve = resolve;
-			this.#closedReject = reject;
-		});
+		const closed = Promise.withResolvers<{ closeCode?: number; reason?: string }>();
+		this.closed = closed.promise;
+		this.#closedResolve = closed.resolve;
+		this.#closedReject = closed.reject;
 		// A real WebSocketStream's `closed` can reject; nothing may await it here
 		// until the test does, so keep that from surfacing as an unhandled rejection.
 		this.closed.catch(() => {});

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { SessionError } from "./error.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
@@ -23,6 +24,7 @@ class FakePeer {
 	}>;
 	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
 	#closedResolve!: (info: { closeCode?: number; reason?: string }) => void;
+	#closedReject!: (err: Error) => void;
 	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
 
 	/** Raw chunks the Session has written. */
@@ -43,14 +45,22 @@ class FakePeer {
 			},
 		});
 		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
-		this.closed = new Promise((resolve) => {
+		this.closed = new Promise((resolve, reject) => {
 			this.#closedResolve = resolve;
+			this.#closedReject = reject;
 		});
+		// A real WebSocketStream's `closed` can reject; nothing may await it here
+		// until the test does, so keep that from surfacing as an unhandled rejection.
+		this.closed.catch(() => {});
 	}
 
 	close(info: { closeCode?: number; reason?: string } = {}) {
 		this.closeInfo = info;
 		this.#closedResolve(info);
+	}
+	/** The socket errored out, rather than closing — `WebSocketStream.closed` rejects. */
+	error(err = new Error("socket error")) {
+		this.#closedReject(err);
 	}
 	setHighWaterMark() {}
 
@@ -110,6 +120,28 @@ function settleTo<T>(p: Promise<T>): Promise<T | Error> {
 		(v) => v,
 		(e) => e,
 	);
+}
+
+/** The code on the CONNECTION_CLOSE the Session put on the wire, if any. A
+ *  locally-detected violation still owes the peer an explanation, even though it
+ *  settles `closed` as a failure on our side. */
+function sentCloseCode(peer: FakePeer): number | undefined {
+	const frame = peer.received().find((f) => f.type === "connection_close");
+	return frame?.type === "connection_close" ? Number(frame.code.value) : undefined;
+}
+
+/** Assert `closed` rejected the way the WebTransport contract requires of an
+ *  abnormal end, and hand the error back for further checks. A fulfilled `closed`
+ *  is the bug this guards: it makes a dropped session look like a clean shutdown. */
+async function expectSessionFailure(session: Session): Promise<SessionError> {
+	const settled = await settleTo(session.closed);
+	expect(settled).toBeInstanceOf(SessionError);
+	const err = settled as SessionError;
+	// Shaped like the native WebTransportError so consumers can branch on it.
+	expect(err.name).toBe("WebTransportError");
+	expect(err.source).toBe("session");
+	expect(err.streamErrorCode).toBeNull();
+	return err;
 }
 
 function peerParams(overrides: Partial<TransportParams> = {}): TransportParams {
@@ -185,23 +217,99 @@ describe("Session integration (scripted peer)", () => {
 		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 	});
 
-	test("a text frame closes the session with a protocol error", async () => {
+	// The WebTransport contract: `closed` fulfills only on a graceful end, and rejects
+	// with a WebTransportError (source "session") on an abnormal one. Without that
+	// split a consumer cannot tell a dropped session from a clean shutdown — the close
+	// code can't carry it, since codes are application-defined.
+	describe("closed settles graceful vs abnormal", () => {
+		test("a peer CONNECTION_CLOSE resolves closed with its code and reason", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// The peer closing the session deliberately is graceful, even though we
+			// didn't initiate it.
+			peer.send({ type: "connection_close", code: VarInt.from(42), reason: "bye" });
+			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
+		});
+
+		test("a socket drop with no CONNECTION_CLOSE rejects closed", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			// Even a "clean" WebSocket status code is a drop at the session layer: the
+			// peer never said goodbye in QMux terms.
+			peer.close({ closeCode: 1000, reason: "" });
+
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("Connection closed");
+		});
+
+		test("a socket error rejects closed", async () => {
+			const { session, peer } = connect();
+			await session.ready;
+
+			peer.error(new Error("connection reset"));
+			await expectSessionFailure(session);
+		});
+
+		test("an idle timeout rejects closed, rather than mimicking a graceful close", async () => {
+			// The sharpest case: an idle timeout used to resolve with { closeCode: 0,
+			// reason: "idle timeout" }, while a graceful close() with no args resolves
+			// with { closeCode: 0, reason: "" }. A dead peer and a clean shutdown differed
+			// only by a free-text string.
+			const { session, peer } = connect({ maxIdleTimeout: 150n });
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			// ...and now the peer goes silent.
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("idle timeout");
+		});
+
+		test("the standard reconnect idiom sees a drop", async () => {
+			// The downstream bug this fixes (moq-dev/moq#2183): code written against the
+			// native API reconnects from the catch arm, which qmux could never reach.
+			const { session, peer } = connect();
+			await session.ready;
+
+			let reconnected = false;
+			const watch = (async () => {
+				try {
+					await session.closed;
+				} catch {
+					reconnected = true;
+				}
+			})();
+
+			peer.close({ closeCode: 1006, reason: "relay bounced" });
+			await watch;
+
+			expect(reconnected).toBe(true);
+		});
+	});
+
+	test("a text frame rejects closed and tells the peer why (1003)", async () => {
 		const { session, peer } = connect();
 		await session.ready;
 		peer.sendText("not binary");
-		const info = await session.closed;
-		expect(info.closeCode).toBe(1003);
+
+		const err = await expectSessionFailure(session);
+		expect(err.message).toContain("text frames are not valid for QMux");
+		await waitFor(() => sentCloseCode(peer) === 1003);
 	});
 
-	test("an unnegotiated RESET_STREAM_AT closes the session", async () => {
+	test("an unnegotiated RESET_STREAM_AT rejects closed and tells the peer why (1002)", async () => {
 		// The peer negotiates qmux-01, which never advertises `reset_stream_at`, so
 		// a RESET_STREAM_AT (0x24) frame is a protocol violation. Hand-built bytes:
 		// type=0x24, id=3, code=0, final_size=0, reliable_size=0.
 		const { session, peer } = connect();
 		await session.ready;
 		peer.sendRaw(new Uint8Array([0x24, 0x03, 0x00, 0x00, 0x00]));
-		const info = await session.closed;
-		expect(info.closeCode).toBe(1002);
+
+		const err = await expectSessionFailure(session);
+		// The decode failure itself is carried as the cause, not flattened away.
+		expect(err.cause).toBeInstanceOf(Error);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: an app write produces a DATAGRAM frame on the wire", async () => {
@@ -251,7 +359,8 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		peer.send({ type: "datagram", data: new Uint8Array(10) });
-		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		await expectSessionFailure(session);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: a DATAGRAM we never advertised support for is fatal", async () => {
@@ -262,7 +371,8 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		peer.send({ type: "datagram", data: new Uint8Array([1, 2, 3]) });
-		expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+		await expectSessionFailure(session);
+		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
 	test("datagrams: a no-length (0x30) DATAGRAM is sized without a length varint", async () => {
@@ -421,7 +531,7 @@ describe("Session integration (scripted peer)", () => {
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
-		test("a STREAM frame on a send-only stream ID closes the session with 1002", async () => {
+		test("a STREAM frame on a send-only stream ID fails the session with 1002", async () => {
 			const { session, peer } = connect();
 			await session.ready;
 			peer.send({ type: "transport_parameters", params: peerParams() });
@@ -437,7 +547,8 @@ describe("Session integration (scripted peer)", () => {
 				fin: false,
 			});
 
-			expect(await session.closed).toEqual({ closeCode: 1002, reason: "Protocol violation" });
+			await expectSessionFailure(session);
+			await waitFor(() => sentCloseCode(peer) === 1002);
 			await settle();
 			expect(rejections).toEqual([]);
 		});

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -124,11 +124,13 @@ function settleTo<T>(p: Promise<T>): Promise<T | Error> {
 
 /** The session-close frame the Session put on the wire, if any. A locally-detected
  *  violation still owes the peer an explanation, even though it settles `closed`
- *  as a failure on our side. Its `application` flag distinguishes the graceful
+ *  as a failure on our side. The frame *type* distinguishes the graceful
  *  APPLICATION_CLOSE a `close()` sends from the CONNECTION_CLOSE a violation sends. */
-function sentClose(peer: FakePeer): Frame.ConnectionClose | undefined {
-	const frame = peer.received().find((f) => f.type === "connection_close");
-	return frame?.type === "connection_close" ? frame : undefined;
+function sentClose(peer: FakePeer): Frame.ApplicationClose | Frame.ConnectionClose | undefined {
+	return peer.received().find((f) => f.type === "application_close" || f.type === "connection_close") as
+		| Frame.ApplicationClose
+		| Frame.ConnectionClose
+		| undefined;
 }
 
 function sentCloseCode(peer: FakePeer): number | undefined {
@@ -216,9 +218,9 @@ describe("Session integration (scripted peer)", () => {
 
 		session.close({ closeCode: 42, reason: "bye" });
 		expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
-		await waitFor(() => peer.has("connection_close"));
+		await waitFor(() => peer.has("application_close"));
 		// A graceful close is an APPLICATION_CLOSE (0x1d), so the peer fulfills.
-		expect(sentClose(peer)?.application).toBe(true);
+		expect(sentClose(peer)?.type).toBe("application_close");
 
 		// Second close is a no-op: the resolved info is unchanged.
 		session.close({ closeCode: 7, reason: "again" });
@@ -236,7 +238,7 @@ describe("Session integration (scripted peer)", () => {
 
 			// The peer closing the session deliberately (APPLICATION_CLOSE / 0x1d) is
 			// graceful, even though we didn't initiate it.
-			peer.send({ type: "connection_close", application: true, code: VarInt.from(42), reason: "bye" });
+			peer.send({ type: "application_close", code: VarInt.from(42), reason: "bye" });
 			expect(await session.closed).toEqual({ closeCode: 42, reason: "bye" });
 		});
 
@@ -247,7 +249,7 @@ describe("Session integration (scripted peer)", () => {
 			// 1002 is a transport-error code, but an APPLICATION_CLOSE is graceful by
 			// definition — the *subtype*, not the code, decides. Codes are
 			// application-defined, so the app still gets its code and reason.
-			peer.send({ type: "connection_close", application: true, code: VarInt.from(1002), reason: "bye" });
+			peer.send({ type: "application_close", code: VarInt.from(1002), reason: "bye" });
 			expect(await session.closed).toEqual({ closeCode: 1002, reason: "bye" });
 		});
 
@@ -260,7 +262,6 @@ describe("Session integration (scripted peer)", () => {
 			// fulfilling. Mirrors the frame we emit from #abort.
 			peer.send({
 				type: "connection_close",
-				application: false,
 				code: VarInt.from(1002),
 				reason: "Protocol violation",
 			});
@@ -338,7 +339,7 @@ describe("Session integration (scripted peer)", () => {
 		expect(err.message).toContain("text frames are not valid for QMux");
 		await waitFor(() => sentCloseCode(peer) === 1003);
 		// A violation we detect is a CONNECTION_CLOSE (0x1c), so the peer rejects too.
-		expect(sentClose(peer)?.application).toBe(false);
+		expect(sentClose(peer)?.type).toBe("connection_close");
 	});
 
 	test("an unnegotiated RESET_STREAM_AT rejects closed and tells the peer why (1002)", async () => {
@@ -353,7 +354,7 @@ describe("Session integration (scripted peer)", () => {
 		// The decode failure itself is carried as the cause, not flattened away.
 		expect(err.cause).toBeInstanceOf(Error);
 		await waitFor(() => sentCloseCode(peer) === 1002);
-		expect(sentClose(peer)?.application).toBe(false);
+		expect(sentClose(peer)?.type).toBe("connection_close");
 	});
 
 	test("datagrams: an app write produces a DATAGRAM frame on the wire", async () => {
@@ -718,7 +719,7 @@ describe("Session integration (scripted peer)", () => {
 
 			// The peer aborts the connection (CONNECTION_CLOSE / 0x1c); the frame's
 			// code/reason must reach the waiter.
-			peer.send({ type: "connection_close", application: false, code: VarInt.from(7n), reason: "peer gone" });
+			peer.send({ type: "connection_close", code: VarInt.from(7n), reason: "peer gone" });
 
 			const err = await created;
 			expect(err).toBeInstanceOf(Error);

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1,5 +1,6 @@
 import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-stream";
 import { Credit, replenishWindow } from "./credit.ts";
+import { SessionError } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
@@ -359,6 +360,7 @@ export default class Session implements WebTransport {
 	#readyReject: (err: Error) => void;
 	readonly closed: Promise<WebTransportCloseInfo>;
 	#closedResolve: (info: WebTransportCloseInfo) => void;
+	#closedReject: (err: Error) => void;
 
 	readonly incomingBidirectionalStreams: ReadableStream<WebTransportBidirectionalStream>;
 	#incomingBidirectionalStreams!: ReadableStreamDefaultController<WebTransportBidirectionalStream>;
@@ -452,6 +454,11 @@ export default class Session implements WebTransport {
 		const closed = Promise.withResolvers<WebTransportCloseInfo>();
 		this.closed = closed.promise;
 		this.#closedResolve = closed.resolve;
+		this.#closedReject = closed.reject;
+		// Same guard as `ready`: an abnormal close rejects `closed`, and a consumer
+		// that only ever calls close() never attaches a handler. Real awaiters still
+		// observe the rejection.
+		this.closed.catch(() => {});
 
 		this.incomingBidirectionalStreams = new ReadableStream<WebTransportBidirectionalStream>({
 			start: (controller) => {
@@ -491,17 +498,21 @@ export default class Session implements WebTransport {
 			},
 			(err: unknown) => {
 				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream failed to open");
-				this.#close(1006, "WebSocketStream error");
+				this.#close(1006, "WebSocketStream error", false);
 			},
 		);
 		wss.closed.then(
 			(info) => {
+				// The socket went away without a CONNECTION_CLOSE. A peer close or a
+				// local close() would already have transitioned us (and #close is
+				// idempotent), so reaching here settled means the session dropped —
+				// even if the WebSocket itself closed with a "clean" status code.
 				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
-				this.#close(info.closeCode ?? 1006, info.reason ?? "");
+				this.#close(info.closeCode ?? 1006, info.reason ?? "", false);
 			},
 			() => {
 				this.#closeReason ??= new Error("WebSocketStream closed");
-				this.#close(1006, "WebSocketStream error");
+				this.#close(1006, "WebSocketStream error", false);
 			},
 		);
 	}
@@ -514,14 +525,14 @@ export default class Session implements WebTransport {
 				// QMux is binary-only; a text frame is a protocol error, not something
 				// to silently drop (which would desync the session).
 				if (typeof value === "string") {
-					this.close({ closeCode: 1003, reason: "text frames are not valid for QMux" });
+					this.#abort(1003, "text frames are not valid for QMux");
 					return;
 				}
 				this.#onData(value);
 			}
 		} catch (err) {
 			this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream read error");
-			this.#close(1006, "WebSocketStream read error");
+			this.#close(1006, "WebSocketStream read error", false);
 		}
 	}
 
@@ -583,7 +594,7 @@ export default class Session implements WebTransport {
 		} catch (error) {
 			// A decode failure or a frame that violates a negotiated limit is fatal.
 			console.error("Protocol violation:", error);
-			this.close({ closeCode: 1002, reason: "Protocol violation" });
+			this.#abort(1002, "Protocol violation", error);
 		}
 	}
 
@@ -605,8 +616,11 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
+			// The peer closed the session deliberately: graceful, so `closed`
+			// fulfills with its code/reason. Only a termination with *no*
+			// CONNECTION_CLOSE is a drop.
 			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
-			this.#close(Number(frame.code.value), frame.reason);
+			this.#close(Number(frame.code.value), frame.reason, true);
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
 			this.#handleTransportParameters(frame.params);
@@ -744,9 +758,11 @@ export default class Session implements WebTransport {
 		}
 		const now = Date.now();
 		if (now - this.#lastRecvAt > timeoutMs) {
-			// Peer has gone silent past the negotiated limit.
+			// Peer has gone silent past the negotiated limit. Abnormal: without a
+			// rejection this is indistinguishable from a graceful close(), which also
+			// settles with closeCode 0.
 			this.#closeReason ??= new Error("idle timeout");
-			this.#close(0, "idle timeout");
+			this.#close(0, "idle timeout", false);
 			this.#transportClose();
 			return;
 		}
@@ -911,7 +927,7 @@ export default class Session implements WebTransport {
 		if (this.#closed) return;
 
 		if (frame.data.byteLength > MAX_FRAME_PAYLOAD) {
-			this.close({ closeCode: 1002, reason: "frame too large" });
+			this.#abort(1002, "frame too large");
 			return;
 		}
 
@@ -937,7 +953,7 @@ export default class Session implements WebTransport {
 			if (isQmux(this.#version)) {
 				const credit = frame.id.dir === Stream.Dir.Bi ? this.#recvBiCredit : this.#recvUniCredit;
 				if (!credit.receiveUpTo(frame.id.index + 1n)) {
-					this.close({ closeCode: 1002, reason: "stream limit exceeded" });
+					this.#abort(1002, "stream limit exceeded");
 					return;
 				}
 			}
@@ -962,7 +978,7 @@ export default class Session implements WebTransport {
 
 			// Validate recv flow control before accepting
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
-				this.close({ closeCode: 1002, reason: "flow control error" });
+				this.#abort(1002, "flow control error");
 				return;
 			}
 
@@ -1041,7 +1057,7 @@ export default class Session implements WebTransport {
 		} else {
 			// Existing stream — validate recv flow control
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
-				this.close({ closeCode: 1002, reason: "flow control error" });
+				this.#abort(1002, "flow control error");
 				return;
 			}
 		}
@@ -1356,8 +1372,17 @@ export default class Session implements WebTransport {
 
 	/** The single, idempotent close transition: marks the session closed, settles
 	 *  `ready`/`closed`, and tears down streams, credits, and the scheduler.
-	 *  Protocol-close paths route through here before/while closing the socket. */
-	#close(code: number, reason: string) {
+	 *  Protocol-close paths route through here before/while closing the socket.
+	 *
+	 *  `graceful` decides how `closed` settles, and it is the only signal a
+	 *  consumer has to tell a dropped session from a clean shutdown. Per the
+	 *  WebTransport contract `closed` fulfills only when the session ends
+	 *  cleanly — a local `close()` or a peer CONNECTION_CLOSE — and rejects with
+	 *  a `WebTransportError` on everything else: socket failure, read error,
+	 *  locally-detected protocol violation, idle timeout. Close codes cannot carry
+	 *  that distinction, since they are application-defined (an app closing with
+	 *  1006 must not look like a dropped socket). */
+	#close(code: number, reason: string, graceful: boolean) {
 		if (this.#closed) return;
 		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
 
@@ -1369,10 +1394,14 @@ export default class Session implements WebTransport {
 		// Settle the WebTransport promises. Rejecting `ready` is a no-op once it
 		// has resolved (i.e. after a successful open).
 		this.#readyReject(this.#closed);
-		this.#closedResolve({
-			closeCode: code,
-			reason,
-		});
+		if (graceful) {
+			this.#closedResolve({
+				closeCode: code,
+				reason,
+			});
+		} else {
+			this.#closedReject(new SessionError(this.#closed.message, { cause: this.#closed }));
+		}
 
 		// Fail active streams so consumers unblock
 		try {
@@ -1429,11 +1458,12 @@ export default class Session implements WebTransport {
 		} catch {}
 	}
 
-	close(info?: { closeCode?: number; reason?: string }) {
+	/** Emit CONNECTION_CLOSE, transition, and give the queued frame a moment to
+	 *  flush before actually closing the socket. Shared by the app-initiated
+	 *  `close()` and the locally-detected failure path `#abort()`, which differ
+	 *  only in how they settle `closed`. */
+	#closeWithFrame(code: number, reason: string, graceful: boolean) {
 		if (this.#closed) return;
-
-		const code = info?.closeCode ?? 0;
-		const reason = info?.reason ?? "";
 
 		this.#sendPriorityFrame({
 			type: "connection_close",
@@ -1441,12 +1471,25 @@ export default class Session implements WebTransport {
 			reason,
 		});
 
-		// Transition state and tear down now; give the queued CONNECTION_CLOSE a
-		// moment to flush before actually closing the socket.
-		this.#close(code, reason);
+		this.#close(code, reason, graceful);
 		setTimeout(() => {
 			this.#transportClose();
 		}, 100);
+	}
+
+	/** A failure we detected ourselves (protocol violation, unsupported frame).
+	 *  It borrows the same wire path as `close()` — the peer still deserves a
+	 *  CONNECTION_CLOSE saying why — but it is not an app-initiated close, so
+	 *  `closed` rejects rather than fulfilling. */
+	#abort(code: number, reason: string, cause?: unknown) {
+		if (cause !== undefined) {
+			this.#closeReason ??= cause instanceof Error ? cause : new Error(String(cause));
+		}
+		this.#closeWithFrame(code, reason, false);
+	}
+
+	close(info?: { closeCode?: number; reason?: string }) {
+		this.#closeWithFrame(info?.closeCode ?? 0, info?.reason ?? "", true);
 	}
 
 	/** Resize the send-buffer high-water mark (bytes) used for write

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1486,34 +1486,27 @@ export default class Session implements WebTransport {
 		} catch {}
 	}
 
-	/** Put a session-close frame on the wire and give it a moment to flush before
-	 *  tearing down the socket. Used only by the paths that initiate a close on a
-	 *  live connection — the app-initiated {@link close} and the locally-detected
-	 *  violations — which the peer deserves to hear about. `application` selects
-	 *  the QUIC subtype the peer keys its resolve-vs-reject on. Must run *before*
-	 *  the terminal transition, which closes the scheduler to new control frames. */
-	#putClose(code: number, reason: string, application: boolean) {
-		this.#sendPriorityFrame(
-			application
-				? { type: "application_close", code: VarInt.from(code), reason }
-				: { type: "connection_close", code: VarInt.from(code), reason },
-		);
-		setTimeout(() => {
-			this.#transportClose();
-		}, 100);
-	}
-
 	/** APPLICATION_CLOSE (0x1d): a graceful, app-initiated close the peer surfaces
 	 *  by *fulfilling* its `closed`. Pairs with the {@link #close} transition. */
 	#sendApplicationClose(code: number, reason: string) {
-		this.#putClose(code, reason, true);
+		this.#sendPriorityFrame({ type: "application_close", code: VarInt.from(code), reason });
+		// Give the queued frame a moment to flush before tearing down the socket.
+		// Must run *before* the terminal transition, which closes the scheduler to
+		// new control frames.
+		setTimeout(() => {
+			this.#transportClose();
+		}, 100);
 	}
 
 	/** CONNECTION_CLOSE (0x1c): a protocol violation or transport error we detected,
 	 *  which the peer surfaces by *rejecting* its `closed`. Pairs with the
 	 *  {@link #abort} transition. */
 	#sendConnectionClose(code: number, reason: string) {
-		this.#putClose(code, reason, false);
+		this.#sendPriorityFrame({ type: "connection_close", code: VarInt.from(code), reason });
+		// Flush the queued frame before tearing down the socket (see above).
+		setTimeout(() => {
+			this.#transportClose();
+		}, 100);
 	}
 
 	close(info?: { closeCode?: number; reason?: string }) {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1444,7 +1444,8 @@ export default class Session implements WebTransport {
 	/** Graceful terminal transition: `closed` **fulfills** with the close code
 	 *  and reason. Per the WebTransport contract this is the only clean outcome —
 	 *  reached by a local {@link close} (which first puts an APPLICATION_CLOSE on
-	 *  the wire) or by receiving a peer's CONNECTION_CLOSE. Idempotent. */
+	 *  the wire) or by receiving a peer's APPLICATION_CLOSE (0x1d). A peer's
+	 *  CONNECTION_CLOSE (0x1c) routes to {@link #abort} instead. Idempotent. */
 	#close(code: number, reason: string) {
 		if (this.#closed) return;
 		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
@@ -1459,8 +1460,9 @@ export default class Session implements WebTransport {
 
 	/** Abnormal terminal transition: `closed` **rejects** with a
 	 *  `WebTransportError`. Reached on everything that is not a clean shutdown —
-	 *  socket failure, read error, idle timeout, or a protocol violation we
-	 *  detected locally. Close codes cannot carry this distinction, since they are
+	 *  socket failure, read error, idle timeout, a protocol violation we detected
+	 *  locally, or a peer's CONNECTION_CLOSE (0x1c). Close codes cannot carry this
+	 *  distinction, since they are
 	 *  application-defined (an app closing with 1006 must not look like a dropped
 	 *  socket). `cause`, when given, is preserved as the close reason so the
 	 *  original failure survives on `closed`. Idempotent. */

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -510,8 +510,10 @@ export default class Session implements WebTransport {
 				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
 				this.#close(info.closeCode ?? 1006, info.reason ?? "", false);
 			},
-			() => {
-				this.#closeReason ??= new Error("WebSocketStream closed");
+			(err: unknown) => {
+				// Keep the socket failure itself — it becomes the SessionError's cause, and
+				// it's the only description of *why* the transport died.
+				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream closed");
 				this.#close(1006, "WebSocketStream error", false);
 			},
 		);

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -498,7 +498,7 @@ export default class Session implements WebTransport {
 			},
 			(err: unknown) => {
 				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream failed to open");
-				this.#close(1006, "WebSocketStream error", false);
+				this.#abort(1006, "WebSocketStream error");
 			},
 		);
 		wss.closed.then(
@@ -508,13 +508,13 @@ export default class Session implements WebTransport {
 				// idempotent), so reaching here settled means the session dropped —
 				// even if the WebSocket itself closed with a "clean" status code.
 				this.#closeReason ??= new Error(`Connection closed: ${info.closeCode ?? 0} ${info.reason ?? ""}`);
-				this.#close(info.closeCode ?? 1006, info.reason ?? "", false);
+				this.#abort(info.closeCode ?? 1006, info.reason ?? "");
 			},
 			(err: unknown) => {
 				// Keep the socket failure itself — it becomes the SessionError's cause, and
 				// it's the only description of *why* the transport died.
 				this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream closed");
-				this.#close(1006, "WebSocketStream error", false);
+				this.#abort(1006, "WebSocketStream error");
 			},
 		);
 	}
@@ -527,6 +527,7 @@ export default class Session implements WebTransport {
 				// QMux is binary-only; a text frame is a protocol error, not something
 				// to silently drop (which would desync the session).
 				if (typeof value === "string") {
+					this.#sendConnectionClose(1003, "text frames are not valid for QMux");
 					this.#abort(1003, "text frames are not valid for QMux");
 					return;
 				}
@@ -534,7 +535,7 @@ export default class Session implements WebTransport {
 			}
 		} catch (err) {
 			this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream read error");
-			this.#close(1006, "WebSocketStream read error", false);
+			this.#abort(1006, "WebSocketStream read error");
 		}
 	}
 
@@ -596,6 +597,7 @@ export default class Session implements WebTransport {
 		} catch (error) {
 			// A decode failure or a frame that violates a negotiated limit is fatal.
 			console.error("Protocol violation:", error);
+			this.#sendConnectionClose(1002, "Protocol violation");
 			this.#abort(1002, "Protocol violation", error);
 		}
 	}
@@ -618,11 +620,17 @@ export default class Session implements WebTransport {
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
 		} else if (frame.type === "connection_close") {
-			// The peer closed the session deliberately: graceful, so `closed`
-			// fulfills with its code/reason. Only a termination with *no*
-			// CONNECTION_CLOSE is a drop.
 			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
-			this.#close(Number(frame.code.value), frame.reason, true);
+			if (frame.application) {
+				// APPLICATION_CLOSE (0x1d): the peer closed the session deliberately —
+				// graceful, so `closed` fulfills with its code/reason.
+				this.#close(Number(frame.code.value), frame.reason);
+			} else {
+				// CONNECTION_CLOSE (0x1c): the peer hit a protocol violation or
+				// transport error, so `closed` rejects. A termination with *no* close
+				// frame at all is a drop, which #abort also handles.
+				this.#abort(Number(frame.code.value), frame.reason);
+			}
 			this.#transportClose();
 		} else if (frame.type === "transport_parameters") {
 			this.#handleTransportParameters(frame.params);
@@ -764,7 +772,7 @@ export default class Session implements WebTransport {
 			// rejection this is indistinguishable from a graceful close(), which also
 			// settles with closeCode 0.
 			this.#closeReason ??= new Error("idle timeout");
-			this.#close(0, "idle timeout", false);
+			this.#abort(0, "idle timeout");
 			this.#transportClose();
 			return;
 		}
@@ -929,6 +937,7 @@ export default class Session implements WebTransport {
 		if (this.#closed) return;
 
 		if (frame.data.byteLength > MAX_FRAME_PAYLOAD) {
+			this.#sendConnectionClose(1002, "frame too large");
 			this.#abort(1002, "frame too large");
 			return;
 		}
@@ -955,6 +964,7 @@ export default class Session implements WebTransport {
 			if (isQmux(this.#version)) {
 				const credit = frame.id.dir === Stream.Dir.Bi ? this.#recvBiCredit : this.#recvUniCredit;
 				if (!credit.receiveUpTo(frame.id.index + 1n)) {
+					this.#sendConnectionClose(1002, "stream limit exceeded");
 					this.#abort(1002, "stream limit exceeded");
 					return;
 				}
@@ -980,6 +990,7 @@ export default class Session implements WebTransport {
 
 			// Validate recv flow control before accepting
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
+				this.#sendConnectionClose(1002, "flow control error");
 				this.#abort(1002, "flow control error");
 				return;
 			}
@@ -1059,6 +1070,7 @@ export default class Session implements WebTransport {
 		} else {
 			// Existing stream — validate recv flow control
 			if (!this.#accountRecv(streamId, frame.data.byteLength)) {
+				this.#sendConnectionClose(1002, "flow control error");
 				this.#abort(1002, "flow control error");
 				return;
 			}
@@ -1372,37 +1384,15 @@ export default class Session implements WebTransport {
 		return writer;
 	}
 
-	/** The single, idempotent close transition: marks the session closed, settles
-	 *  `ready`/`closed`, and tears down streams, credits, and the scheduler.
-	 *  Protocol-close paths route through here before/while closing the socket.
-	 *
-	 *  `graceful` decides how `closed` settles, and it is the only signal a
-	 *  consumer has to tell a dropped session from a clean shutdown. Per the
-	 *  WebTransport contract `closed` fulfills only when the session ends
-	 *  cleanly — a local `close()` or a peer CONNECTION_CLOSE — and rejects with
-	 *  a `WebTransportError` on everything else: socket failure, read error,
-	 *  locally-detected protocol violation, idle timeout. Close codes cannot carry
-	 *  that distinction, since they are application-defined (an app closing with
-	 *  1006 must not look like a dropped socket). */
-	#close(code: number, reason: string, graceful: boolean) {
-		if (this.#closed) return;
-		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
-
+	/** Shared teardown for both terminal transitions: tears down streams,
+	 *  credits, and the scheduler. The caller has already marked the session
+	 *  closed and settled `ready`/`closed` — the only thing that differs between
+	 *  a clean shutdown and a dropped session is which way `closed` settled, and
+	 *  {@link #close} vs {@link #abort} own that choice. */
+	#teardown() {
 		if (this.#idleTimer) {
 			clearInterval(this.#idleTimer);
 			this.#idleTimer = undefined;
-		}
-
-		// Settle the WebTransport promises. Rejecting `ready` is a no-op once it
-		// has resolved (i.e. after a successful open).
-		this.#readyReject(this.#closed);
-		if (graceful) {
-			this.#closedResolve({
-				closeCode: code,
-				reason,
-			});
-		} else {
-			this.#closedReject(new SessionError(this.#closed.message, { cause: this.#closed }));
 		}
 
 		// Fail active streams so consumers unblock
@@ -1448,7 +1438,43 @@ export default class Session implements WebTransport {
 
 		// Reject pending stream writes; already-queued control (e.g. CONNECTION_CLOSE)
 		// still flushes before the socket is torn down.
-		this.#scheduler?.close(this.#closed ?? this.#closeReason ?? new Error("Connection closed"));
+		this.#scheduler?.close(closeErr);
+	}
+
+	/** Graceful terminal transition: `closed` **fulfills** with the close code
+	 *  and reason. Per the WebTransport contract this is the only clean outcome —
+	 *  reached by a local {@link close} (which first puts an APPLICATION_CLOSE on
+	 *  the wire) or by receiving a peer's CONNECTION_CLOSE. Idempotent. */
+	#close(code: number, reason: string) {
+		if (this.#closed) return;
+		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
+
+		// Rejecting `ready` is a no-op once it has resolved (i.e. after a
+		// successful open).
+		this.#readyReject(this.#closed);
+		this.#closedResolve({ closeCode: code, reason });
+
+		this.#teardown();
+	}
+
+	/** Abnormal terminal transition: `closed` **rejects** with a
+	 *  `WebTransportError`. Reached on everything that is not a clean shutdown —
+	 *  socket failure, read error, idle timeout, or a protocol violation we
+	 *  detected locally. Close codes cannot carry this distinction, since they are
+	 *  application-defined (an app closing with 1006 must not look like a dropped
+	 *  socket). `cause`, when given, is preserved as the close reason so the
+	 *  original failure survives on `closed`. Idempotent. */
+	#abort(code: number, reason: string, cause?: unknown) {
+		if (this.#closed) return;
+		if (cause !== undefined) {
+			this.#closeReason ??= cause instanceof Error ? cause : new Error(String(cause));
+		}
+		this.#closed = this.#closeReason ?? new Error(`Connection closed: ${code} ${reason}`);
+
+		this.#readyReject(this.#closed);
+		this.#closedReject(new SessionError(this.#closed.message, { cause: this.#closed }));
+
+		this.#teardown();
 	}
 
 	/** Tear down the underlying transport. The meaningful close code/reason
@@ -1460,38 +1486,43 @@ export default class Session implements WebTransport {
 		} catch {}
 	}
 
-	/** Emit CONNECTION_CLOSE, transition, and give the queued frame a moment to
-	 *  flush before actually closing the socket. Shared by the app-initiated
-	 *  `close()` and the locally-detected failure path `#abort()`, which differ
-	 *  only in how they settle `closed`. */
-	#closeWithFrame(code: number, reason: string, graceful: boolean) {
-		if (this.#closed) return;
-
+	/** Put a session-close frame on the wire and give it a moment to flush before
+	 *  tearing down the socket. Used only by the paths that initiate a close on a
+	 *  live connection — the app-initiated {@link close} and the locally-detected
+	 *  violations — which the peer deserves to hear about. `application` selects
+	 *  the QUIC subtype the peer keys its resolve-vs-reject on. Must run *before*
+	 *  the terminal transition, which closes the scheduler to new control frames. */
+	#putClose(code: number, reason: string, application: boolean) {
 		this.#sendPriorityFrame({
 			type: "connection_close",
 			code: VarInt.from(code),
 			reason,
+			application,
 		});
-
-		this.#close(code, reason, graceful);
 		setTimeout(() => {
 			this.#transportClose();
 		}, 100);
 	}
 
-	/** A failure we detected ourselves (protocol violation, unsupported frame).
-	 *  It borrows the same wire path as `close()` — the peer still deserves a
-	 *  CONNECTION_CLOSE saying why — but it is not an app-initiated close, so
-	 *  `closed` rejects rather than fulfilling. */
-	#abort(code: number, reason: string, cause?: unknown) {
-		if (cause !== undefined) {
-			this.#closeReason ??= cause instanceof Error ? cause : new Error(String(cause));
-		}
-		this.#closeWithFrame(code, reason, false);
+	/** APPLICATION_CLOSE (0x1d): a graceful, app-initiated close the peer surfaces
+	 *  by *fulfilling* its `closed`. Pairs with the {@link #close} transition. */
+	#sendApplicationClose(code: number, reason: string) {
+		this.#putClose(code, reason, true);
+	}
+
+	/** CONNECTION_CLOSE (0x1c): a protocol violation or transport error we detected,
+	 *  which the peer surfaces by *rejecting* its `closed`. Pairs with the
+	 *  {@link #abort} transition. */
+	#sendConnectionClose(code: number, reason: string) {
+		this.#putClose(code, reason, false);
 	}
 
 	close(info?: { closeCode?: number; reason?: string }) {
-		this.#closeWithFrame(info?.closeCode ?? 0, info?.reason ?? "", true);
+		if (this.#closed) return;
+		const code = info?.closeCode ?? 0;
+		const reason = info?.reason ?? "";
+		this.#sendApplicationClose(code, reason);
+		this.#close(code, reason);
 	}
 
 	/** Resize the send-buffer high-water mark (bytes) used for write

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -619,9 +619,9 @@ export default class Session implements WebTransport {
 			this.#handleResetStream(frame);
 		} else if (frame.type === "stop_sending") {
 			this.#handleStopSending(frame);
-		} else if (frame.type === "connection_close") {
+		} else if (frame.type === "application_close" || frame.type === "connection_close") {
 			this.#closeReason ??= new Error(`Connection closed: ${frame.code.value} ${frame.reason}`);
-			if (frame.application) {
+			if (frame.type === "application_close") {
 				// APPLICATION_CLOSE (0x1d): the peer closed the session deliberately —
 				// graceful, so `closed` fulfills with its code/reason.
 				this.#close(Number(frame.code.value), frame.reason);
@@ -1493,12 +1493,11 @@ export default class Session implements WebTransport {
 	 *  the QUIC subtype the peer keys its resolve-vs-reject on. Must run *before*
 	 *  the terminal transition, which closes the scheduler to new control frames. */
 	#putClose(code: number, reason: string, application: boolean) {
-		this.#sendPriorityFrame({
-			type: "connection_close",
-			code: VarInt.from(code),
-			reason,
-			application,
-		});
+		this.#sendPriorityFrame(
+			application
+				? { type: "application_close", code: VarInt.from(code), reason }
+				: { type: "connection_close", code: VarInt.from(code), reason },
+		);
 		setTimeout(() => {
 			this.#transportClose();
 		}, 100);

--- a/js/qmux/src/wire-format.test.ts
+++ b/js/qmux/src/wire-format.test.ts
@@ -95,37 +95,33 @@ describe("WebTransport wire format", () => {
 		expect(arr(Frame.encode(frame, "webtransport"))).toEqual(arr(wire));
 	});
 
-	test("connection_close", () => {
+	test("application_close", () => {
 		// 0x1d + code(=42) + reason("bye") as the rest of the buffer.
 		const wire = bytes(0x1d, 0x2a, 0x62, 0x79, 0x65);
-		const frame: Frame.ConnectionClose = {
-			type: "connection_close",
+		const frame: Frame.ApplicationClose = {
+			type: "application_close",
 			code: code(42n),
 			reason: "bye",
-			application: true,
 		};
-		const decoded = Frame.decode(wire, "webtransport") as Frame.ConnectionClose;
-		expect(decoded.type).toBe("connection_close");
+		const decoded = Frame.decode(wire, "webtransport") as Frame.ApplicationClose;
+		expect(decoded.type).toBe("application_close");
 		expect(decoded.code.value).toBe(42n);
 		expect(decoded.reason).toBe("bye");
-		expect(decoded.application).toBe(true);
 
 		expect(arr(Frame.encode(frame, "webtransport"))).toEqual(arr(wire));
 	});
 
 	test("connection_close (transport, 0x1c)", () => {
-		// Same body as APPLICATION_CLOSE, but the leading byte flips to 0x1c and the
-		// decoded frame is flagged application:false so the receiver rejects.
+		// Same legacy body, but the leading byte flips to 0x1c and it decodes to a
+		// distinct transport-close frame so the receiver rejects.
 		const wire = bytes(0x1c, 0x2a, 0x62, 0x79, 0x65);
 		const frame: Frame.ConnectionClose = {
 			type: "connection_close",
 			code: code(42n),
 			reason: "bye",
-			application: false,
 		};
 		const decoded = Frame.decode(wire, "webtransport") as Frame.ConnectionClose;
 		expect(decoded.type).toBe("connection_close");
-		expect(decoded.application).toBe(false);
 
 		expect(arr(Frame.encode(frame, "webtransport"))).toEqual(arr(wire));
 	});
@@ -191,36 +187,33 @@ describe("QMux draft-00 wire format", () => {
 	});
 
 	test("application_close", () => {
-		// 0x1d + code(=42) + frame_type(=0) + reason_len(=3) + "bye"
-		const wire = bytes(0x1d, 0x2a, 0x00, 0x03, 0x62, 0x79, 0x65);
-		const frame: Frame.ConnectionClose = {
-			type: "connection_close",
+		// 0x1d + code(=42) + reason_len(=3) + "bye". No Frame Type field — RFC 9000
+		// §19.19 omits it for the application variant.
+		const wire = bytes(0x1d, 0x2a, 0x03, 0x62, 0x79, 0x65);
+		const frame: Frame.ApplicationClose = {
+			type: "application_close",
 			code: code(42n),
 			reason: "bye",
-			application: true,
 		};
-		const decoded = Frame.decode(wire, "qmux-00") as Frame.ConnectionClose;
-		expect(decoded.type).toBe("connection_close");
+		const decoded = Frame.decode(wire, "qmux-00") as Frame.ApplicationClose;
+		expect(decoded.type).toBe("application_close");
 		expect(decoded.code.value).toBe(42n);
 		expect(decoded.reason).toBe("bye");
-		expect(decoded.application).toBe(true);
 
 		expect(arr(Frame.encode(frame, "qmux-00"))).toEqual(arr(wire));
 	});
 
 	test("connection_close (transport, 0x1c)", () => {
 		// 0x1c + code(=42) + frame_type(=0) + reason_len(=3) + "bye" — a transport
-		// error / protocol violation. Only the leading type byte differs from 0x1d.
+		// error / protocol violation. The transport variant carries the Frame Type.
 		const wire = bytes(0x1c, 0x2a, 0x00, 0x03, 0x62, 0x79, 0x65);
 		const frame: Frame.ConnectionClose = {
 			type: "connection_close",
 			code: code(42n),
 			reason: "bye",
-			application: false,
 		};
 		const decoded = Frame.decode(wire, "qmux-00") as Frame.ConnectionClose;
 		expect(decoded.type).toBe("connection_close");
-		expect(decoded.application).toBe(false);
 
 		expect(arr(Frame.encode(frame, "qmux-00"))).toEqual(arr(wire));
 	});
@@ -255,7 +248,7 @@ describe("QMux draft-00 wire format", () => {
 		const cases: [Frame.Any, number][] = [
 			[{ type: "stream", id: sid(4n), data: bytes(0x68, 0x69), fin: false }, 0x0a],
 			[{ type: "max_data", max: 1024n }, 0x10],
-			[{ type: "connection_close", code: code(42n), reason: "bye", application: true }, 0x1d],
+			[{ type: "application_close", code: code(42n), reason: "bye" }, 0x1d],
 		];
 		for (const [frame, expectedFirstByte] of cases) {
 			const encoded = Frame.encode(frame, "qmux-00");

--- a/js/qmux/src/wire-format.test.ts
+++ b/js/qmux/src/wire-format.test.ts
@@ -102,11 +102,30 @@ describe("WebTransport wire format", () => {
 			type: "connection_close",
 			code: code(42n),
 			reason: "bye",
+			application: true,
 		};
 		const decoded = Frame.decode(wire, "webtransport") as Frame.ConnectionClose;
 		expect(decoded.type).toBe("connection_close");
 		expect(decoded.code.value).toBe(42n);
 		expect(decoded.reason).toBe("bye");
+		expect(decoded.application).toBe(true);
+
+		expect(arr(Frame.encode(frame, "webtransport"))).toEqual(arr(wire));
+	});
+
+	test("connection_close (transport, 0x1c)", () => {
+		// Same body as APPLICATION_CLOSE, but the leading byte flips to 0x1c and the
+		// decoded frame is flagged application:false so the receiver rejects.
+		const wire = bytes(0x1c, 0x2a, 0x62, 0x79, 0x65);
+		const frame: Frame.ConnectionClose = {
+			type: "connection_close",
+			code: code(42n),
+			reason: "bye",
+			application: false,
+		};
+		const decoded = Frame.decode(wire, "webtransport") as Frame.ConnectionClose;
+		expect(decoded.type).toBe("connection_close");
+		expect(decoded.application).toBe(false);
 
 		expect(arr(Frame.encode(frame, "webtransport"))).toEqual(arr(wire));
 	});
@@ -174,11 +193,34 @@ describe("QMux draft-00 wire format", () => {
 	test("application_close", () => {
 		// 0x1d + code(=42) + frame_type(=0) + reason_len(=3) + "bye"
 		const wire = bytes(0x1d, 0x2a, 0x00, 0x03, 0x62, 0x79, 0x65);
-		const frame: Frame.ConnectionClose = { type: "connection_close", code: code(42n), reason: "bye" };
+		const frame: Frame.ConnectionClose = {
+			type: "connection_close",
+			code: code(42n),
+			reason: "bye",
+			application: true,
+		};
 		const decoded = Frame.decode(wire, "qmux-00") as Frame.ConnectionClose;
 		expect(decoded.type).toBe("connection_close");
 		expect(decoded.code.value).toBe(42n);
 		expect(decoded.reason).toBe("bye");
+		expect(decoded.application).toBe(true);
+
+		expect(arr(Frame.encode(frame, "qmux-00"))).toEqual(arr(wire));
+	});
+
+	test("connection_close (transport, 0x1c)", () => {
+		// 0x1c + code(=42) + frame_type(=0) + reason_len(=3) + "bye" — a transport
+		// error / protocol violation. Only the leading type byte differs from 0x1d.
+		const wire = bytes(0x1c, 0x2a, 0x00, 0x03, 0x62, 0x79, 0x65);
+		const frame: Frame.ConnectionClose = {
+			type: "connection_close",
+			code: code(42n),
+			reason: "bye",
+			application: false,
+		};
+		const decoded = Frame.decode(wire, "qmux-00") as Frame.ConnectionClose;
+		expect(decoded.type).toBe("connection_close");
+		expect(decoded.application).toBe(false);
 
 		expect(arr(Frame.encode(frame, "qmux-00"))).toEqual(arr(wire));
 	});
@@ -213,7 +255,7 @@ describe("QMux draft-00 wire format", () => {
 		const cases: [Frame.Any, number][] = [
 			[{ type: "stream", id: sid(4n), data: bytes(0x68, 0x69), fin: false }, 0x0a],
 			[{ type: "max_data", max: 1024n }, 0x10],
-			[{ type: "connection_close", code: code(42n), reason: "bye" }, 0x1d],
+			[{ type: "connection_close", code: code(42n), reason: "bye", application: true }, 0x1d],
 		];
 		for (const [frame, expectedFirstByte] of cases) {
 			const encoded = Frame.encode(frame, "qmux-00");

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -15,8 +15,18 @@ pub enum Error {
     #[error("stream closed")]
     StreamClosed,
 
+    /// The peer sent an APPLICATION_CLOSE (0x1d): a graceful, deliberate session
+    /// close carrying an application code and reason. Surfaced as a clean session
+    /// error (see [`session_error`](web_transport_trait::Error::session_error)).
     #[error("connection closed: {code}: {reason}")]
     ConnectionClosed { code: VarInt, reason: String },
+
+    /// The peer sent a CONNECTION_CLOSE (0x1c): it detected a protocol violation
+    /// or transport error. Abnormal — unlike [`ConnectionClosed`](Self::ConnectionClosed)
+    /// it does *not* surface as a clean application close, mirroring how a QUIC
+    /// transport CONNECTION_CLOSE rejects rather than gracefully ending a session.
+    #[error("connection reset: {code}: {reason}")]
+    ConnectionReset { code: VarInt, reason: String },
 
     #[error("stream reset: {0}")]
     StreamReset(VarInt),
@@ -98,6 +108,30 @@ pub enum Error {
 
     #[error("datagrams not supported")]
     DatagramsUnsupported,
+}
+
+impl Error {
+    /// The wire error code to send on a CONNECTION_CLOSE (0x1c) when *we* tear the
+    /// session down because of this error, or `None` when the peer should not (or
+    /// cannot) be told: a graceful close, a close the peer already sent us, an idle
+    /// timeout (silent, like QUIC), or a dead transport. Every protocol/transport
+    /// violation we detect maps to 1002, matching the JS QMux polyfill.
+    pub(crate) fn transport_close(&self) -> Option<u32> {
+        match self {
+            Error::ProtocolViolation
+            | Error::FrameEncoding
+            | Error::TransportParameter
+            | Error::DuplicateParam(_)
+            | Error::InvalidFrameType(_)
+            | Error::InvalidStreamId
+            | Error::FlowControlError
+            | Error::StreamLimitExceeded
+            | Error::FrameTooLarge
+            | Error::DatagramsUnsupported
+            | Error::Short => Some(1002),
+            _ => None,
+        }
+    }
 }
 
 impl From<VarIntUnexpectedEnd> for Error {

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -94,22 +94,29 @@ pub struct StopSending {
     pub code: VarInt,
 }
 
-/// Closes the entire connection with an error code and reason.
+/// Transport CONNECTION_CLOSE (0x1c): a protocol violation or transport error the
+/// sender detected. The receiver surfaces it as an *abnormal* close. Per RFC 9000
+/// §19.19 the transport variant carries the Frame Type field (we always send 0).
 #[derive(Debug, Clone)]
 pub struct ConnectionClose {
+    /// Error code (RFC 9000 transport error-code space).
+    pub code: VarInt,
+    /// Human-readable reason for closing.
+    pub reason: String,
+}
+
+/// APPLICATION_CLOSE (0x1d): a graceful, app-initiated close carrying an
+/// application code/reason. The receiver surfaces it as a *clean* session close.
+/// Per RFC 9000 §19.19 the application variant omits the Frame Type field.
+///
+/// The close subtype, not the code, carries the graceful/abnormal distinction —
+/// codes are application-defined, so a graceful close may use any value.
+#[derive(Debug, Clone)]
+pub struct ApplicationClose {
     /// Application-defined error code.
     pub code: VarInt,
     /// Human-readable reason for closing.
     pub reason: String,
-    /// Which QUIC close subtype this is, and how the receiver settles the session:
-    /// - `true` → APPLICATION_CLOSE (0x1d): a graceful, app-initiated close; the
-    ///   receiver surfaces it as a clean session close carrying `code`/`reason`.
-    /// - `false` → CONNECTION_CLOSE (0x1c): a protocol violation or transport error
-    ///   the sender detected; the receiver surfaces it as an abnormal close.
-    ///
-    /// The subtype, not the code, carries this distinction — codes are
-    /// application-defined, so a graceful close may legitimately use any value.
-    pub application: bool,
 }
 
 /// A QX_PING frame for connection liveness probing (draft-01).
@@ -171,6 +178,7 @@ pub enum Frame {
     ResetStream(ResetStream),
     StopSending(StopSending),
     ConnectionClose(ConnectionClose),
+    ApplicationClose(ApplicationClose),
     Stream(Stream),
     MaxData(u64),
     MaxStreamData {
@@ -319,8 +327,8 @@ impl Frame {
                 let code = VarInt::decode(data)?;
                 Ok(Some(Frame::StopSending(StopSending { id, code })))
             }
-            // CONNECTION_CLOSE / APPLICATION_CLOSE
-            0x1c | 0x1d => {
+            // CONNECTION_CLOSE (0x1c): carries the Frame Type field (RFC 9000 §19.19).
+            0x1c => {
                 let code = VarInt::decode(data)?;
                 let _frame_type = VarInt::decode(data)?;
                 let reason_len = VarInt::decode(data)?.into_inner();
@@ -332,7 +340,20 @@ impl Frame {
                 Ok(Some(Frame::ConnectionClose(ConnectionClose {
                     code,
                     reason,
-                    application: frame_type == 0x1d,
+                })))
+            }
+            // APPLICATION_CLOSE (0x1d): no Frame Type field (RFC 9000 §19.19).
+            0x1d => {
+                let code = VarInt::decode(data)?;
+                let reason_len = VarInt::decode(data)?.into_inner();
+                if (data.remaining() as u64) < reason_len {
+                    return Err(Error::Short);
+                }
+                let reason =
+                    String::from_utf8_lossy(&data.split_to(reason_len as usize)).into_owned();
+                Ok(Some(Frame::ApplicationClose(ApplicationClose {
+                    code,
+                    reason,
                 })))
             }
             // MAX_DATA
@@ -444,9 +465,15 @@ impl Frame {
                 s.id.0.encode(buf);
                 s.code.encode(buf);
             }
+            // The legacy WebTransport format keeps the reason as the rest of the
+            // buffer (no Frame Type / length fields); only the type byte differs.
             Frame::ConnectionClose(c) => {
-                // APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c).
-                buf.put_u8(if c.application { 0x1d } else { 0x1c });
+                buf.put_u8(0x1c);
+                c.code.encode(buf);
+                buf.put_slice(c.reason.as_bytes());
+            }
+            Frame::ApplicationClose(c) => {
+                buf.put_u8(0x1d);
                 c.code.encode(buf);
                 buf.put_slice(c.reason.as_bytes());
             }
@@ -479,16 +506,19 @@ impl Frame {
                 s.code.encode(buf);
             }
             Frame::ConnectionClose(c) => {
-                // APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c). Both carry the
-                // causing-frame-type field in this draft, so only the type differs.
-                if c.application {
-                    APPLICATION_CLOSE.encode(buf);
-                } else {
-                    CONNECTION_CLOSE.encode(buf);
-                }
+                CONNECTION_CLOSE.encode(buf);
                 c.code.encode(buf);
-                // frame_type = 0 (application close)
+                // Frame Type field — present for 0x1c (RFC 9000 §19.19). We don't
+                // track which frame tripped the error, so it's always 0 (PADDING).
                 VarInt::from(0u32).encode(buf);
+                let reason_bytes = c.reason.as_bytes();
+                VarInt::try_from(reason_bytes.len())?.encode(buf);
+                buf.put_slice(reason_bytes);
+            }
+            Frame::ApplicationClose(c) => {
+                APPLICATION_CLOSE.encode(buf);
+                c.code.encode(buf);
+                // No Frame Type field for 0x1d (RFC 9000 §19.19).
                 let reason_bytes = c.reason.as_bytes();
                 VarInt::try_from(reason_bytes.len())?.encode(buf);
                 buf.put_slice(reason_bytes);
@@ -606,14 +636,15 @@ impl Frame {
                     fin: true,
                 }))
             }
-            0x1c | 0x1d => {
+            0x1c => {
                 let code = VarInt::decode(&mut data)?;
                 let reason = String::from_utf8_lossy(&data).into_owned();
-                Ok(Frame::ConnectionClose(ConnectionClose {
-                    code,
-                    reason,
-                    application: frame_type == 0x1d,
-                }))
+                Ok(Frame::ConnectionClose(ConnectionClose { code, reason }))
+            }
+            0x1d => {
+                let code = VarInt::decode(&mut data)?;
+                let reason = String::from_utf8_lossy(&data).into_owned();
+                Ok(Frame::ApplicationClose(ApplicationClose { code, reason }))
             }
             _ => Err(Error::InvalidFrameType(frame_type as u64)),
         }
@@ -689,8 +720,8 @@ impl Frame {
                 let code = VarInt::decode(&mut data)?;
                 Ok(Some(Frame::StopSending(StopSending { id, code })))
             }
-            // CONNECTION_CLOSE / APPLICATION_CLOSE
-            0x1c | 0x1d => {
+            // CONNECTION_CLOSE (0x1c): carries the Frame Type field (RFC 9000 §19.19).
+            0x1c => {
                 let code = VarInt::decode(&mut data)?;
                 let _frame_type = VarInt::decode(&mut data)?;
                 let reason_len = VarInt::decode(&mut data)?.into_inner();
@@ -702,7 +733,20 @@ impl Frame {
                 Ok(Some(Frame::ConnectionClose(ConnectionClose {
                     code,
                     reason,
-                    application: frame_type == 0x1d,
+                })))
+            }
+            // APPLICATION_CLOSE (0x1d): no Frame Type field (RFC 9000 §19.19).
+            0x1d => {
+                let code = VarInt::decode(&mut data)?;
+                let reason_len = VarInt::decode(&mut data)?.into_inner();
+                if (data.remaining() as u64) < reason_len {
+                    return Err(Error::Short);
+                }
+                let reason =
+                    String::from_utf8_lossy(&data.split_to(reason_len as usize)).into_owned();
+                Ok(Some(Frame::ApplicationClose(ApplicationClose {
+                    code,
+                    reason,
                 })))
             }
             // MAX_DATA
@@ -819,5 +863,11 @@ impl From<StopSending> for Frame {
 impl From<ConnectionClose> for Frame {
     fn from(close: ConnectionClose) -> Self {
         Frame::ConnectionClose(close)
+    }
+}
+
+impl From<ApplicationClose> for Frame {
+    fn from(close: ApplicationClose) -> Self {
+        Frame::ApplicationClose(close)
     }
 }

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -21,6 +21,7 @@ const STREAM_DATA_BLOCKED: VarInt = VarInt::from_u32(0x15);
 const STREAMS_BLOCKED_BIDI: VarInt = VarInt::from_u32(0x16);
 const STREAMS_BLOCKED_UNI: VarInt = VarInt::from_u32(0x17);
 const APPLICATION_CLOSE: VarInt = VarInt::from_u32(0x1d);
+const CONNECTION_CLOSE: VarInt = VarInt::from_u32(0x1c);
 // DATAGRAM frames (RFC 9221). 0x30 has no length (the payload runs to the end of
 // the record); 0x31 prefixes a length varint. Datagrams are only ever sent on
 // QMux01, where each rides its own record, so the record boundary would already
@@ -100,6 +101,15 @@ pub struct ConnectionClose {
     pub code: VarInt,
     /// Human-readable reason for closing.
     pub reason: String,
+    /// Which QUIC close subtype this is, and how the receiver settles the session:
+    /// - `true` → APPLICATION_CLOSE (0x1d): a graceful, app-initiated close; the
+    ///   receiver surfaces it as a clean session close carrying `code`/`reason`.
+    /// - `false` → CONNECTION_CLOSE (0x1c): a protocol violation or transport error
+    ///   the sender detected; the receiver surfaces it as an abnormal close.
+    ///
+    /// The subtype, not the code, carries this distinction — codes are
+    /// application-defined, so a graceful close may legitimately use any value.
+    pub application: bool,
 }
 
 /// A QX_PING frame for connection liveness probing (draft-01).
@@ -322,6 +332,7 @@ impl Frame {
                 Ok(Some(Frame::ConnectionClose(ConnectionClose {
                     code,
                     reason,
+                    application: frame_type == 0x1d,
                 })))
             }
             // MAX_DATA
@@ -434,7 +445,8 @@ impl Frame {
                 s.code.encode(buf);
             }
             Frame::ConnectionClose(c) => {
-                buf.put_u8(0x1d);
+                // APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c).
+                buf.put_u8(if c.application { 0x1d } else { 0x1c });
                 c.code.encode(buf);
                 buf.put_slice(c.reason.as_bytes());
             }
@@ -467,7 +479,13 @@ impl Frame {
                 s.code.encode(buf);
             }
             Frame::ConnectionClose(c) => {
-                APPLICATION_CLOSE.encode(buf);
+                // APPLICATION_CLOSE (0x1d) vs CONNECTION_CLOSE (0x1c). Both carry the
+                // causing-frame-type field in this draft, so only the type differs.
+                if c.application {
+                    APPLICATION_CLOSE.encode(buf);
+                } else {
+                    CONNECTION_CLOSE.encode(buf);
+                }
                 c.code.encode(buf);
                 // frame_type = 0 (application close)
                 VarInt::from(0u32).encode(buf);
@@ -588,10 +606,14 @@ impl Frame {
                     fin: true,
                 }))
             }
-            0x1d => {
+            0x1c | 0x1d => {
                 let code = VarInt::decode(&mut data)?;
                 let reason = String::from_utf8_lossy(&data).into_owned();
-                Ok(Frame::ConnectionClose(ConnectionClose { code, reason }))
+                Ok(Frame::ConnectionClose(ConnectionClose {
+                    code,
+                    reason,
+                    application: frame_type == 0x1d,
+                }))
             }
             _ => Err(Error::InvalidFrameType(frame_type as u64)),
         }
@@ -680,6 +702,7 @@ impl Frame {
                 Ok(Some(Frame::ConnectionClose(ConnectionClose {
                     code,
                     reason,
+                    application: frame_type == 0x1d,
                 })))
             }
             // MAX_DATA

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -11,8 +11,8 @@ use crate::credit::Credit;
 use crate::sched::PriorityQueue;
 use crate::transport::{Reader, Transport, Writer};
 use crate::{
-    proto::varint_size, ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir,
-    StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD,
+    proto::varint_size, ApplicationClose, ConnectionClose, Error, Frame, ResetStream, StopSending,
+    Stream, StreamDir, StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD,
 };
 use bytes::{Buf, BufMut, Bytes};
 use tokio::sync::{mpsc, watch};
@@ -970,23 +970,25 @@ impl<R: Reader> SessionState<R> {
                     send.inbound_stopped.send(stop).ok();
                 }
             }
+            // APPLICATION_CLOSE (0x1d): a graceful, deliberate peer close — surfaces
+            // as a clean session close carrying the peer's code/reason.
+            Frame::ApplicationClose(close) => {
+                self.closed
+                    .send(Some(Error::ConnectionClosed {
+                        code: close.code,
+                        reason: close.reason,
+                    }))
+                    .ok();
+            }
+            // CONNECTION_CLOSE (0x1c): the peer hit a protocol/transport error —
+            // surfaces as an abnormal close, not a clean one.
             Frame::ConnectionClose(close) => {
-                // APPLICATION_CLOSE (0x1d) is a graceful, deliberate peer close;
-                // CONNECTION_CLOSE (0x1c) means the peer hit a protocol/transport
-                // error. The subtype, not the code, decides which — so the former
-                // surfaces as a clean session close and the latter as abnormal.
-                let err = if close.application {
-                    Error::ConnectionClosed {
+                self.closed
+                    .send(Some(Error::ConnectionReset {
                         code: close.code,
                         reason: close.reason,
-                    }
-                } else {
-                    Error::ConnectionReset {
-                        code: close.code,
-                        reason: close.reason,
-                    }
-                };
-                self.closed.send(Some(err)).ok();
+                    }))
+                    .ok();
             }
             // Flow control frames
             Frame::MaxData(max) => {
@@ -1250,7 +1252,6 @@ impl Session {
                     ConnectionClose {
                         code: VarInt::from(0u32),
                         reason: "handshake timeout".to_string(),
-                        application: false,
                     }
                     .into(),
                 );
@@ -1447,7 +1448,6 @@ impl Session {
                     ConnectionClose {
                         code: VarInt::from(code),
                         reason: err.to_string(),
-                        application: false,
                     }
                     .into(),
                 );
@@ -1660,10 +1660,9 @@ impl generic::Session for Session {
     fn close(&self, code: u32, reason: &str) {
         // App-initiated: an APPLICATION_CLOSE (0x1d) the peer surfaces as a clean
         // session close carrying our code/reason.
-        let frame = ConnectionClose {
+        let frame = ApplicationClose {
             code: VarInt::from(code),
             reason: reason.to_string(),
-            application: true,
         };
         let _ = self.outbound_priority.send(frame.into());
 
@@ -2561,7 +2560,8 @@ mod datagram_recv_tests {
     }
 
     /// Scan the size-prefixed records the server wrote and return the first
-    /// CONNECTION_CLOSE / APPLICATION_CLOSE frame among them.
+    /// transport CONNECTION_CLOSE (0x1c) frame among them — a graceful
+    /// APPLICATION_CLOSE (0x1d) is a different `Frame` variant and won't match.
     fn find_connection_close(buf: &[u8]) -> Option<ConnectionClose> {
         let mut data = Bytes::copy_from_slice(buf);
         while !data.is_empty() {
@@ -2606,11 +2606,10 @@ mod datagram_recv_tests {
             .expect("reading the server's output timed out")
             .unwrap();
 
-        let close = find_connection_close(&buf).expect("server must emit a CONNECTION_CLOSE");
-        assert!(
-            !close.application,
-            "a violation is a transport CONNECTION_CLOSE (0x1c), not APPLICATION_CLOSE"
-        );
+        // Finding a `ConnectionClose` (0x1c) at all is the assertion: a graceful
+        // APPLICATION_CLOSE (0x1d) would be a different variant and not match.
+        let close = find_connection_close(&buf)
+            .expect("a violation must emit a transport CONNECTION_CLOSE (0x1c)");
         assert_eq!(close.code.into_inner(), 1002, "protocol-violation code");
     }
 
@@ -2620,10 +2619,9 @@ mod datagram_recv_tests {
     async fn peer_application_close_is_graceful() {
         let (server, mut raw) = raw_peer(Config::new(Version::QMux01)).await;
 
-        let close = Frame::ConnectionClose(ConnectionClose {
+        let close = Frame::ApplicationClose(ApplicationClose {
             code: VarInt::from_u32(42),
             reason: "bye".to_string(),
-            application: true,
         })
         .encode(Version::QMux01)
         .unwrap();
@@ -2651,7 +2649,6 @@ mod datagram_recv_tests {
         let close = Frame::ConnectionClose(ConnectionClose {
             code: VarInt::from_u32(1002),
             reason: "protocol violation".to_string(),
-            application: false,
         })
         .encode(Version::QMux01)
         .unwrap();

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -971,12 +971,22 @@ impl<R: Reader> SessionState<R> {
                 }
             }
             Frame::ConnectionClose(close) => {
-                self.closed
-                    .send(Some(Error::ConnectionClosed {
+                // APPLICATION_CLOSE (0x1d) is a graceful, deliberate peer close;
+                // CONNECTION_CLOSE (0x1c) means the peer hit a protocol/transport
+                // error. The subtype, not the code, decides which — so the former
+                // surfaces as a clean session close and the latter as abnormal.
+                let err = if close.application {
+                    Error::ConnectionClosed {
                         code: close.code,
                         reason: close.reason,
-                    }))
-                    .ok();
+                    }
+                } else {
+                    Error::ConnectionReset {
+                        code: close.code,
+                        reason: close.reason,
+                    }
+                };
+                self.closed.send(Some(err)).ok();
             }
             // Flow control frames
             Frame::MaxData(max) => {
@@ -1234,10 +1244,13 @@ impl Session {
             // Timed out waiting for the peer's parameters: abort the half-open
             // handshake, notifying the peer, and fail rather than hang.
             None => {
+                // Abnormal: a CONNECTION_CLOSE (0x1c) so the peer's session rejects
+                // rather than seeing a graceful close.
                 let _ = self.outbound_priority.send(
                     ConnectionClose {
                         code: VarInt::from(0u32),
                         reason: "handshake timeout".to_string(),
+                        application: false,
                     }
                     .into(),
                 );
@@ -1422,6 +1435,23 @@ impl Session {
 
         tokio::spawn(async move {
             let err = backend.run().await.err().unwrap_or(Error::Closed);
+            // If we tore down because of a protocol/transport violation *we*
+            // detected, tell the peer with a CONNECTION_CLOSE (0x1c) so their
+            // session rejects too, rather than seeing a bare drop. Enqueue on the
+            // control lane *before* flipping `closed`, so the writer's teardown
+            // flush picks it up. `transport_close` returns `None` for a graceful
+            // close, a close the peer already sent us, an idle timeout, or a dead
+            // transport — none of which should (or can) emit a frame here.
+            if let Some(code) = err.transport_close() {
+                let _ = backend.control.send(
+                    ConnectionClose {
+                        code: VarInt::from(code),
+                        reason: err.to_string(),
+                        application: false,
+                    }
+                    .into(),
+                );
+            }
             // Dropping `backend` drops the `established` sender; an `established()`
             // waiter that was still pending then observes the channel close and
             // reports this terminal error. The OnceLock stays unset, so the
@@ -1628,9 +1658,12 @@ impl generic::Session for Session {
     }
 
     fn close(&self, code: u32, reason: &str) {
+        // App-initiated: an APPLICATION_CLOSE (0x1d) the peer surfaces as a clean
+        // session close carrying our code/reason.
         let frame = ConnectionClose {
             code: VarInt::from(code),
             reason: reason.to_string(),
+            application: true,
         };
         let _ = self.outbound_priority.send(frame.into());
 
@@ -2525,6 +2558,112 @@ mod datagram_recv_tests {
         raw.flush().await.unwrap();
 
         assert!(matches!(server.closed().await, Error::DatagramsUnsupported));
+    }
+
+    /// Scan the size-prefixed records the server wrote and return the first
+    /// CONNECTION_CLOSE / APPLICATION_CLOSE frame among them.
+    fn find_connection_close(buf: &[u8]) -> Option<ConnectionClose> {
+        let mut data = Bytes::copy_from_slice(buf);
+        while !data.is_empty() {
+            let len = VarInt::decode(&mut data).ok()?.into_inner() as usize;
+            if data.len() < len {
+                return None;
+            }
+            let record = data.split_to(len);
+            for frame in Frame::decode_record(record).ok()? {
+                if let Frame::ConnectionClose(c) = frame {
+                    return Some(c);
+                }
+            }
+        }
+        None
+    }
+
+    /// A protocol violation we detect is reported to the peer as a CONNECTION_CLOSE
+    /// (0x1c), not a graceful APPLICATION_CLOSE — so the peer's session rejects too,
+    /// matching the JS polyfill.
+    #[tokio::test]
+    async fn violation_emits_connection_close_to_peer() {
+        use tokio::io::AsyncReadExt;
+
+        let mut cfg = Config::new(Version::QMux01);
+        cfg.max_datagram_frame_size = 100;
+        let (server, mut raw) = raw_peer(cfg).await;
+
+        // Oversized DATAGRAM frame → the server tears down with FrameTooLarge.
+        let datagram = Frame::Datagram(Bytes::from(vec![0u8; 98]).into())
+            .encode(Version::QMux01)
+            .unwrap();
+        raw.write_all(&record(datagram)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        assert!(matches!(server.closed().await, Error::FrameTooLarge));
+
+        // Drain everything the server wrote and find the close frame it emitted.
+        let mut buf = Vec::new();
+        tokio::time::timeout(std::time::Duration::from_secs(1), raw.read_to_end(&mut buf))
+            .await
+            .expect("reading the server's output timed out")
+            .unwrap();
+
+        let close = find_connection_close(&buf).expect("server must emit a CONNECTION_CLOSE");
+        assert!(
+            !close.application,
+            "a violation is a transport CONNECTION_CLOSE (0x1c), not APPLICATION_CLOSE"
+        );
+        assert_eq!(close.code.into_inner(), 1002, "protocol-violation code");
+    }
+
+    /// A peer APPLICATION_CLOSE (0x1d) is graceful: a clean session close carrying
+    /// the peer's code/reason.
+    #[tokio::test]
+    async fn peer_application_close_is_graceful() {
+        let (server, mut raw) = raw_peer(Config::new(Version::QMux01)).await;
+
+        let close = Frame::ConnectionClose(ConnectionClose {
+            code: VarInt::from_u32(42),
+            reason: "bye".to_string(),
+            application: true,
+        })
+        .encode(Version::QMux01)
+        .unwrap();
+        raw.write_all(&record(close)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        match server.closed().await {
+            Error::ConnectionClosed { code, reason } => {
+                assert_eq!(code.into_inner(), 42);
+                assert_eq!(reason, "bye");
+            }
+            other => panic!("expected a graceful ConnectionClosed, got {other:?}"),
+        }
+    }
+
+    /// A peer CONNECTION_CLOSE (0x1c) is abnormal: the peer hit a protocol/transport
+    /// error, so it surfaces as a reset — and must NOT masquerade as a clean
+    /// application close (`session_error()` returns `None`).
+    #[tokio::test]
+    async fn peer_connection_close_is_abnormal() {
+        use web_transport_trait::Error as _;
+
+        let (server, mut raw) = raw_peer(Config::new(Version::QMux01)).await;
+
+        let close = Frame::ConnectionClose(ConnectionClose {
+            code: VarInt::from_u32(1002),
+            reason: "protocol violation".to_string(),
+            application: false,
+        })
+        .encode(Version::QMux01)
+        .unwrap();
+        raw.write_all(&record(close)).await.unwrap();
+        raw.flush().await.unwrap();
+
+        let err = server.closed().await;
+        assert!(
+            matches!(err, Error::ConnectionReset { .. }),
+            "a peer CONNECTION_CLOSE must be abnormal, got {err:?}"
+        );
+        assert!(err.session_error().is_none());
     }
 
     /// A DATAGRAM whose encoded frame exactly hits the advertised limit is

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -337,10 +337,13 @@ mod stream_transport {
                 read_varint_into(reader, &mut buf).await?; // id
                 read_varint_into(reader, &mut buf).await?; // code
             }
-            // CONNECTION_CLOSE / APPLICATION_CLOSE
+            // CONNECTION_CLOSE (0x1c) carries the Frame Type field; APPLICATION_CLOSE
+            // (0x1d) omits it (RFC 9000 §19.19).
             0x1c | 0x1d => {
                 read_varint_into(reader, &mut buf).await?; // code
-                read_varint_into(reader, &mut buf).await?; // frame_type
+                if frame_type == 0x1c {
+                    read_varint_into(reader, &mut buf).await?; // frame_type
+                }
                 let reason_len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
                 if reason_len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -20,7 +20,7 @@
 //! encodes as `0x44 0x00`.
 
 use bytes::Bytes;
-use qmux::proto::{ConnectionClose, Frame, ResetStream, StopSending, Stream};
+use qmux::proto::{ApplicationClose, ConnectionClose, Frame, ResetStream, StopSending, Stream};
 use qmux::{Error, StreamId, Version};
 use web_transport_proto::VarInt;
 
@@ -66,7 +66,10 @@ fn assert_frames_eq(got: &Frame, want: &Frame, version: Version) {
         (Frame::ConnectionClose(a), Frame::ConnectionClose(b)) => {
             assert_eq!(a.code.into_inner(), b.code.into_inner(), "close code");
             assert_eq!(a.reason, b.reason, "close reason");
-            assert_eq!(a.application, b.application, "close application flag");
+        }
+        (Frame::ApplicationClose(a), Frame::ApplicationClose(b)) => {
+            assert_eq!(a.code.into_inner(), b.code.into_inner(), "app close code");
+            assert_eq!(a.reason, b.reason, "app close reason");
         }
         (Frame::MaxData(a), Frame::MaxData(b)) => assert_eq!(a, b, "max_data"),
         (
@@ -182,25 +185,23 @@ fn webtransport_stop_sending() {
 }
 
 #[test]
-fn webtransport_connection_close() {
+fn webtransport_application_close() {
     // 0x1d + code(=42) + reason("bye") as the rest of the buffer.
     let bytes = [0x1d, 0x2a, b'b', b'y', b'e'];
-    let frame = Frame::ConnectionClose(ConnectionClose {
+    let frame = Frame::ApplicationClose(ApplicationClose {
         code: code(42),
         reason: "bye".to_string(),
-        application: true,
     });
     assert_round_trip(Version::WebTransport, &bytes, &frame);
 }
 
 #[test]
-fn webtransport_connection_close_transport() {
-    // Same body as APPLICATION_CLOSE, but 0x1c flags it as a transport close.
+fn webtransport_connection_close() {
+    // Same legacy body, but 0x1c marks it a transport close.
     let bytes = [0x1c, 0x2a, b'b', b'y', b'e'];
     let frame = Frame::ConnectionClose(ConnectionClose {
         code: code(42),
         reason: "bye".to_string(),
-        application: false,
     });
     assert_round_trip(Version::WebTransport, &bytes, &frame);
 }
@@ -421,24 +422,24 @@ fn qmux02_wire_matches_qmux01() {
 
 #[test]
 fn qmux00_application_close() {
-    // 0x1d (APPLICATION_CLOSE) + code(=42) + frame_type(=0) + reason_len(=3) + "bye".
-    let bytes = [0x1d, 0x2a, 0x00, 0x03, b'b', b'y', b'e'];
-    let frame = Frame::ConnectionClose(ConnectionClose {
+    // 0x1d (APPLICATION_CLOSE) + code(=42) + reason_len(=3) + "bye".
+    // No Frame Type field — RFC 9000 §19.19 omits it for the application variant.
+    let bytes = [0x1d, 0x2a, 0x03, b'b', b'y', b'e'];
+    let frame = Frame::ApplicationClose(ApplicationClose {
         code: code(42),
         reason: "bye".to_string(),
-        application: true,
     });
     assert_round_trip(Version::QMux00, &bytes, &frame);
 }
 
 #[test]
-fn qmux00_connection_close_transport() {
+fn qmux00_connection_close() {
     // 0x1c (CONNECTION_CLOSE) + code(=42) + frame_type(=0) + reason_len(=3) + "bye".
+    // The transport variant *does* carry the Frame Type field.
     let bytes = [0x1c, 0x2a, 0x00, 0x03, b'b', b'y', b'e'];
     let frame = Frame::ConnectionClose(ConnectionClose {
         code: code(42),
         reason: "bye".to_string(),
-        application: false,
     });
     assert_round_trip(Version::QMux00, &bytes, &frame);
 }
@@ -567,10 +568,9 @@ fn qmux00_encoding_has_no_record_size_prefix() {
             fin: false,
         }),
         Frame::MaxData(1024),
-        Frame::ConnectionClose(ConnectionClose {
+        Frame::ApplicationClose(ApplicationClose {
             code: code(42),
             reason: "bye".to_string(),
-            application: true,
         }),
     ];
     for frame in &cases {
@@ -579,7 +579,7 @@ fn qmux00_encoding_has_no_record_size_prefix() {
         match frame {
             Frame::Stream(_) => assert_eq!(bytes[0], 0x0a, "stream without fin = type 0x0a"),
             Frame::MaxData(_) => assert_eq!(bytes[0], 0x10, "max_data = type 0x10"),
-            Frame::ConnectionClose(_) => {
+            Frame::ApplicationClose(_) => {
                 assert_eq!(bytes[0], 0x1d, "application_close = type 0x1d")
             }
             _ => unreachable!(),

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -66,6 +66,7 @@ fn assert_frames_eq(got: &Frame, want: &Frame, version: Version) {
         (Frame::ConnectionClose(a), Frame::ConnectionClose(b)) => {
             assert_eq!(a.code.into_inner(), b.code.into_inner(), "close code");
             assert_eq!(a.reason, b.reason, "close reason");
+            assert_eq!(a.application, b.application, "close application flag");
         }
         (Frame::MaxData(a), Frame::MaxData(b)) => assert_eq!(a, b, "max_data"),
         (
@@ -187,6 +188,19 @@ fn webtransport_connection_close() {
     let frame = Frame::ConnectionClose(ConnectionClose {
         code: code(42),
         reason: "bye".to_string(),
+        application: true,
+    });
+    assert_round_trip(Version::WebTransport, &bytes, &frame);
+}
+
+#[test]
+fn webtransport_connection_close_transport() {
+    // Same body as APPLICATION_CLOSE, but 0x1c flags it as a transport close.
+    let bytes = [0x1c, 0x2a, b'b', b'y', b'e'];
+    let frame = Frame::ConnectionClose(ConnectionClose {
+        code: code(42),
+        reason: "bye".to_string(),
+        application: false,
     });
     assert_round_trip(Version::WebTransport, &bytes, &frame);
 }
@@ -412,6 +426,19 @@ fn qmux00_application_close() {
     let frame = Frame::ConnectionClose(ConnectionClose {
         code: code(42),
         reason: "bye".to_string(),
+        application: true,
+    });
+    assert_round_trip(Version::QMux00, &bytes, &frame);
+}
+
+#[test]
+fn qmux00_connection_close_transport() {
+    // 0x1c (CONNECTION_CLOSE) + code(=42) + frame_type(=0) + reason_len(=3) + "bye".
+    let bytes = [0x1c, 0x2a, 0x00, 0x03, b'b', b'y', b'e'];
+    let frame = Frame::ConnectionClose(ConnectionClose {
+        code: code(42),
+        reason: "bye".to_string(),
+        application: false,
     });
     assert_round_trip(Version::QMux00, &bytes, &frame);
 }
@@ -543,6 +570,7 @@ fn qmux00_encoding_has_no_record_size_prefix() {
         Frame::ConnectionClose(ConnectionClose {
             code: code(42),
             reason: "bye".to_string(),
+            application: true,
         }),
     ];
     for frame in &cases {


### PR DESCRIPTION
Builds on #291 (rwl4's commits are preserved as the base of this branch).

## What

Distinguish the two QUIC close subtypes across both qmux implementations, as **separate frame message types** — so a session's `closed` settles correctly and the wire format follows RFC 9000 §19.19.

| Frame | Type byte | Frame Type field | `closed` (JS) | `Error` (Rust) |
|---|---|---|---|---|
| `ApplicationClose` | `0x1d` | **omitted** | **resolves** | `ConnectionClosed` (`session_error()` = `Some`) |
| `ConnectionClose` | `0x1c` | present (=0) | **rejects** | `ConnectionReset` (`session_error()` = `None`) |

The *subtype*, not the application code, carries the graceful/abnormal distinction — codes are app-defined, so a graceful close may use any value (including one that looks like a violation).

## Wire format fix (RFC 9000 §19.19)
The previous code wrote the Frame Type field (`0`) for **both** `0x1c` and `0x1d`. Per the RFC, only the transport variant (`0x1c`) carries it; the application variant (`0x1d`) omits it. Both encoders/decoders — and the Rust byte-stream length prober in `transport.rs` — now gate that field on the subtype.

## JS (`js/qmux`)
- `Frame.ApplicationClose` (0x1d) and `Frame.ConnectionClose` (0x1c) are distinct message types (no `application` boolean).
- The close transition is split into `#close` (resolve) and `#abort` (reject); a locally-detected violation emits a `ConnectionClose` (0x1c) so the peer rejects too.

## Rust (`rs/qmux`)
- New `Frame::ApplicationClose` variant. **Previously a detected violation dropped the socket silently** — it now emits a `ConnectionClose` (0x1c) to the peer before teardown.
- New `Error::ConnectionReset` (received 0x1c → abnormal) alongside `ConnectionClosed` (received 0x1d → graceful); `Error::transport_close()` maps detected violations to code `1002` (matching the JS polyfill).

## Interop
- JS↔JS, Rust↔Rust, and JS↔Rust are all symmetric: violations emit `0x1c` (peer rejects), graceful emits `0x1d` (peer resolves).

## Note / open question
Idle timeout still emits **no** frame on either side — QUIC closes silently on idle and the peer is unresponsive by definition. Happy to make it send a `0x1c` if preferred.

## Tests
- JS: 96 pass (tsc + biome clean). Wire-format round-trips for both `0x1c` and `0x1d` (including the dropped Frame Type byte on `0x1d`), plus session tests for the resolve/reject split.
- Rust: lib 63 + wire_format 30 pass, clippy + rustfmt clean. Includes `violation_emits_connection_close_to_peer` (reads the real 0x1c/1002 off the wire), `peer_application_close_is_graceful`, `peer_connection_close_is_abnormal`.
- Pre-existing unrelated: `rs/qmux/tests/ws_reassembly.rs` fails to compile on a `Config::new` arity mismatch — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)