### PR TITLE
fix(qmux): reset idle timeout on send activity

### DIFF
--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -26,6 +26,8 @@ class FakePeer {
 	#closedResolve: (info: { closeCode?: number; reason?: string }) => void;
 	#closedReject: (err: Error) => void;
 	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
+	#writeBlocked: Promise<void> | undefined;
+	#unblockWrites: (() => void) | undefined;
 
 	/** Raw chunks the Session has written. */
 	sent: Uint8Array[] = [];
@@ -40,7 +42,8 @@ class FakePeer {
 			},
 		});
 		const writable = new WritableStream<Uint8Array>({
-			write: (chunk) => {
+			write: async (chunk) => {
+				await this.#writeBlocked;
 				this.sent.push(chunk);
 			},
 		});
@@ -63,6 +66,16 @@ class FakePeer {
 		this.#closedReject(err);
 	}
 	setHighWaterMark() {}
+	blockWrites() {
+		const blocked = Promise.withResolvers<void>();
+		this.#writeBlocked = blocked.promise;
+		this.#unblockWrites = blocked.resolve;
+	}
+	unblockWrites() {
+		this.#unblockWrites?.();
+		this.#writeBlocked = undefined;
+		this.#unblockWrites = undefined;
+	}
 
 	// --- test controls ---
 	/** Inject a frame as if sent by the peer. */
@@ -294,18 +307,41 @@ describe("Session integration (scripted peer)", () => {
 			expect((err.cause as Error).message).toBe("connection reset");
 		});
 
-		test("an idle timeout rejects closed, rather than mimicking a graceful close", async () => {
+		test("an idle timeout rejects closed when neither direction makes progress", async () => {
 			// The sharpest case: an idle timeout used to resolve with { closeCode: 0,
 			// reason: "idle timeout" }, while a graceful close() with no args resolves
 			// with { closeCode: 0, reason: "" }. A dead peer and a clean shutdown differed
 			// only by a free-text string.
 			const { session, peer } = connect({ maxIdleTimeout: 150n });
 			await session.ready;
+			await waitFor(() => peer.has("transport_parameters"));
+			// A successfully written keep-alive is send activity under QMux. Block the
+			// sink so neither inbound nor outbound frames can reset the idle deadline.
+			peer.blockWrites();
 			peer.send({ type: "transport_parameters", params: peerParams() });
 
-			// ...and now the peer goes silent.
 			const err = await expectSessionFailure(session);
 			expect(err.message).toContain("idle timeout");
+			peer.unblockWrites();
+		});
+
+		test("outbound frame activity resets the idle timeout", async () => {
+			const { session, peer } = connect({ maxIdleTimeout: 120n });
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			const writable = await session.createUnidirectionalStream();
+			const writer = writable.getWriter();
+			for (let i = 0; i < 6; i++) {
+				await new Promise((resolve) => setTimeout(resolve, 45));
+				await writer.write(new Uint8Array([i]));
+			}
+
+			// More than two idle windows elapsed without another inbound frame, but
+			// the successful STREAM writes above kept resetting the shared deadline.
+			expect(peer.has("connection_close")).toBe(false);
+			session.close();
+			expect(await session.closed).toEqual({ closeCode: 0, reason: "" });
 		});
 
 		test("the standard reconnect idiom sees a drop", async () => {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -767,10 +767,10 @@ export default class Session implements WebTransport {
 			return;
 		}
 		const now = Date.now();
-		if (now - this.#lastRecvAt > timeoutMs) {
-			// Peer has gone silent past the negotiated limit. Abnormal: without a
-			// rejection this is indistinguishable from a graceful close(), which also
-			// settles with closeCode 0.
+		if (now - Math.max(this.#lastRecvAt, this.#lastSendAt) > timeoutMs) {
+			// No frames have been sent or received within the negotiated limit. Abnormal:
+			// without a rejection this is indistinguishable from a graceful close(), which
+			// also settles with closeCode 0.
 			this.#closeReason ??= new Error("idle timeout");
 			this.#abort(0, "idle timeout");
 			this.#transportClose();

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -522,8 +522,8 @@ impl<W: Writer> WriterState<W> {
 ///
 ///  - enqueues a `QX_PING` on the control lane once we've been silent on send for a
 ///    third of the idle window (the keep-alive cadence), and
-///  - closes the session once we've been silent on receive for a full idle window,
-///    deferred by at most one extra window while the reader or writer is
+///  - closes the session once we've been silent on send and receive for a full
+///    idle window, deferred by at most one extra window while the reader or writer is
 ///    backpressured — that's evidence the peer is alive and we simply can't get a
 ///    keep-alive through (or aren't reading its replies).
 ///
@@ -587,7 +587,12 @@ impl TimerState {
         let mut next_ping_seq: u64 = 0;
 
         loop {
-            let last_recv = instant_at(self.base, self.last_recv_at.load(Ordering::Acquire));
+            let last_activity = instant_at(
+                self.base,
+                self.last_recv_at
+                    .load(Ordering::Acquire)
+                    .max(self.last_send_at.load(Ordering::Acquire)),
+            );
             let ping_ref = instant_at(
                 self.base,
                 self.last_send_at.load(Ordering::Acquire).max(last_ping_ms),
@@ -597,7 +602,7 @@ impl TimerState {
             // idle deadline, so we don't busy-spin on an already-elapsed instant.
             let idle_wake = match deferred_since {
                 Some(since) => since + idle,
-                None => last_recv + idle,
+                None => last_activity + idle,
             };
             let wake = idle_wake.min(ping_ref + ping_every);
 
@@ -630,10 +635,16 @@ impl TimerState {
                 last_ping_ms = millis_since(self.base, now);
             }
 
-            // Idle close: due once we've been silent on receive for a full window.
-            let last_recv = instant_at(self.base, self.last_recv_at.load(Ordering::Acquire));
-            if now < last_recv + idle {
-                deferred_since = None; // receive progressed — not idle
+            // Idle close: due once we've been silent on send and receive for a full
+            // window. Draft-02 section 7.1 resets the timer for either direction.
+            let last_activity = instant_at(
+                self.base,
+                self.last_recv_at
+                    .load(Ordering::Acquire)
+                    .max(self.last_send_at.load(Ordering::Acquire)),
+            );
+            if now < last_activity + idle {
+                deferred_since = None; // send or receive progressed — not idle
                 continue;
             }
 
@@ -2177,6 +2188,7 @@ mod timer_tests {
     struct Harness {
         reader_backpressured: Arc<AtomicBool>,
         last_recv_at: Arc<AtomicU64>,
+        last_send_at: Arc<AtomicU64>,
         closed: watch::Sender<Option<Error>>,
         // Kept alive so the control lane the timer pings on doesn't close under it.
         _control_rx: mpsc::UnboundedReceiver<crate::Frame>,
@@ -2198,7 +2210,7 @@ mod timer_tests {
         let timer = TimerState {
             base,
             last_recv_at: last_recv_at.clone(),
-            last_send_at,
+            last_send_at: last_send_at.clone(),
             reader_backpressured: reader_backpressured.clone(),
             writer_backpressured: writer_backpressured.clone(),
             idle_timeout_ms,
@@ -2212,6 +2224,7 @@ mod timer_tests {
         Harness {
             reader_backpressured,
             last_recv_at,
+            last_send_at,
             closed,
             _control_rx,
         }
@@ -2276,6 +2289,25 @@ mod timer_tests {
         assert!(
             h.closed.borrow().is_none(),
             "a peer that keeps sending must not be idle-closed"
+        );
+    }
+
+    /// Successful outbound frames reset the same idle deadline as inbound frames.
+    /// A one-way sender must remain open while its writes continue beyond a full
+    /// idle window, even when the peer sends nothing back.
+    #[tokio::test]
+    async fn send_progress_averts_idle_close() {
+        let h = spawn_timer(100);
+
+        let base = tokio::time::Instant::now();
+        for _ in 0..6 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let elapsed = base.elapsed().as_millis() as u64;
+            h.last_send_at.store(elapsed, Ordering::Release);
+        }
+        assert!(
+            h.closed.borrow().is_none(),
+            "a session that keeps sending must not be idle-closed"
         );
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -338,8 +338,8 @@ fn note_closed(closed: &watch::Sender<Option<Error>>, err: Error) {
 /// The QMux keep-alive ping is *not* driven here — the timer task ([`TimerState`])
 /// owns the cadence and enqueues `QX_PING` on the control lane like any other
 /// frame. The writer only records *when* a send last landed (`last_send_at`) so
-/// the timer can decide whether a ping is due, independently of where this task is
-/// parked.
+/// the timer can schedule pings and idle closure independently of where this task
+/// is parked.
 struct WriterState<W: Writer> {
     writer: W,
     version: Version,
@@ -360,7 +360,7 @@ struct WriterState<W: Writer> {
     closed: watch::Sender<Option<Error>>,
 
     // Origin shared with the reader and timer, plus the millis (since `base`) at
-    // which our last send landed — published for the timer's keep-alive cadence.
+    // which our last send landed — published for keep-alive and idle scheduling.
     base: tokio::time::Instant,
     last_send_at: Arc<AtomicU64>,
 }
@@ -502,7 +502,7 @@ impl<W: Writer> WriterState<W> {
         let result = self.writer.send(bytes).await;
         self.writer_backpressured.store(false, Ordering::Release);
         result?;
-        // Publish send progress for the timer's keep-alive cadence.
+        // Publish send progress for the timer's keep-alive and idle scheduling.
         self.last_send_at.store(
             millis_since(self.base, tokio::time::Instant::now()),
             Ordering::Release,

--- a/rs/qmux/tests/backpressure.rs
+++ b/rs/qmux/tests/backpressure.rs
@@ -208,20 +208,21 @@ async fn idle_timeout_deferred_but_bounded_under_backpressure() {
     let (s2c_tx, s2c_rx) = mpsc::channel(256);
     // Keep the client's receive channel open even after the server task goes
     // away, so the client sees a *silent but open* peer rather than a transport
-    // close. This isolates the client's own idle logic: the server (writer not
-    // gated) will itself idle-close once the wedged client goes quiet.
+    // close. This isolates the client's own idle logic after both transport
+    // writers are gated: otherwise the server's successful QX_PING writes would
+    // count as activity and correctly keep the client alive.
     let _s2c_keepalive = s2c_tx.clone();
 
     let (gate_tx, gate_rx) = watch::channel(true); // open: handshake flows
     let client_transport = GatedTransport {
         tx: c2s_tx,
         rx: s2c_rx,
-        gate: Some(gate_rx),
+        gate: Some(gate_rx.clone()),
     };
     let server_transport = GatedTransport {
         tx: s2c_tx,
         rx: c2s_rx,
-        gate: None,
+        gate: Some(gate_rx),
     };
 
     // Short idle timeout so the test is quick; the deferral grace is one more


### PR DESCRIPTION
## Summary

- reset the QMux idle deadline on successful outbound frame activity in both Rust and TypeScript
- add regression coverage for one-way senders that remain active beyond an idle window
- update idle/backpressure fixtures so successful QX_PING writes correctly count as activity

## Root cause

Both implementations tracked send activity for keep-alive scheduling, but calculated idle closure from receive activity alone. A session that continued sending QMux frames without receiving traffic could therefore be closed as idle, contrary to draft-ietf-quic-qmux-02 section 7.1.

## Impact

One-way publishers and other send-heavy sessions now remain open while outbound QMux frames continue to land successfully. Failed or blocked writes do not falsely extend the idle deadline.

## Validation

- `cargo test -p qmux` (122 tests)
- `bun test js/qmux` (97 tests)
- `bun run --cwd js/qmux check`
- `bunx biome check js/qmux/src/session.ts js/qmux/src/session.test.ts`
- `cargo fmt --all --check`

Fixes #301
