### PR TITLE
fix(quiche): make AsyncWrite shutdown idempotent

### DIFF
--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -110,6 +110,20 @@ impl SendState {
         Poll::Pending
     }
 
+    pub fn poll_flushed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+        if let Some(reset) = self.reset {
+            return Poll::Ready(Err(StreamError::Reset(reset)));
+        } else if let Some(stop) = self.stop {
+            return Poll::Ready(Err(StreamError::Stop(stop)));
+        } else if self.queued.is_empty() {
+            return Poll::Ready(Ok(()));
+        }
+
+        self.blocked = Some(waker.clone());
+
+        Poll::Pending
+    }
+
     #[must_use = "wake the driver"]
     pub fn flush(&mut self, qconn: &mut QuicheConnection) -> quiche::Result<Option<Waker>> {
         if let Some(code) = self.reset {
@@ -187,7 +201,9 @@ impl SendState {
             Err(e) => return Err(e),
         };
 
-        if self.capacity > 0 {
+        // A flush waiter can make progress as soon as the internal queue has
+        // drained, even if there is no capacity available for another write.
+        if self.queued.is_empty() || self.capacity > 0 {
             return Ok(self.blocked.take());
         }
 
@@ -348,6 +364,18 @@ impl SendStream {
         Poll::Pending
     }
 
+    fn poll_flushed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+        if let Poll::Ready(res) = self.state.lock().poll_flushed(waker) {
+            return Poll::Ready(res);
+        }
+
+        if let Poll::Ready(res) = self.driver.lock().closed(waker) {
+            return Poll::Ready(Err(res.into()));
+        }
+
+        Poll::Pending
+    }
+
     /// Wait until the stream is closed by either side.
     ///
     /// This includes:
@@ -403,21 +431,26 @@ impl AsyncWrite for SendStream {
         }
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Flushing happens automatically via the driver
-        Poll::Ready(Ok(()))
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.poll_flushed(cx.waker())
+            .map_err(|e| io::Error::other(e.to_string()))
     }
 
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        match self.finish() {
-            Ok(()) => match self.poll_closed(cx.waker()) {
-                Poll::Ready(res) => Poll::Ready(res.map_err(|e| io::Error::other(e.to_string()))),
-                Poll::Pending => Poll::Pending,
-            },
-            Err(e) => Poll::Ready(Err(io::Error::other(e.to_string()))),
+        match self.is_finished() {
+            Ok(false) => {
+                if let Err(e) = self.finish() {
+                    return Poll::Ready(Err(io::Error::other(e.to_string())));
+                }
+            }
+            Ok(true) => {}
+            Err(e) => return Poll::Ready(Err(io::Error::other(e.to_string()))),
         }
+
+        self.poll_closed(cx.waker())
+            .map_err(|e| io::Error::other(e.to_string()))
     }
 }

--- a/rs/web-transport-quiche/tests/async_write.rs
+++ b/rs/web-transport-quiche/tests/async_write.rs
@@ -1,0 +1,93 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    task::Poll,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use futures::poll;
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::io::AsyncWriteExt;
+use url::Url;
+use web_transport_quiche::{ClientBuilder, ServerBuilder, Settings};
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn flush_and_shutdown_complete_after_returning_pending() -> Result<()> {
+    let (chain, key) = make_self_signed()?;
+
+    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let server_addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("server accept")?;
+        let session = request.ok().await.context("server session")?;
+        let mut recv = session.accept_uni().await.context("accept stream")?;
+        let data = recv.read_all(1024).await.context("read stream")?;
+        anyhow::ensure!(data.as_ref() == b"hello", "unexpected stream contents");
+        anyhow::Ok(())
+    });
+
+    let mut client_settings = Settings::default();
+    client_settings.verify_peer = false;
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", server_addr.port()))?;
+    let client = ClientBuilder::default()
+        .with_settings(client_settings)
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?;
+
+    let session = client
+        .connect(url)
+        .await?
+        .established()
+        .await
+        .context("client handshake")?;
+
+    let mut send = session.open_uni().await.context("open stream")?;
+    send.write_all(b"hello").await.context("write stream")?;
+
+    // The current-thread runtime cannot run the driver between these statements,
+    // so the data is still in SendState's queue on the first flush poll.
+    let mut flush = Box::pin(send.flush());
+    assert!(matches!(poll!(&mut flush), Poll::Pending));
+    tokio::time::timeout(Duration::from_secs(5), flush)
+        .await
+        .context("flush timed out")??;
+
+    // The first shutdown poll initiates FIN and must return Pending. A subsequent
+    // poll must continue waiting for FIN instead of calling finish() a second time.
+    let mut shutdown = Box::pin(send.shutdown());
+    assert!(matches!(poll!(&mut shutdown), Poll::Pending));
+    tokio::time::timeout(Duration::from_secs(5), shutdown)
+        .await
+        .context("shutdown timed out")??;
+
+    server_task
+        .await
+        .context("server task panicked")?
+        .context("server task errored")?;
+
+    session.close(0, "bye");
+    session.closed().await;
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #300.

## What changed

- make `AsyncWrite::poll_shutdown` initiate FIN only once, then continue polling close progress
- make `AsyncWrite::poll_flush` wait until the internal send queue is drained
- wake flush waiters when queued data drains, even when no additional write capacity is available
- add a current-thread loopback regression test that forces both flush and shutdown to return `Pending` on their first poll

## Root cause and impact

`poll_shutdown` previously called the non-idempotent `finish()` method on every poll. If the first poll initiated FIN but returned `Pending`, the next poll called `finish()` again and surfaced `StreamError::Closed`. Separately, `poll_flush` returned success while bytes could still be queued in `SendState`.

The fix preserves FIN initiation state across polls and defines flush completion in terms of draining the internal queue.

## Validation

- `cargo test -p web-transport-quiche` (8 tests passed)
- `cargo clippy -p web-transport-quiche --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
