### PR TITLE
fix(qmux): honor RESET_STREAM final sizes

### DIFF
--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -89,6 +89,18 @@ describe("QMux01 record framing", () => {
 		expect(respDecoded[0]).toEqual({ type: "ping_response", sequence: 0xdeadbeefn });
 	});
 
+	test("RESET_STREAM round-trip preserves final_size", () => {
+		const frame: Frame.ResetStream = {
+			type: "reset_stream",
+			id: new Stream.Id(VarInt.from(4n)),
+			code: VarInt.from(42n),
+			finalSize: 128n,
+		};
+		const decoded = Frame.decodeRecord(Frame.encode(frame, "qmux-01"));
+		expect(decoded).toHaveLength(1);
+		expect(decoded[0]).toEqual(frame);
+	});
+
 	test("datagram round-trips via the length-prefixed (0x31) form", () => {
 		const frame: Frame.Any = { type: "datagram", data: new Uint8Array([1, 2, 3, 4]) };
 		const bytes = Frame.encode(frame, "qmux-01");
@@ -175,6 +187,7 @@ describe("QMux02 (draft-02)", () => {
 		if (decoded?.type === "reset_stream") {
 			expect(decoded.id.value.value).toBe(4n);
 			expect(decoded.code.value).toBe(42n);
+			expect(decoded.finalSize).toBe(128n);
 			// reliableSize present marks it as RESET_STREAM_AT (vs a plain 0x04 reset,
 			// which leaves it undefined); the session uses this to gate on negotiation.
 			expect(decoded.reliableSize).toBe(64n);

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -26,6 +26,9 @@ export interface ResetStream {
 	type: "reset_stream";
 	id: Stream.Id;
 	code: VarInt;
+	/** Final byte offset consumed by the send side. The legacy WebTransport wire
+	 * format omits this field and decodes it as zero. */
+	finalSize: bigint;
 	/** Set (to the frame's Reliable Size) when this was decoded from a
 	 * RESET_STREAM_AT frame (0x24, draft-02); absent for a plain RESET_STREAM.
 	 * The session uses its presence to enforce that RESET_STREAM_AT is only
@@ -329,7 +332,7 @@ function encodeQMux(frame: Any): Uint8Array {
 
 		case "reset_stream": {
 			const frameType = VarInt.from(0x04);
-			const finalSize = VarInt.from(0);
+			const finalSize = VarInt.from(frame.finalSize);
 
 			let buffer = new Uint8Array(new ArrayBuffer(8 + 8 + 8 + 8), 0, 0);
 
@@ -673,7 +676,7 @@ function decodeWebTransport(buffer: Uint8Array): Any {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 
-		return { type: "reset_stream", id, code };
+		return { type: "reset_stream", id, code, finalSize: 0n };
 	}
 
 	if (frameType === 0x05) {
@@ -758,10 +761,10 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
 
-		// Skip final_size
 		[v, buffer] = VarInt.decode(buffer);
+		const finalSize = v.value;
 
-		return { type: "reset_stream", id, code };
+		return { type: "reset_stream", id, code, finalSize };
 	}
 
 	// RESET_STREAM_AT (draft-02). On a reliable, ordered transport all stream data
@@ -779,7 +782,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		if (reliableSize > finalSize) {
 			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
 		}
-		return { type: "reset_stream", id, code, reliableSize };
+		return { type: "reset_stream", id, code, finalSize, reliableSize };
 	}
 
 	// STOP_SENDING
@@ -954,8 +957,9 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		const id = new Stream.Id(v);
 		[v, buffer] = VarInt.decode(buffer);
 		const code = v;
-		[v, buffer] = VarInt.decode(buffer); // final_size
-		return [{ type: "reset_stream", id, code }, buffer];
+		[v, buffer] = VarInt.decode(buffer);
+		const finalSize = v.value;
+		return [{ type: "reset_stream", id, code, finalSize }, buffer];
 	}
 
 	// RESET_STREAM_AT (draft-02); see the single-frame decoder for the semantics.
@@ -971,7 +975,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		if (reliableSize > finalSize) {
 			throw new Error("RESET_STREAM_AT reliable_size exceeds final_size");
 		}
-		return [{ type: "reset_stream", id, code, reliableSize }, buffer];
+		return [{ type: "reset_stream", id, code, finalSize, reliableSize }, buffer];
 	}
 
 	// STOP_SENDING

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -225,6 +225,76 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
+	test("aborting after a write sends the transmitted byte count as final_size", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		const writer = writable.getWriter();
+		await writer.write(new Uint8Array([1, 2, 3]));
+		await writer.abort(new Error("cancel"));
+
+		await waitFor(() => peer.has("reset_stream"));
+		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
+		expect(reset.finalSize).toBe(3n);
+		session.close();
+	});
+
+	test("a RESET_STREAM received first keeps the stream terminal", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(5n, Stream.Dir.Uni, true);
+		peer.send({ type: "reset_stream", id, code: VarInt.from(0), finalSize: 0n });
+		peer.send({ type: "stream", id, data: new Uint8Array([1, 2, 3]), fin: false });
+		peer.send({ type: "ping_request", sequence: 1n });
+		await waitFor(() => peer.has("ping_response"));
+
+		const reader = session.incomingUnidirectionalStreams.getReader();
+		const next = reader.read();
+		const resurrected = await Promise.race([
+			next.then(() => true),
+			new Promise<false>((resolve) => setTimeout(() => resolve(false), 50)),
+		]);
+		expect(resurrected).toBe(false);
+		session.close();
+		await next;
+		reader.releaseLock();
+	});
+
+	test("RESET_STREAM final_size consumes connection flow control", async () => {
+		const { session, peer } = connect({ maxData: 4n, maxStreamDataUni: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({
+			type: "reset_stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+			code: VarInt.from(0),
+			finalSize: 5n,
+		});
+
+		const err = await expectSessionFailure(session);
+		expect(err.message).toContain("flow control error");
+		await waitFor(() => sentCloseCode(peer) === 1002);
+	});
+
+	test("draft-01 tolerates the legacy zero final_size after data", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		peer.send({ type: "stream", id, data: new Uint8Array([1, 2, 3]), fin: false });
+		peer.send({ type: "reset_stream", id, code: VarInt.from(0), finalSize: 0n });
+		peer.send({ type: "ping_request", sequence: 1n });
+		await waitFor(() => peer.has("ping_response"));
+		expect(peer.has("connection_close")).toBe(false);
+		session.close();
+	});
+
 	test("close() sends APPLICATION_CLOSE, resolves closed, and is idempotent", async () => {
 		const { session, peer } = connect();
 		await session.ready;

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -286,25 +286,43 @@ describe("Session integration (scripted peer)", () => {
 		await session.ready;
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
-		// The reset-only stream consumes six bytes of connection credit even though
-		// no STREAM frame carried them. Five bytes on a second stream then exceed
-		// MAX_DATA (6 + 5 > 10).
+		// Three bytes do not cross the receive-window replenishment threshold. Eight
+		// bytes on a second stream therefore exceed MAX_DATA (3 + 8 > 10), proving
+		// the reset-only final size shares the cumulative connection budget.
 		peer.send({
 			type: "reset_stream",
 			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
 			code: VarInt.from(0),
-			finalSize: 6n,
+			finalSize: 3n,
 		});
 		peer.send({
 			type: "stream",
 			id: Stream.Id.create(1n, Stream.Dir.Uni, true),
-			data: new Uint8Array(5),
+			data: new Uint8Array(8),
 			fin: false,
 		});
 
 		const err = await expectSessionFailure(session);
 		expect(err.message).toContain("flow control error");
 		await waitFor(() => sentCloseCode(peer) === 1002);
+	});
+
+	test("RESET_STREAM final_size replenishes connection credit once discarded", async () => {
+		const { session, peer } = connect({ maxData: 10n, maxStreamDataUni: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({
+			type: "reset_stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+			code: VarInt.from(0),
+			finalSize: 6n,
+		});
+
+		await waitFor(() => peer.has("max_data"));
+		const update = peer.received().find((frame) => frame.type === "max_data") as Frame.MaxData;
+		expect(update.max).toBe(16n);
+		session.close();
 	});
 
 	test("draft-01 tolerates the legacy zero final_size after data", async () => {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -281,6 +281,32 @@ describe("Session integration (scripted peer)", () => {
 		await waitFor(() => sentCloseCode(peer) === 1002);
 	});
 
+	test("RESET_STREAM final_size is cumulative with later stream data for MAX_DATA", async () => {
+		const { session, peer } = connect({ maxData: 10n, maxStreamDataUni: 10n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		// The reset-only stream consumes six bytes of connection credit even though
+		// no STREAM frame carried them. Five bytes on a second stream then exceed
+		// MAX_DATA (6 + 5 > 10).
+		peer.send({
+			type: "reset_stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+			code: VarInt.from(0),
+			finalSize: 6n,
+		});
+		peer.send({
+			type: "stream",
+			id: Stream.Id.create(1n, Stream.Dir.Uni, true),
+			data: new Uint8Array(5),
+			fin: false,
+		});
+
+		const err = await expectSessionFailure(session);
+		expect(err.message).toContain("flow control error");
+		await waitFor(() => sentCloseCode(peer) === 1002);
+	});
+
 	test("draft-01 tolerates the legacy zero final_size after data", async () => {
 		const { session, peer } = connect();
 		await session.ready;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -411,9 +411,37 @@ function parseProtocol(raw: string, version: WireFormat): string {
 /** Per-stream flow control state. */
 interface StreamFlowState {
 	sendCredit: Credit;
+	/** Bytes that have actually reached the transport for this send half. */
+	sendOffset: bigint;
 	recvMax: bigint;
 	recvOffset: bigint;
 	recvConsumed: bigint;
+}
+
+/** Compact open/terminal tracking for peer-initiated receive streams.
+ *
+ * Opening stream N implicitly opens every lower stream. `holes` distinguishes
+ * one of those not-yet-seen streams from an id whose receive half has already
+ * reached FIN or RESET_STREAM, so a late STREAM frame cannot resurrect it. */
+class RecvOpen {
+	#createdMax?: bigint;
+	#holes = new Set<bigint>();
+
+	isClosed(index: bigint): boolean {
+		return this.#createdMax !== undefined && index <= this.#createdMax && !this.#holes.has(index);
+	}
+
+	record(index: bigint) {
+		if (this.#createdMax !== undefined && index <= this.#createdMax) {
+			this.#holes.delete(index);
+			return;
+		}
+
+		for (let hole = (this.#createdMax ?? -1n) + 1n; hole < index; hole++) {
+			this.#holes.add(hole);
+		}
+		this.#createdMax = index;
+	}
 }
 
 export default class Session implements WebTransport {
@@ -480,6 +508,8 @@ export default class Session implements WebTransport {
 
 	// Per-stream flow control
 	#streamFlow = new Map<bigint, StreamFlowState>();
+	#recvOpenBi = new RecvOpen();
+	#recvOpenUni = new RecvOpen();
 
 	// Stream count tracking via Credit (for sending — peer's limits).
 	// Initialized to "unlimited" matching the default webtransport version;
@@ -1002,6 +1032,42 @@ export default class Session implements WebTransport {
 		}
 	}
 
+	#recvOpen(dir: Stream.DirType): RecvOpen {
+		return dir === Stream.Dir.Bi ? this.#recvOpenBi : this.#recvOpenUni;
+	}
+
+	/** Account the previously-unseen tail declared by RESET_STREAM.
+	 *
+	 * Drafts through -02 were emitted by implementations that used an incorrect
+	 * zero final size, so tolerate a value below the bytes already received. The
+	 * stricter FINAL_SIZE_ERROR check starts with draft-03; meanwhile the larger
+	 * of the two values still prevents a reset from undoing flow-control usage. */
+	#accountReset(frame: Frame.ResetStream): boolean {
+		if (!isQmux(this.#version)) return true;
+
+		const streamId = frame.id.value.value;
+		const flow = this.#streamFlow.get(streamId);
+		const received = flow?.recvOffset ?? 0n;
+		// TODO(qmux-03): Once draft-03 is implemented, reject finalSize < received
+		// (and conflicting terminal final sizes) with FINAL_SIZE_ERROR instead of
+		// applying this draft-00/-01/-02 compatibility fallback.
+		const finalSize = frame.finalSize > received ? frame.finalSize : received;
+		const gap = finalSize - received;
+
+		const recvMax =
+			flow?.recvMax ??
+			(frame.id.dir === Stream.Dir.Bi
+				? this.#ourParams.initialMaxStreamDataBidiRemote
+				: this.#ourParams.initialMaxStreamDataUni);
+		if (finalSize > recvMax || this.#recvDataOffset + gap > this.#recvDataMax) {
+			return false;
+		}
+
+		this.#recvDataOffset += gap;
+		if (flow) flow.recvOffset = finalSize;
+		return true;
+	}
+
 	/** Delete stream flow state only when both send and recv sides are gone. */
 	#maybeDeleteStreamFlow(streamId: bigint) {
 		if (!this.#sendStreams.has(streamId) && !this.#recvStreams.has(streamId)) {
@@ -1032,6 +1098,14 @@ export default class Session implements WebTransport {
 		}
 
 		let recv = this.#recvStreams.get(streamId);
+		if (
+			isQmux(this.#version) &&
+			frame.id.serverInitiated !== this.#isServer &&
+			!recv &&
+			this.#recvOpen(frame.id.dir).isClosed(frame.id.index)
+		) {
+			return;
+		}
 		if (!recv) {
 			// We created the stream, we can skip it.
 			if (frame.id.serverInitiated === this.#isServer) {
@@ -1051,6 +1125,7 @@ export default class Session implements WebTransport {
 					this.#abort(1002, "stream limit exceeded");
 					return;
 				}
+				this.#recvOpen(frame.id.dir).record(frame.id.index);
 			}
 
 			// Initialize flow control state for new stream
@@ -1065,6 +1140,7 @@ export default class Session implements WebTransport {
 
 				this.#streamFlow.set(streamId, {
 					sendCredit: new Credit(sendMax),
+					sendOffset: 0n,
 					recvMax,
 					recvOffset: 0n,
 					recvConsumed: 0n,
@@ -1137,6 +1213,7 @@ export default class Session implements WebTransport {
 							type: "reset_stream",
 							id: frame.id,
 							code: VarInt.from(0),
+							finalSize: this.#sendFinalSize(streamId),
 						});
 
 						this.#sendStreams.delete(streamId);
@@ -1194,10 +1271,44 @@ export default class Session implements WebTransport {
 		if (frame.reliableSize !== undefined && !this.#ourParams.resetStreamAt) {
 			throw new Error("RESET_STREAM_AT received without advertising reset_stream_at");
 		}
+		if (!frame.id.canRecv(this.#isServer)) {
+			throw new Error("Invalid stream ID direction");
+		}
 
 		const streamId = frame.id.value.value;
 		const recv = this.#recvStreams.get(streamId);
-		if (!recv) return;
+		const peerInitiated = frame.id.serverInitiated !== this.#isServer;
+
+		if (!recv) {
+			// A terminal peer-initiated stream stays terminal. In particular, a
+			// duplicate RESET must not consume its final size twice.
+			if (isQmux(this.#version) && peerInitiated && this.#recvOpen(frame.id.dir).isClosed(frame.id.index)) {
+				return;
+			}
+			// A locally-created receive half that is no longer live is already closed.
+			if (!peerInitiated) return;
+
+			if (isQmux(this.#version)) {
+				const credit = frame.id.dir === Stream.Dir.Bi ? this.#recvBiCredit : this.#recvUniCredit;
+				if (!credit.receiveUpTo(frame.id.index + 1n)) {
+					this.#sendConnectionClose(1002, "stream limit exceeded");
+					this.#abort(1002, "stream limit exceeded");
+					return;
+				}
+			}
+		}
+
+		if (!this.#accountReset(frame)) {
+			this.#sendConnectionClose(1002, "flow control error");
+			this.#abort(1002, "flow control error");
+			return;
+		}
+
+		if (!recv) {
+			if (isQmux(this.#version)) this.#recvOpen(frame.id.dir).record(frame.id.index);
+			this.#replenishStreamCredit(frame.id.dir);
+			return;
+		}
 
 		this.#accountConnConsumed(recv.reset(new Error(`RESET_STREAM: ${frame.code.value}`)));
 		this.#recvStreams.delete(streamId);
@@ -1217,9 +1328,14 @@ export default class Session implements WebTransport {
 			type: "reset_stream",
 			id: frame.id,
 			code: frame.code,
+			finalSize: this.#sendFinalSize(streamId),
 		});
 
 		this.#maybeDeleteStreamFlow(streamId);
+	}
+
+	#sendFinalSize(streamId: bigint): bigint {
+		return this.#streamFlow.get(streamId)?.sendOffset ?? 0n;
 	}
 
 	#sendTransportParameters() {
@@ -1272,6 +1388,8 @@ export default class Session implements WebTransport {
 
 			try {
 				await this.#enqueueStreamFrame(streamId, { type: "stream", id, data: chunk, fin: false });
+				const flow = this.#streamFlow.get(streamId);
+				if (flow) flow.sendOffset += BigInt(sendable);
 			} catch (e) {
 				// Return claimed credits on send failure
 				if (sendable > 0) {
@@ -1362,6 +1480,7 @@ export default class Session implements WebTransport {
 		if (isQmux(this.#version)) {
 			this.#streamFlow.set(streamIdVal, {
 				sendCredit: new Credit(this.#peerParams.initialMaxStreamDataBidiRemote),
+				sendOffset: 0n,
 				recvMax: this.#ourParams.initialMaxStreamDataBidiLocal,
 				recvOffset: 0n,
 				recvConsumed: 0n,
@@ -1382,6 +1501,7 @@ export default class Session implements WebTransport {
 					type: "reset_stream",
 					id: streamId,
 					code: VarInt.from(0),
+					finalSize: this.#sendFinalSize(streamIdVal),
 				});
 
 				this.#sendStreams.delete(streamIdVal);
@@ -1438,6 +1558,7 @@ export default class Session implements WebTransport {
 		if (isQmux(this.#version)) {
 			this.#streamFlow.set(streamIdVal, {
 				sendCredit: new Credit(this.#peerParams.initialMaxStreamDataUni),
+				sendOffset: 0n,
 				recvMax: 0n,
 				recvOffset: 0n,
 				recvConsumed: 0n,
@@ -1460,6 +1581,7 @@ export default class Session implements WebTransport {
 					type: "reset_stream",
 					id: streamId,
 					code: VarInt.from(0),
+					finalSize: session.#sendFinalSize(streamIdVal),
 				});
 
 				session.#sendStreams.delete(streamIdVal);

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -967,8 +967,8 @@ export default class Session implements WebTransport {
 	 *  application or deliberately discarded, never merely on receipt. This keeps
 	 *  completed-but-unread streams inside the aggregate receive-memory window.
 	 *  `recvDataConsumed` is cumulative. */
-	#accountConnConsumed(bytes: number) {
-		if (!isQmux(this.#version) || bytes === 0) return;
+	#accountConnConsumed(bytes: number | bigint) {
+		if (!isQmux(this.#version) || bytes === 0 || bytes === 0n) return;
 		this.#recvDataConsumed += BigInt(bytes);
 		this.#maybeSendMaxData();
 	}
@@ -1042,8 +1042,8 @@ export default class Session implements WebTransport {
 	 * zero final size, so tolerate a value below the bytes already received. The
 	 * stricter FINAL_SIZE_ERROR check starts with draft-03; meanwhile the larger
 	 * of the two values still prevents a reset from undoing flow-control usage. */
-	#accountReset(frame: Frame.ResetStream): boolean {
-		if (!isQmux(this.#version)) return true;
+	#accountReset(frame: Frame.ResetStream): bigint | null {
+		if (!isQmux(this.#version)) return 0n;
 
 		const streamId = frame.id.value.value;
 		const flow = this.#streamFlow.get(streamId);
@@ -1060,12 +1060,12 @@ export default class Session implements WebTransport {
 				? this.#ourParams.initialMaxStreamDataBidiRemote
 				: this.#ourParams.initialMaxStreamDataUni);
 		if (finalSize > recvMax || this.#recvDataOffset + gap > this.#recvDataMax) {
-			return false;
+			return null;
 		}
 
 		this.#recvDataOffset += gap;
 		if (flow) flow.recvOffset = finalSize;
-		return true;
+		return gap;
 	}
 
 	/** Delete stream flow state only when both send and recv sides are gone. */
@@ -1298,19 +1298,25 @@ export default class Session implements WebTransport {
 			}
 		}
 
-		if (!this.#accountReset(frame)) {
+		const resetGap = this.#accountReset(frame);
+		if (resetGap === null) {
 			this.#sendConnectionClose(1002, "flow control error");
 			this.#abort(1002, "flow control error");
 			return;
 		}
 
 		if (!recv) {
+			// The final-size gap consumes connection flow control, but it can never
+			// occupy receive memory, so it is immediately eligible to replenish the
+			// connection window.
+			this.#accountConnConsumed(resetGap);
 			if (isQmux(this.#version)) this.#recvOpen(frame.id.dir).record(frame.id.index);
 			this.#replenishStreamCredit(frame.id.dir);
 			return;
 		}
 
-		this.#accountConnConsumed(recv.reset(new Error(`RESET_STREAM: ${frame.code.value}`)));
+		const discarded = recv.reset(new Error(`RESET_STREAM: ${frame.code.value}`));
+		this.#accountConnConsumed(resetGap + BigInt(discarded));
 		this.#recvStreams.delete(streamId);
 		this.#maybeDeleteStreamFlow(streamId);
 	}

--- a/js/qmux/src/wire-format.test.ts
+++ b/js/qmux/src/wire-format.test.ts
@@ -71,6 +71,7 @@ describe("WebTransport wire format", () => {
 			type: "reset_stream",
 			id: sid(4n),
 			code: code(42n),
+			finalSize: 0n,
 		};
 		const decoded = Frame.decode(wire, "webtransport") as Frame.ResetStream;
 		expect(decoded.type).toBe("reset_stream");

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -225,16 +225,24 @@ impl PriorityQueue {
     }
 
     /// Drop every queued frame for `id`, unscheduling it and freeing the
-    /// capacity they held. Used when a stream is reset: any STREAM data still
-    /// buffered here must not reach the wire *after* the RESET_STREAM, or it's
-    /// post-terminal data that wastes congestion window on a stream the peer has
-    /// already abandoned. No-op if the stream has nothing queued.
-    pub fn remove(&self, id: StreamId) {
+    /// capacity they held. Returns the number of queued STREAM payload bytes
+    /// removed so the caller can return flow-control credit that never reached
+    /// the wire. Used when a stream is reset: buffered STREAM data must not trail
+    /// RESET_STREAM. Returns zero if the stream has nothing queued.
+    pub fn remove(&self, id: StreamId) -> u64 {
         let mut inner = self.inner.lock().unwrap();
         let Some(slot) = inner.streams.remove(&id) else {
-            return;
+            return 0;
         };
         let removed = slot.frames.len();
+        let removed_bytes = slot
+            .frames
+            .iter()
+            .map(|frame| match frame {
+                Frame::Stream(stream) => stream.data.len() as u64,
+                _ => 0,
+            })
+            .sum();
 
         // Unschedule it from its band (it's scheduled iff it had frames, which it
         // did). `slot.priority` is the single source of truth for which band.
@@ -254,6 +262,7 @@ impl PriorityQueue {
         for _ in 0..removed {
             self.has_space.notify_one();
         }
+        removed_bytes
     }
 
     /// Close the queue, unblocking any blocked producers and the consumer.
@@ -422,7 +431,7 @@ mod tests {
         q.push(5, b, frame(b, 9)).await.unwrap();
 
         // Reset `a`: its queued frames vanish, `b`'s survive.
-        q.remove(a);
+        assert_eq!(q.remove(a), 2);
 
         assert_eq!(id_of(&q.pop().await.unwrap()), b);
         // Nothing left: the next pop blocks, so a closed-drain returns None.
@@ -445,7 +454,7 @@ mod tests {
         assert!(!pushing.is_finished(), "push should block while full");
 
         // Removing `a` frees both slots and wakes the blocked producer.
-        q.remove(a);
+        assert_eq!(q.remove(a), 2);
         pushing.await.unwrap().unwrap();
         assert_eq!(id_of(&q.pop().await.unwrap()), b);
     }
@@ -453,6 +462,6 @@ mod tests {
     #[tokio::test]
     async fn remove_unknown_stream_is_noop() {
         let q = PriorityQueue::new(8);
-        q.remove(sid(99)); // must not panic or underflow
+        assert_eq!(q.remove(sid(99)), 0); // must not panic or underflow
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -470,10 +470,20 @@ impl<W: Writer> WriterState<W> {
     /// Retire the stream a terminal frame closes, encode the frame (validating its
     /// size for QMux01), and write it. The `streams` lock is only held for the
     /// synchronous retirement, never across the `send` await.
-    async fn transmit(&mut self, frame: Frame) -> Result<(), Error> {
-        match &frame {
+    async fn transmit(&mut self, mut frame: Frame) -> Result<(), Error> {
+        let transmitted_stream = match &frame {
+            Frame::Stream(stream) if !stream.fin => Some((stream.id, stream.data.len() as u64)),
+            _ => None,
+        };
+
+        match &mut frame {
             Frame::ResetStream(reset) => {
-                self.streams.lock().unwrap().send.remove(&reset.id);
+                // The frontend offset includes frames that may still be queued.
+                // RESET_STREAM is a priority frame and drops that backlog, so its
+                // final size must come from bytes this writer actually emitted.
+                if let Some(send) = self.streams.lock().unwrap().send.remove(&reset.id) {
+                    reset.final_size = send.sent_offset;
+                }
             }
             Frame::Stream(stream) if stream.fin => {
                 self.streams.lock().unwrap().send.remove(&stream.id);
@@ -502,12 +512,99 @@ impl<W: Writer> WriterState<W> {
         let result = self.writer.send(bytes).await;
         self.writer_backpressured.store(false, Ordering::Release);
         result?;
+        if let Some((id, len)) = transmitted_stream {
+            if let Some(send) = self.streams.lock().unwrap().send.get_mut(&id) {
+                send.sent_offset += len;
+            }
+        }
         // Publish send progress for the timer's keep-alive and idle scheduling.
         self.last_send_at.store(
             millis_since(self.base, tokio::time::Instant::now()),
             Ordering::Release,
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod writer_final_size_tests {
+    use super::*;
+
+    struct CaptureWriter(Arc<Mutex<Vec<Bytes>>>);
+
+    impl Writer for CaptureWriter {
+        async fn send(&mut self, data: Bytes) -> Result<(), Error> {
+            self.0.lock().unwrap().push(data);
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn reset_uses_bytes_transmitted_not_frontend_offset() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let streams = Arc::new(Mutex::new(Streams::default()));
+        let id = StreamId::new(0, StreamDir::Uni, false);
+        let (stopped, _stopped_rx) = mpsc::unbounded_channel();
+        streams.lock().unwrap().send.insert(
+            id,
+            SendState {
+                inbound_stopped: stopped,
+                sent_offset: 0,
+                stream_credit: None,
+            },
+        );
+
+        let (_control_tx, control) = mpsc::unbounded_channel();
+        let (_datagram_tx, datagrams) = mpsc::channel(1);
+        let mut writer = WriterState {
+            writer: CaptureWriter(sent.clone()),
+            version: Version::QMux01,
+            control,
+            datagrams,
+            outbound: PriorityQueue::new(1),
+            streams,
+            record_limit: Arc::new(AtomicU64::new(u64::MAX)),
+            writer_backpressured: Arc::new(AtomicBool::new(false)),
+            closed: watch::Sender::new(None),
+            base: tokio::time::Instant::now(),
+            last_send_at: Arc::new(AtomicU64::new(0)),
+        };
+
+        writer
+            .transmit(
+                Stream {
+                    id,
+                    data: Bytes::from_static(b"abc"),
+                    fin: false,
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+        writer
+            .transmit(
+                ResetStream {
+                    id,
+                    code: VarInt::from_u32(0),
+                    // Simulate a frontend offset that also included queued data.
+                    final_size: 99,
+                    reliable_size: None,
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        let wire = sent.lock().unwrap()[1].clone();
+        let decoded = Frame::decode(wire, Version::QMux01).unwrap().unwrap();
+        let Frame::ResetStream(reset) = decoded else {
+            panic!("expected RESET_STREAM");
+        };
+        assert_eq!(reset.final_size, 3);
     }
 }
 
@@ -767,10 +864,11 @@ impl<R: Reader> SessionState<R> {
                 // a brief lock (never held across an await).
                 {
                     let mut streams = self.streams.lock().unwrap();
-                    if let Some(recv) = streams.recv.get(&stream.id) {
+                    if let Some(recv) = streams.recv.get_mut(&stream.id) {
                         if data_len > 0 && !recv.recv_credit.receive(data_len) {
                             return Err(Error::FlowControlError);
                         }
+                        recv.recv_offset += data_len;
                         // An empty STREAM without FIN carries no state beyond
                         // opening the stream. Once the stream exists, queuing one
                         // only allocates an unbounded-channel node without using
@@ -839,6 +937,7 @@ impl<R: Reader> SessionState<R> {
                     inbound_data: tx,
                     inbound_reset: tx2,
                     recv_credit: recv_credit.clone(),
+                    recv_offset: data_len,
                 };
 
                 let recv_streams_credit = if self.config.version.is_qmux() {
@@ -878,6 +977,7 @@ impl<R: Reader> SessionState<R> {
                         let (tx, rx) = mpsc::unbounded_channel();
                         let send_backend = SendState {
                             inbound_stopped: tx,
+                            sent_offset: 0,
                             stream_credit: if self.config.version.is_qmux() {
                                 // Peer opened this bidi stream, so our send limit
                                 // is their bidi_local (they are local to this stream)
@@ -947,9 +1047,78 @@ impl<R: Reader> SessionState<R> {
                     return Err(Error::InvalidStreamId);
                 }
 
+                let reset_id = reset.id;
+                let peer_initiated = reset_id.server_initiated() != self.is_server;
+                let live = self.streams.lock().unwrap().recv.contains_key(&reset_id);
+
+                if !live {
+                    // A terminal peer-initiated stream stays terminal. In
+                    // particular, a duplicate RESET must not consume its final
+                    // size twice. A locally-created receive half that is absent is
+                    // likewise already closed.
+                    if !peer_initiated {
+                        return Ok(());
+                    }
+                    if self.config.version.is_qmux()
+                        && self.recv_open(reset_id.dir()).is_closed(reset_id.index())
+                    {
+                        return Ok(());
+                    }
+
+                    // RESET_STREAM can be the first frame for a peer-initiated
+                    // stream and therefore implicitly opens its index.
+                    if self.config.version.is_qmux() {
+                        let credit = match reset_id.dir() {
+                            StreamDir::Bi => &self.recv_bi_credit,
+                            StreamDir::Uni => &self.recv_uni_credit,
+                        };
+                        if !credit.receive_up_to(reset_id.index() + 1) {
+                            return Err(Error::StreamLimitExceeded);
+                        }
+                    }
+                }
+
+                if self.config.version.is_qmux() {
+                    let received = self
+                        .streams
+                        .lock()
+                        .unwrap()
+                        .recv
+                        .get(&reset_id)
+                        .map_or(0, |recv| recv.recv_offset);
+
+                    // Drafts through -02 were emitted by implementations that
+                    // incorrectly used zero here. Preserve compatibility by never
+                    // letting that value reduce bytes already received; strict
+                    // FINAL_SIZE_ERROR validation begins with draft-03.
+                    // TODO(qmux-03): Once draft-03 is implemented, reject
+                    // reset.final_size < received (and conflicting terminal final
+                    // sizes) with FINAL_SIZE_ERROR instead of taking the maximum.
+                    let final_size = reset.final_size.max(received);
+                    let gap = final_size - received;
+
+                    let stream_ok = if live {
+                        let mut streams = self.streams.lock().unwrap();
+                        let recv = streams.recv.get_mut(&reset_id).expect("live recv stream");
+                        let ok = recv.recv_credit.receive(gap);
+                        if ok {
+                            recv.recv_offset = final_size;
+                        }
+                        ok
+                    } else {
+                        let recv_max = match reset_id.dir() {
+                            StreamDir::Bi => self.our_params.initial_max_stream_data_bidi_remote,
+                            StreamDir::Uni => self.our_params.initial_max_stream_data_uni,
+                        };
+                        final_size <= recv_max
+                    };
+                    if !stream_ok || !self.conn_recv_credit.receive(gap) {
+                        return Err(Error::FlowControlError);
+                    }
+                }
+
                 // Live stream: deliver the reset and drop it (it was recorded in
                 // `recv_open` at creation, so it now reads as closed).
-                let reset_id = reset.id;
                 let delivered = {
                     let mut streams = self.streams.lock().unwrap();
                     if let Some(recv) = streams.recv.remove(&reset_id) {
@@ -959,28 +1128,25 @@ impl<R: Reader> SessionState<R> {
                         false
                     }
                 };
-                if !delivered
-                    && self.config.version.is_qmux()
-                    && reset_id.server_initiated() != self.is_server
-                {
-                    // RESET_STREAM can be the *first* frame for a peer-initiated
-                    // stream (it implicitly opens the id). Record it as closed so a
-                    // later STREAM on the same id is recognized as retired rather than
-                    // resurrected into a new accepted stream. Gate on the stream limit
-                    // first (mirroring the STREAM path) so the hole set stays bounded
-                    // by MAX_STREAMS.
-                    let credit = match reset_id.dir() {
-                        StreamDir::Bi => &self.recv_bi_credit,
-                        StreamDir::Uni => &self.recv_uni_credit,
-                    };
-                    if !credit.receive_up_to(reset_id.index() + 1) {
-                        return Err(Error::StreamLimitExceeded);
-                    }
+                if !delivered && self.config.version.is_qmux() && peer_initiated {
                     match reset_id.dir() {
                         StreamDir::Bi => &mut self.recv_open_bi,
                         StreamDir::Uni => &mut self.recv_open_uni,
                     }
                     .record(reset_id.index());
+
+                    // No frontend exists to replenish MAX_STREAMS on Drop.
+                    let credit = match reset_id.dir() {
+                        StreamDir::Bi => &self.recv_bi_credit,
+                        StreamDir::Uni => &self.recv_uni_credit,
+                    };
+                    if let Some(new_max) = credit.consume(1) {
+                        let frame = match reset_id.dir() {
+                            StreamDir::Bi => Frame::MaxStreamsBidi(new_max),
+                            StreamDir::Uni => Frame::MaxStreamsUni(new_max),
+                        };
+                        self.control.send(frame).ok();
+                    }
                 }
             }
             Frame::StopSending(stop) => {
@@ -1564,6 +1730,7 @@ impl generic::Session for Session {
 
         let send_backend = SendState {
             inbound_stopped: tx,
+            sent_offset: 0,
             stream_credit: stream_credit.clone(),
         };
         let send_frontend = SendStream {
@@ -1618,6 +1785,7 @@ impl generic::Session for Session {
 
         let send_backend = SendState {
             inbound_stopped: tx,
+            sent_offset: 0,
             stream_credit: stream_credit.clone(),
         };
         let send_frontend = SendStream {
@@ -1648,6 +1816,7 @@ impl generic::Session for Session {
             inbound_data: tx,
             inbound_reset: tx2,
             recv_credit: recv_credit.clone(),
+            recv_offset: 0,
         };
         let recv_frontend = RecvStream {
             id,
@@ -1764,6 +1933,8 @@ fn negotiate_protocol(is_server: bool, ours: &[String], peers: &[String]) -> Opt
 
 struct SendState {
     inbound_stopped: mpsc::UnboundedSender<StopSending>,
+    /// Bytes that the writer has successfully put on the transport.
+    sent_offset: u64,
     stream_credit: Option<Credit>,
 }
 
@@ -2007,6 +2178,7 @@ pub(crate) struct RecvState {
     inbound_data: mpsc::UnboundedSender<Stream>,
     inbound_reset: mpsc::UnboundedSender<ResetStream>,
     recv_credit: Credit,
+    recv_offset: u64,
 }
 
 /// The receive half of a multiplexed stream.
@@ -2417,14 +2589,14 @@ mod recv_open_tests {
 
     /// A client session fed by a scripted transport, plus the sender for inbound
     /// frames. QMux01, where the closed-stream tracking is active.
-    fn scripted_session() -> (Session, mpsc::UnboundedSender<Bytes>) {
+    fn scripted_session_with_config(config: Config) -> (Session, mpsc::UnboundedSender<Bytes>) {
         let (tx, rx) = mpsc::unbounded_channel();
-        let session = Session::new(
-            ScriptedTransport { incoming: rx },
-            false,
-            Config::new(Version::QMux01),
-        );
+        let session = Session::new(ScriptedTransport { incoming: rx }, false, config);
         (session, tx)
+    }
+
+    fn scripted_session() -> (Session, mpsc::UnboundedSender<Bytes>) {
+        scripted_session_with_config(Config::new(Version::QMux01))
     }
 
     /// Encode a STREAM frame on a server-initiated uni stream (peer-initiated and
@@ -2440,11 +2612,11 @@ mod recv_open_tests {
     }
 
     /// Encode a RESET_STREAM frame on a server-initiated uni stream.
-    fn uni_reset(index: u64) -> Bytes {
+    fn uni_reset(index: u64, final_size: u64) -> Bytes {
         Frame::ResetStream(ResetStream {
             id: StreamId::new(index, StreamDir::Uni, true),
             code: VarInt::from_u32(0),
-            final_size: 0,
+            final_size,
             reliable_size: None,
         })
         .encode(Version::QMux01)
@@ -2515,7 +2687,7 @@ mod recv_open_tests {
         let (session, tx) = scripted_session();
 
         // RESET arrives before any STREAM frame for this id, then a STREAM does.
-        tx.send(uni_reset(5)).unwrap();
+        tx.send(uni_reset(5, 0)).unwrap();
         tx.send(uni_stream(5, b"late", false)).unwrap();
 
         let accepted = tokio::time::timeout(Duration::from_millis(200), session.accept_uni()).await;
@@ -2557,6 +2729,51 @@ mod recv_open_tests {
             0,
             "empty non-FIN STREAM frames accumulated behind a stalled reader"
         );
+    }
+
+    /// A reset's final size consumes connection-level credit even when no STREAM
+    /// frame preceded it; otherwise reset-only streams bypass MAX_DATA entirely.
+    #[tokio::test]
+    async fn reset_final_size_consumes_connection_credit() {
+        let mut config = Config::new(Version::QMux01);
+        config.max_data = 4;
+        config.max_stream_data_uni = 10;
+        let (session, tx) = scripted_session_with_config(config);
+
+        tx.send(uni_reset(0, 5)).unwrap();
+
+        let err = tokio::time::timeout(Duration::from_secs(1), session.closed())
+            .await
+            .expect("session did not close on RESET_STREAM flow-control violation");
+        assert!(matches!(err, Error::FlowControlError), "got {err:?}");
+    }
+
+    /// Older QMux drafts were emitted by implementations that always wrote a
+    /// zero final size. Keep accepting those resets until draft-03 while still
+    /// retaining the stream's terminal state.
+    #[tokio::test]
+    async fn legacy_zero_final_size_after_data_is_tolerated() {
+        let (session, tx) = scripted_session();
+
+        tx.send(uni_stream(0, b"hello", false)).unwrap();
+        let mut recv = tokio::time::timeout(Duration::from_secs(1), session.accept_uni())
+            .await
+            .expect("accept_uni timed out")
+            .expect("accept_uni failed");
+        tx.send(uni_reset(0, 0)).unwrap();
+        let err = tokio::time::timeout(Duration::from_secs(1), recv.closed())
+            .await
+            .expect("reset was not delivered")
+            .expect_err("reset should close the receive stream");
+        assert!(matches!(err, Error::StreamReset(_)), "got {err:?}");
+
+        // The connection remains usable after tolerating the legacy value.
+        tx.send(uni_stream(1, b"ok", true)).unwrap();
+        let mut next = tokio::time::timeout(Duration::from_secs(1), session.accept_uni())
+            .await
+            .expect("connection closed after legacy reset")
+            .expect("accept_uni failed");
+        assert_eq!(next.read_all().await.unwrap().as_ref(), b"ok");
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -606,6 +606,41 @@ mod writer_final_size_tests {
         };
         assert_eq!(reset.final_size, 3);
     }
+
+    #[tokio::test]
+    async fn reset_returns_credit_reserved_for_dropped_frames() {
+        let id = StreamId::new(0, StreamDir::Uni, false);
+        let outbound = PriorityQueue::new(4);
+        let (priority, _priority_rx) = mpsc::unbounded_channel();
+        let (_stopped, stopped_rx) = mpsc::unbounded_channel();
+        let stream_credit = Credit::new(3);
+        let conn_credit = Credit::new(3);
+        let mut send = SendStream {
+            id,
+            outbound,
+            outbound_priority: priority,
+            inbound_stopped: stopped_rx,
+            offset: 0,
+            priority: 0,
+            closed: None,
+            fin: false,
+            stream_credit: Some(stream_credit.clone()),
+            conn_credit: Some(conn_credit.clone()),
+        };
+
+        assert_eq!(
+            generic::SendStream::write(&mut send, b"abc").await.unwrap(),
+            3
+        );
+        assert_eq!(stream_credit.try_claim(1), 0);
+        assert_eq!(conn_credit.try_claim(1), 0);
+
+        // All three bytes are still queued, so reset drops them. They are not
+        // part of the transmitted final size and must not consume flow control.
+        generic::SendStream::reset(&mut send, 0);
+        assert_eq!(stream_credit.try_claim(3), 3);
+        assert_eq!(conn_credit.try_claim(3), 3);
+    }
 }
 
 /// Timer task: the sole owner of the record-framed-draft idle timeout and
@@ -1975,8 +2010,11 @@ impl SendStream {
                 final_size: self.offset,
                 reliable_size: None,
             };
-            // Flush queued STREAM data so none trails the RESET_STREAM on the wire.
-            self.outbound.remove(self.id);
+            // Flush queued STREAM data so none trails RESET_STREAM, and return
+            // the connection/stream credit reserved for bytes that never reached
+            // the wire. The reset final size only consumes transmitted bytes.
+            let dropped = self.outbound.remove(self.id);
+            self.release_credit(dropped);
             self.outbound_priority.send(frame.into()).ok();
         }
         self.closed = Some(error.clone());
@@ -2135,7 +2173,8 @@ impl generic::SendStream for SendStream {
         // Flush any STREAM data still queued for this stream: it must not go out
         // after the RESET_STREAM, where it would be post-terminal data burning
         // congestion window on a stream the peer has abandoned.
-        self.outbound.remove(self.id);
+        let dropped = self.outbound.remove(self.id);
+        self.release_credit(dropped);
         self.outbound_priority.send(frame.into()).ok();
         self.closed = Some(Error::StreamReset(code));
     }
@@ -2745,6 +2784,24 @@ mod recv_open_tests {
         let err = tokio::time::timeout(Duration::from_secs(1), session.closed())
             .await
             .expect("session did not close on RESET_STREAM flow-control violation");
+        assert!(matches!(err, Error::FlowControlError), "got {err:?}");
+    }
+
+    /// Reset-only final sizes and ordinary STREAM payloads share the same
+    /// cumulative MAX_DATA budget across streams.
+    #[tokio::test]
+    async fn reset_final_size_is_cumulative_with_later_stream_data() {
+        let mut config = Config::new(Version::QMux01);
+        config.max_data = 10;
+        config.max_stream_data_uni = 10;
+        let (session, tx) = scripted_session_with_config(config);
+
+        tx.send(uni_reset(0, 6)).unwrap();
+        tx.send(uni_stream(1, b"12345", false)).unwrap();
+
+        let err = tokio::time::timeout(Duration::from_secs(1), session.closed())
+            .await
+            .expect("session did not close after cumulative MAX_DATA exhaustion");
         assert!(matches!(err, Error::FlowControlError), "got {err:?}");
     }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1150,6 +1150,12 @@ impl<R: Reader> SessionState<R> {
                     if !stream_ok || !self.conn_recv_credit.receive(gap) {
                         return Err(Error::FlowControlError);
                     }
+                    // The gap consumes connection flow control, but no bytes in
+                    // it can ever occupy receive memory. Make it immediately
+                    // eligible to replenish the connection window.
+                    if let Some(new_max) = self.conn_recv_credit.consume(gap) {
+                        self.control.send(Frame::MaxData(new_max)).ok();
+                    }
                 }
 
                 // Live stream: deliver the reset and drop it (it was recorded in
@@ -2796,13 +2802,32 @@ mod recv_open_tests {
         config.max_stream_data_uni = 10;
         let (session, tx) = scripted_session_with_config(config);
 
-        tx.send(uni_reset(0, 6)).unwrap();
-        tx.send(uni_stream(1, b"12345", false)).unwrap();
+        tx.send(uni_reset(0, 3)).unwrap();
+        tx.send(uni_stream(1, b"12345678", false)).unwrap();
 
         let err = tokio::time::timeout(Duration::from_secs(1), session.closed())
             .await
             .expect("session did not close after cumulative MAX_DATA exhaustion");
         assert!(matches!(err, Error::FlowControlError), "got {err:?}");
+    }
+
+    /// A reset gap cannot occupy receive memory, so once it has been charged to
+    /// MAX_DATA it is immediately eligible to replenish the connection window.
+    #[tokio::test]
+    async fn reset_final_size_replenishes_connection_credit() {
+        let mut config = Config::new(Version::QMux01);
+        config.max_data = 10;
+        config.max_stream_data_uni = 10;
+        let (session, tx) = scripted_session_with_config(config);
+
+        tx.send(uni_reset(0, 6)).unwrap();
+        tx.send(uni_stream(1, b"12345", true)).unwrap();
+
+        let mut recv = tokio::time::timeout(Duration::from_secs(1), session.accept_uni())
+            .await
+            .expect("connection credit was not replenished after reset")
+            .expect("accept_uni failed");
+        assert_eq!(recv.read_all().await.unwrap().as_ref(), b"12345");
     }
 
     /// Older QMux drafts were emitted by implementations that always wrote a


### PR DESCRIPTION
## Summary

- preserve and encode `RESET_STREAM` final sizes in the TypeScript implementation
- track bytes actually transmitted before emitting reset final sizes in both implementations
- account reset gaps against stream and connection flow control
- replenish connection receive windows for reset gaps after charging them, since those bytes can never occupy receive memory
- return stream and connection credit reserved for queued bytes discarded by reset
- retain terminal state for reset-first streams so later `STREAM` frames cannot resurrect them
- keep draft-00/-01/-02 compatibility with legacy zero final sizes and leave explicit `TODO(qmux-03)` markers for strict `FINAL_SIZE_ERROR` enforcement

## Root cause

The TypeScript encoder always emitted zero and its decoder discarded the wire value. Both session implementations lacked complete receive-side final-size accounting, while reset-first terminal state was not retained in TypeScript. Rust also used the frontend's queued offset rather than the number of bytes that had actually reached the transport when a priority reset dropped queued stream data, and retained flow-control reservations for those discarded bytes.

## Impact

Peers now communicate accurate reset final sizes, reset-only gaps consume cumulative stream and connection flow-control credit, and terminal receive streams remain terminal. Reset gaps become eligible to replenish the connection window after accounting because they cannot consume buffer space. On send, discarded queued bytes return their reservations so consumed credit converges on the transmitted final size. Existing peers that emitted an incorrect zero final size remain compatible through draft-02.

## Validation

- `bun test js/qmux/src/frame.test.ts js/qmux/src/wire-format.test.ts js/qmux/src/session.test.ts` (73 passed)
- `bun run --cwd js/qmux check`
- `CARGO_TARGET_DIR=/private/tmp/web-transport-qmux-target cargo test -p qmux --lib` (73 passed)
- `CARGO_TARGET_DIR=/private/tmp/web-transport-qmux-target cargo clippy -p qmux --lib --all-features -- -D warnings`
- `cargo fmt --all`
- `bun run fix`
- `git diff --check`

Closes #295
