### PR TITLE
fix(qmux): bound unread incoming streams

### DIFF
--- a/js/qmux/src/recv.test.ts
+++ b/js/qmux/src/recv.test.ts
@@ -38,10 +38,9 @@ describe("RecvStream", () => {
 		for (let i = 0; i < 10; i++) recv.push(new Uint8Array(100));
 		await tick();
 
-		// The stream eagerly pulls at most its high-water mark (one chunk); the rest
-		// stays buffered and uncredited until read. Crucially, credit does NOT track
-		// receipt — otherwise this would be 1000.
-		expect(consumed).toBeLessThanOrEqual(100);
+		// A zero high-water mark prevents even one chunk from being prefetched into
+		// the ReadableStream before the application issues a read.
+		expect(consumed).toBe(0);
 	});
 
 	test("reading resumes crediting", async () => {
@@ -79,20 +78,21 @@ describe("RecvStream", () => {
 			() => {},
 		);
 		recv.push(new Uint8Array(50));
-		recv.error(new Error("RESET_STREAM"));
+		expect(recv.error(new Error("RESET_STREAM"))).toBe(50);
 		await expect(recv.readable.getReader().read()).rejects.toThrow("RESET_STREAM");
 	});
 
 	test("cancel invokes onCancel (STOP_SENDING)", async () => {
-		let cancelled = false;
+		let discarded = -1;
 		const recv = new RecvStream(
 			() => {},
-			() => {
-				cancelled = true;
+			(bytes) => {
+				discarded = bytes;
 			},
 		);
+		recv.push(new Uint8Array(25));
 		await recv.readable.getReader().cancel();
-		expect(cancelled).toBe(true);
+		expect(discarded).toBe(25);
 	});
 });
 

--- a/js/qmux/src/recv.ts
+++ b/js/qmux/src/recv.ts
@@ -17,6 +17,8 @@ export class RecvStream {
 	#fin = false;
 	#error?: Error;
 	#wake?: () => void;
+	#terminal = false;
+	#onTerminal: () => void;
 
 	/** The application-facing readable. */
 	readonly readable: ReadableStream<Uint8Array>;
@@ -26,8 +28,15 @@ export class RecvStream {
 	 *   to the reader. Drives MAX_STREAM_DATA.
 	 * @param onCancel Invoked with the number of discarded buffered bytes when the
 	 *   application cancels the readable (→ STOP_SENDING).
+	 * @param onTerminal Invoked once when FIN, RESET_STREAM, or local cancellation
+	 *   makes the receive side terminal.
 	 */
-	constructor(onConsume: (bytes: number) => void, onCancel: (discarded: number) => void) {
+	constructor(
+		onConsume: (bytes: number) => void,
+		onCancel: (discarded: number) => void,
+		onTerminal: () => void = () => {},
+	) {
+		this.#onTerminal = onTerminal;
 		this.readable = new ReadableStream<Uint8Array>(
 			{
 				pull: async (controller) => {
@@ -55,6 +64,7 @@ export class RecvStream {
 				cancel: () => {
 					this.#error ??= new Error("stream cancelled");
 					onCancel(this.#discard());
+					this.#notifyTerminal();
 					this.#signal();
 				},
 			},
@@ -73,7 +83,15 @@ export class RecvStream {
 	/** Mark end-of-stream; the readable closes once buffered data drains. */
 	finish(): void {
 		this.#fin = true;
+		this.#notifyTerminal();
 		this.#signal();
+	}
+
+	/** Abort the readable because the peer reset its sending side. */
+	reset(err: Error): number {
+		const discarded = this.error(err);
+		this.#notifyTerminal();
+		return discarded;
 	}
 
 	/** Abort the readable, discarding undelivered buffered data. */
@@ -90,6 +108,12 @@ export class RecvStream {
 		for (const chunk of this.#queue) bytes += chunk.byteLength;
 		this.#queue = [];
 		return bytes;
+	}
+
+	#notifyTerminal(): void {
+		if (this.#terminal) return;
+		this.#terminal = true;
+		this.#onTerminal();
 	}
 
 	#signal(): void {

--- a/js/qmux/src/recv.ts
+++ b/js/qmux/src/recv.ts
@@ -8,9 +8,9 @@
  * ahead of a slow reader: it can buffer at most one receive window of undelivered
  * data before its credit is exhausted.
  *
- * The default queuing strategy (high-water mark 1) means at most one delivered
- * chunk sits in the `ReadableStream` itself; everything else waits in our buffer
- * until pulled.
+ * A zero high-water mark prevents the `ReadableStream` from prefetching even one
+ * chunk before the application issues a read; all undelivered data stays in the
+ * explicitly flow-controlled queue below.
  */
 export class RecvStream {
 	#queue: Uint8Array[] = [];
@@ -24,41 +24,50 @@ export class RecvStream {
 	/**
 	 * @param onConsume Invoked with each chunk's byte length as it is delivered
 	 *   to the reader. Drives MAX_STREAM_DATA.
-	 * @param onCancel Invoked when the application cancels the readable (→ STOP_SENDING).
+	 * @param onCancel Invoked with the number of discarded buffered bytes when the
+	 *   application cancels the readable (→ STOP_SENDING).
 	 */
-	constructor(onConsume: (bytes: number) => void, onCancel: () => void) {
-		this.readable = new ReadableStream<Uint8Array>({
-			pull: async (controller) => {
-				while (this.#queue.length === 0) {
-					if (this.#error) {
-						controller.error(this.#error);
-						return;
+	constructor(onConsume: (bytes: number) => void, onCancel: (discarded: number) => void) {
+		this.readable = new ReadableStream<Uint8Array>(
+			{
+				pull: async (controller) => {
+					while (this.#queue.length === 0) {
+						if (this.#error) {
+							controller.error(this.#error);
+							return;
+						}
+						if (this.#fin) {
+							controller.close();
+							return;
+						}
+						await new Promise<void>((resolve) => {
+							this.#wake = resolve;
+						});
 					}
-					if (this.#fin) {
-						controller.close();
-						return;
-					}
-					await new Promise<void>((resolve) => {
-						this.#wake = resolve;
-					});
-				}
-				const chunk = this.#queue.shift() as Uint8Array;
-				controller.enqueue(chunk);
-				// Credit must track *delivery*, not receipt — do NOT move onConsume
-				// into push(). This is the line that bounds the peer to one receive
-				// window ahead of a slow reader; crediting on receipt would let the
-				// buffer grow without bound.
-				onConsume(chunk.byteLength);
+					const chunk = this.#queue.shift() as Uint8Array;
+					controller.enqueue(chunk);
+					// Credit must track *delivery*, not receipt — do NOT move onConsume
+					// into push(). With a zero high-water mark, pull only runs for an
+					// application read, so even the first chunk cannot be prefetched into
+					// an unaccepted stream's hidden ReadableStream queue.
+					onConsume(chunk.byteLength);
+				},
+				cancel: () => {
+					this.#error ??= new Error("stream cancelled");
+					onCancel(this.#discard());
+					this.#signal();
+				},
 			},
-			cancel: () => onCancel(),
-		});
+			{ highWaterMark: 0 },
+		);
 	}
 
 	/** Buffer a received chunk for delivery. Ignored after FIN/error. */
-	push(chunk: Uint8Array): void {
-		if (this.#fin || this.#error) return;
+	push(chunk: Uint8Array): boolean {
+		if (this.#fin || this.#error) return false;
 		this.#queue.push(chunk);
 		this.#signal();
+		return true;
 	}
 
 	/** Mark end-of-stream; the readable closes once buffered data drains. */
@@ -68,11 +77,19 @@ export class RecvStream {
 	}
 
 	/** Abort the readable, discarding undelivered buffered data. */
-	error(err: Error): void {
-		if (this.#error) return;
+	error(err: Error): number {
+		if (this.#error) return 0;
 		this.#error = err;
-		this.#queue = [];
+		const discarded = this.#discard();
 		this.#signal();
+		return discarded;
+	}
+
+	#discard(): number {
+		let bytes = 0;
+		for (const chunk of this.#queue) bytes += chunk.byteLength;
+		this.#queue = [];
+		return bytes;
 	}
 
 	#signal(): void {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -518,6 +518,48 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
+	test("completed unaccepted streams do not recycle receive credit", async () => {
+		// A single-stream/single-payload budget makes any premature replenishment
+		// immediately observable. This is the reproduction from issue #299: the peer
+		// sends a full stream plus FIN while the application never reads the acceptor.
+		const { session, peer } = connect({
+			maxStreamsUni: 1n,
+			maxData: 100n,
+			maxStreamDataUni: 100n,
+		});
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.send({
+			type: "stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+			data: new Uint8Array(100),
+			fin: true,
+		});
+		peer.send({ type: "ping_request", sequence: 1n });
+		await waitFor(() => peer.has("ping_response"));
+
+		// FIN only completed the wire-level receive. The stream object and all 100
+		// bytes are still transport-owned, so neither budget may be recycled yet.
+		expect(peer.count("max_streams_uni")).toBe(0);
+		expect(peer.count("max_data")).toBe(0);
+		expect(peer.count("max_stream_data")).toBe(0);
+
+		const acceptor = session.incomingUnidirectionalStreams.getReader();
+		const accepted = await acceptor.read();
+		if (accepted.done || !accepted.value) throw new Error("expected an incoming stream");
+
+		// Accepting transfers ownership of the stream object, but the unread payload
+		// remains charged to MAX_DATA until the application asks for it.
+		await waitFor(() => peer.count("max_streams_uni") === 1);
+		expect(peer.count("max_data")).toBe(0);
+
+		const payload = await accepted.value.getReader().read();
+		expect(payload.value?.byteLength).toBe(100);
+		await waitFor(() => peer.count("max_data") === 1);
+		session.close();
+	});
+
 	// Regression: a STREAM frame delivered by the read loop after the session has
 	// closed used to hit the already-closed incoming-stream controllers, and the
 	// throw escaped as an unhandled rejection because #handleStreamFrame was an

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -560,6 +560,27 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
+	test("accepted active streams do not recycle stream-count credit", async () => {
+		const { session, peer } = connect({ maxStreamsUni: 1n });
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		peer.send({ type: "stream", id, data: new Uint8Array([1]), fin: false });
+
+		const acceptor = session.incomingUnidirectionalStreams.getReader();
+		const accepted = await acceptor.read();
+		if (accepted.done || !accepted.value) throw new Error("expected an incoming stream");
+
+		peer.send({ type: "ping_request", sequence: 1n });
+		await waitFor(() => peer.has("ping_response"));
+		expect(peer.count("max_streams_uni")).toBe(0);
+
+		peer.send({ type: "stream", id, data: new Uint8Array(), fin: true });
+		await waitFor(() => peer.count("max_streams_uni") === 1);
+		session.close();
+	});
+
 	// Regression: a STREAM frame delivered by the read loop after the session has
 	// closed used to hit the already-closed incoming-stream controllers, and the
 	// throw escaped as an unhandled rejection because #handleStreamFrame was an

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -150,6 +150,98 @@ export class Datagrams implements WebTransportDatagramDuplexStream {
 	}
 }
 
+interface PendingIncomingStream<T> {
+	value: T;
+	onAccept: () => void;
+	onDrop: (err: Error) => void;
+}
+
+/** Application-facing incoming-stream acceptor with no implicit prefetch.
+ *
+ * A normal ReadableStream controller will happily queue past its high-water
+ * mark; `desiredSize` is only a backpressure signal. QMux cannot stop reading
+ * its underlying byte stream, so keep new streams in this explicit queue and
+ * transfer ownership only in response to an application read. The peer's
+ * MAX_STREAMS credit is replenished by `onAccept`, which bounds this pending
+ * queue to the stream count we advertised.
+ */
+class IncomingStreamQueue<T> {
+	readonly readable: ReadableStream<T>;
+
+	#controller!: ReadableStreamDefaultController<T>;
+	#pending: PendingIncomingStream<T>[] = [];
+	#pullResolve?: () => void;
+	#cancelled = false;
+	#closed = false;
+
+	constructor() {
+		this.readable = new ReadableStream<T>(
+			{
+				start: (controller) => {
+					this.#controller = controller;
+				},
+				pull: () => {
+					if (this.#deliver()) return;
+					return new Promise<void>((resolve) => {
+						this.#pullResolve = resolve;
+					});
+				},
+				cancel: () => {
+					this.#cancelled = true;
+					this.#dropPending(new Error("incoming stream acceptor cancelled"));
+					this.#resolvePull();
+				},
+			},
+			{ highWaterMark: 0 },
+		);
+	}
+
+	push(value: T, onAccept: () => void, onDrop: (err: Error) => void): boolean {
+		if (this.#cancelled || this.#closed) return false;
+		this.#pending.push({ value, onAccept, onDrop });
+		if (this.#pullResolve) {
+			this.#deliver();
+			this.#resolvePull();
+		}
+		return true;
+	}
+
+	close(err?: Error): void {
+		if (this.#closed || this.#cancelled) return;
+		this.#closed = true;
+		this.#dropPending(err ?? new Error("session closed"));
+		try {
+			if (err) this.#controller.error(err);
+			else this.#controller.close();
+		} catch {}
+		this.#resolvePull();
+	}
+
+	#deliver(): boolean {
+		const item = this.#pending.shift();
+		if (!item) return false;
+		try {
+			this.#controller.enqueue(item.value);
+			item.onAccept();
+		} catch {
+			item.onDrop(new Error("incoming stream acceptor cancelled"));
+		}
+		return true;
+	}
+
+	#dropPending(err: Error): void {
+		const pending = this.#pending;
+		this.#pending = [];
+		for (const item of pending) item.onDrop(err);
+	}
+
+	#resolvePull(): void {
+		const resolve = this.#pullResolve;
+		this.#pullResolve = undefined;
+		resolve?.();
+	}
+}
+
 /** Options for opening a QMux Session over WebSocket. */
 export interface SessionOptions extends WebTransportOptions {
 	/** Application-level subprotocols to advertise via `Sec-WebSocket-Protocol`.
@@ -363,9 +455,9 @@ export default class Session implements WebTransport {
 	#closedReject: (err: Error) => void;
 
 	readonly incomingBidirectionalStreams: ReadableStream<WebTransportBidirectionalStream>;
-	#incomingBidirectionalStreams!: ReadableStreamDefaultController<WebTransportBidirectionalStream>;
+	#incomingBidirectionalQueue: IncomingStreamQueue<WebTransportBidirectionalStream>;
 	readonly incomingUnidirectionalStreams: ReadableStream<ReadableStream<Uint8Array>>;
-	#incomingUnidirectionalStreams!: ReadableStreamDefaultController<ReadableStream<Uint8Array>>;
+	#incomingUnidirectionalQueue: IncomingStreamQueue<ReadableStream<Uint8Array>>;
 
 	readonly datagrams = new Datagrams((data) => this.#sendDatagram(data));
 
@@ -460,21 +552,11 @@ export default class Session implements WebTransport {
 		// observe the rejection.
 		this.closed.catch(() => {});
 
-		this.incomingBidirectionalStreams = new ReadableStream<WebTransportBidirectionalStream>({
-			start: (controller) => {
-				this.#incomingBidirectionalStreams = controller;
-			},
-		});
+		this.#incomingBidirectionalQueue = new IncomingStreamQueue<WebTransportBidirectionalStream>();
+		this.incomingBidirectionalStreams = this.#incomingBidirectionalQueue.readable;
 
-		this.incomingUnidirectionalStreams = new ReadableStream<ReadableStream<Uint8Array>>({
-			start: (controller) => {
-				this.#incomingUnidirectionalStreams = controller;
-			},
-		});
-
-		if (!this.#incomingBidirectionalStreams || !this.#incomingUnidirectionalStreams) {
-			throw new Error("ReadableStream didn't call start");
-		}
+		this.#incomingUnidirectionalQueue = new IncomingStreamQueue<ReadableStream<Uint8Array>>();
+		this.incomingUnidirectionalStreams = this.#incomingUnidirectionalQueue.readable;
 
 		this.#connect(toWebSocketUrl(url), subprotocols);
 	}
@@ -851,9 +933,10 @@ export default class Session implements WebTransport {
 		return true;
 	}
 
-	/** Connection-level credit. Accounted at receipt: MAX_DATA is a coarse
-	 *  aggregate limit, and per-stream backpressure (below) is what throttles a
-	 *  slow reader. `recvDataConsumed` is cumulative. */
+	/** Connection-level credit. Accounted when bytes are delivered to the
+	 *  application or deliberately discarded, never merely on receipt. This keeps
+	 *  completed-but-unread streams inside the aggregate receive-memory window.
+	 *  `recvDataConsumed` is cumulative. */
 	#accountConnConsumed(bytes: number) {
 		if (!isQmux(this.#version) || bytes === 0) return;
 		this.#recvDataConsumed += BigInt(bytes);
@@ -996,8 +1079,12 @@ export default class Session implements WebTransport {
 			}
 
 			const recvStream = new RecvStream(
-				(bytes) => this.#accountStreamConsumed(streamId, bytes),
-				() => {
+				(bytes) => {
+					this.#accountStreamConsumed(streamId, bytes);
+					this.#accountConnConsumed(bytes);
+				},
+				(discarded) => {
+					this.#accountConnConsumed(discarded);
 					this.#sendPriorityFrame({
 						type: "stop_sending",
 						id: frame.id,
@@ -1005,13 +1092,17 @@ export default class Session implements WebTransport {
 					});
 
 					this.#recvStreams.delete(streamId);
-					this.#replenishStreamCredit(frame.id.dir);
 					this.#maybeDeleteStreamFlow(streamId);
 				},
 			);
 			this.#recvStreams.set(streamId, recvStream);
 			recv = recvStream;
 			const reader = recvStream.readable;
+
+			const onAccept = () => this.#replenishStreamCredit(frame.id.dir);
+			const onDrop = (err: Error) => {
+				this.#accountConnConsumed(recvStream.error(err));
+			};
 
 			if (frame.id.dir === Stream.Dir.Bi) {
 				// Incoming bidirectional stream
@@ -1044,27 +1135,15 @@ export default class Session implements WebTransport {
 				});
 				this.#attachSendOrder(writer, streamId, DEFAULT_SEND_ORDER);
 
-				try {
-					this.#incomingBidirectionalStreams.enqueue({ readable: reader, writable: writer });
-				} catch {
-					// The app cancelled the incoming-bidi acceptor while the session is
-					// still open (a closed session already returned at the #closed guard
-					// above). Keep the stream registered in #recvStreams — as in <=0.2.0 —
-					// so later in-flight frames for this id take the existing-stream path
-					// below instead of re-opening it (which would re-credit stream-count
-					// and re-emit STOP_SENDING per frame). Error the orphaned recv buffer
-					// so we don't retain bytes no reader can drain, then fall through so
-					// connection flow control is still accounted for this frame.
-					recv.error(new Error("incoming stream acceptor cancelled"));
+				if (!this.#incomingBidirectionalQueue.push({ readable: reader, writable: writer }, onAccept, onDrop)) {
+					// Keep the refused stream registered until FIN/RESET so in-flight frames
+					// cannot repeatedly reopen it. RecvStream rejects subsequent pushes,
+					// letting the receive path account them as deliberately discarded.
+					onDrop(new Error("incoming stream acceptor cancelled"));
 				}
 			} else {
-				try {
-					this.#incomingUnidirectionalStreams.enqueue(reader);
-				} catch {
-					// Acceptor cancelled mid-session; see the bidi branch. Keep the stream
-					// registered, drop its orphaned buffer, and fall through to account
-					// connection flow control below.
-					recv.error(new Error("incoming stream acceptor cancelled"));
+				if (!this.#incomingUnidirectionalQueue.push(reader, onAccept, onDrop)) {
+					onDrop(new Error("incoming stream acceptor cancelled"));
 				}
 			}
 		} else {
@@ -1077,18 +1156,15 @@ export default class Session implements WebTransport {
 		}
 
 		if (frame.data.byteLength > 0) {
-			recv.push(frame.data);
-			// Connection-level credit at receipt; stream-level credit is deferred to
-			// delivery (RecvStream.onConsume) so a slow reader backpressures the peer.
-			this.#accountConnConsumed(frame.data.byteLength);
+			// A refused/reset/cancelled stream discards new in-flight data. Discarded
+			// bytes free memory immediately and therefore count as consumed; buffered
+			// bytes advance both flow-control windows only when RecvStream delivers them.
+			if (!recv.push(frame.data)) this.#accountConnConsumed(frame.data.byteLength);
 		}
 
 		if (frame.fin) {
 			recv.finish();
 			this.#recvStreams.delete(streamId);
-			if (frame.id.serverInitiated !== this.#isServer) {
-				this.#replenishStreamCredit(frame.id.dir);
-			}
 			this.#maybeDeleteStreamFlow(streamId);
 		}
 	}
@@ -1106,11 +1182,8 @@ export default class Session implements WebTransport {
 		const recv = this.#recvStreams.get(streamId);
 		if (!recv) return;
 
-		recv.error(new Error(`RESET_STREAM: ${frame.code.value}`));
+		this.#accountConnConsumed(recv.error(new Error(`RESET_STREAM: ${frame.code.value}`)));
 		this.#recvStreams.delete(streamId);
-		if (frame.id.serverInitiated !== this.#isServer) {
-			this.#replenishStreamCredit(frame.id.dir);
-		}
 		this.#maybeDeleteStreamFlow(streamId);
 	}
 
@@ -1308,8 +1381,12 @@ export default class Session implements WebTransport {
 		this.#attachSendOrder(writer, streamIdVal, sendOrder);
 
 		const recvStream = new RecvStream(
-			(bytes) => this.#accountStreamConsumed(streamIdVal, bytes),
-			() => {
+			(bytes) => {
+				this.#accountStreamConsumed(streamIdVal, bytes);
+				this.#accountConnConsumed(bytes);
+			},
+			(discarded) => {
+				this.#accountConnConsumed(discarded);
 				this.#sendPriorityFrame({
 					type: "stop_sending",
 					id: streamId,
@@ -1396,12 +1473,8 @@ export default class Session implements WebTransport {
 		}
 
 		// Fail active streams so consumers unblock
-		try {
-			this.#incomingBidirectionalStreams.close();
-		} catch {}
-		try {
-			this.#incomingUnidirectionalStreams.close();
-		} catch {}
+		this.#incomingBidirectionalQueue.close(this.#closeReason);
+		this.#incomingUnidirectionalQueue.close(this.#closeReason);
 		// Pass the *reason*, not `#closed` (always an Error): a graceful
 		// app-initiated close leaves `#closeReason` unset, so the datagram
 		// readable closes cleanly instead of erroring, matching the incoming

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1078,6 +1078,23 @@ export default class Session implements WebTransport {
 				return;
 			}
 
+			let accepted = false;
+			let terminal = false;
+			let streamCreditReplenished = false;
+			const maybeReplenishStreamCredit = () => {
+				if (!accepted || !terminal || streamCreditReplenished) return;
+				streamCreditReplenished = true;
+				this.#replenishStreamCredit(frame.id.dir);
+			};
+			const onAccept = () => {
+				accepted = true;
+				maybeReplenishStreamCredit();
+			};
+			const onTerminal = () => {
+				terminal = true;
+				maybeReplenishStreamCredit();
+			};
+
 			const recvStream = new RecvStream(
 				(bytes) => {
 					this.#accountStreamConsumed(streamId, bytes);
@@ -1094,12 +1111,12 @@ export default class Session implements WebTransport {
 					this.#recvStreams.delete(streamId);
 					this.#maybeDeleteStreamFlow(streamId);
 				},
+				onTerminal,
 			);
 			this.#recvStreams.set(streamId, recvStream);
 			recv = recvStream;
 			const reader = recvStream.readable;
 
-			const onAccept = () => this.#replenishStreamCredit(frame.id.dir);
 			const onDrop = (err: Error) => {
 				this.#accountConnConsumed(recvStream.error(err));
 			};
@@ -1182,7 +1199,7 @@ export default class Session implements WebTransport {
 		const recv = this.#recvStreams.get(streamId);
 		if (!recv) return;
 
-		this.#accountConnConsumed(recv.error(new Error(`RESET_STREAM: ${frame.code.value}`)));
+		this.#accountConnConsumed(recv.reset(new Error(`RESET_STREAM: ${frame.code.value}`)));
 		this.#recvStreams.delete(streamId);
 		this.#maybeDeleteStreamFlow(streamId);
 	}


### PR DESCRIPTION
## Summary

- add a zero-prefetch admission queue for incoming QMux streams
- return `MAX_STREAMS` credit only when the application accepts a stream
- return connection receive credit only when payload bytes are read or deliberately discarded
- account for buffered bytes released by reset and cancellation paths
- add a regression test for completed, unread incoming streams

## Root cause

Completed streams were removed from active receive tracking and both connection and stream-count credit were replenished while their application-facing stream objects and payloads remained queued. A peer could repeatedly send a window-sized stream plus FIN and grow receiver memory without bound when the application did not read the incoming-stream acceptor.

## Impact

Unread incoming streams now remain charged against the advertised receive budgets until ownership transfers to the application. This preserves QMux forward progress without allowing completed streams to bypass the memory bound.

Fixes #299.

## Validation

- `bun test js/qmux/src` — 97 passed
- `bun run --cwd js/qmux check`
- `bun run check` — completed with existing unrelated warnings
