### PR TITLE
fix(quiche): wait for driver before reporting closed

### DIFF
--- a/rs/web-transport-quiche/src/ez/connection.rs
+++ b/rs/web-transport-quiche/src/ez/connection.rs
@@ -144,6 +144,10 @@ impl ConnectionClose {
         poll_fn(|cx| self.driver.lock().closed(cx.waker())).await
     }
 
+    pub async fn error(&self) -> ConnectionError {
+        poll_fn(|cx| self.driver.lock().error(cx.waker())).await
+    }
+
     pub fn is_closed(&self) -> bool {
         self.driver.lock().is_closed()
     }
@@ -208,7 +212,7 @@ impl Connection {
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), ConnectionError> {
         tokio::select! {
             Ok(res) = self.accept_bi.recv_async() => Ok(res),
-            res = self.closed() => Err(res),
+            err = self.close.error() => Err(err),
         }
     }
 
@@ -216,7 +220,7 @@ impl Connection {
     pub async fn accept_uni(&self) -> Result<RecvStream, ConnectionError> {
         tokio::select! {
             Ok(res) = self.accept_uni.recv_async() => Ok(res),
-            res = self.closed() => Err(res),
+            err = self.close.error() => Err(err),
         }
     }
 
@@ -256,9 +260,9 @@ impl Connection {
             res = self.dgram_in.recv_async() => match res {
                 Ok(bytes) => Ok(bytes),
                 // Sender dropped — the driver closed; surface the close reason.
-                Err(_) => Err(self.closed().await),
+                Err(_) => Err(self.close.error().await),
             },
-            err = self.closed() => Err(err),
+            err = self.close.error() => Err(err),
         }
     }
 
@@ -343,5 +347,25 @@ impl Deref for Connection {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::FutureExt;
+
+    use super::*;
+
+    #[test]
+    fn local_close_is_an_error_before_driver_is_closed() {
+        let close = ConnectionClose::new(Lock::new(DriverState::new(false)));
+
+        close.close(ConnectionError::Local(42, "done".to_string()));
+
+        assert!(matches!(
+            close.error().now_or_never(),
+            Some(ConnectionError::Local(42, reason)) if reason == "done"
+        ));
+        assert!(close.wait().now_or_never().is_none());
     }
 }

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -36,8 +36,8 @@ pub(super) struct DriverState {
     bi: DriverOpen<(Lock<SendState>, Lock<RecvState>)>,
     uni: DriverOpen<Lock<SendState>>,
 
-    local: ConnectionClosed,
-    remote: ConnectionClosed,
+    close_requested: ConnectionClosed,
+    closed: ConnectionClosed,
 
     /// The negotiated ALPN protocol, set after the handshake completes.
     alpn: Option<Vec<u8>>,
@@ -67,8 +67,8 @@ impl DriverState {
             send: HashSet::new(),
             recv: HashSet::new(),
             waker: None,
-            local: ConnectionClosed::default(),
-            remote: ConnectionClosed::default(),
+            close_requested: ConnectionClosed::default(),
+            closed: ConnectionClosed::default(),
             bi: DriverOpen::new(next_bi),
             uni: DriverOpen::new(next_uni),
             alpn: None,
@@ -84,15 +84,31 @@ impl DriverState {
     }
 
     pub fn close(&mut self, err: ConnectionError) -> Vec<Waker> {
-        self.local.abort(err)
+        self.close_requested.abort(err)
     }
 
     pub fn closed(&self, waker: &Waker) -> Poll<ConnectionError> {
-        self.local.poll(waker)
+        self.closed.poll(waker)
+    }
+
+    fn finish_close(&self, err: ConnectionError) -> Vec<Waker> {
+        self.closed.abort(err)
+    }
+
+    fn close_requested(&self, waker: &Waker) -> Poll<ConnectionError> {
+        self.close_requested.poll(waker)
+    }
+
+    pub fn error(&self, waker: &Waker) -> Poll<ConnectionError> {
+        if let Poll::Ready(err) = self.close_requested.poll(waker) {
+            return Poll::Ready(err);
+        }
+
+        self.closed.poll(waker)
     }
 
     pub fn is_closed(&self) -> bool {
-        self.local.is_closed() || self.remote.is_closed()
+        self.close_requested.is_closed() || self.closed.is_closed()
     }
 
     /// Returns the negotiated ALPN protocol, if the handshake has completed.
@@ -119,10 +135,7 @@ impl DriverState {
         }
 
         // Check if connection is closed
-        if let Poll::Ready(err) = self.local.poll(waker) {
-            return Poll::Ready(Err(err));
-        }
-        if let Poll::Ready(err) = self.remote.poll(waker) {
+        if let Poll::Ready(err) = self.error(waker) {
             return Poll::Ready(Err(err));
         }
 
@@ -166,7 +179,7 @@ impl DriverState {
 
     // Try to create the next bidirectional stream, although it may not be possible yet.
     pub fn open_bi(&mut self, waker: &Waker) -> OpenBiResult {
-        if let Poll::Ready(err) = self.local.poll(waker) {
+        if let Poll::Ready(err) = self.error(waker) {
             return Poll::Ready(Err(err));
         }
 
@@ -188,7 +201,7 @@ impl DriverState {
     }
 
     pub fn open_uni(&mut self, waker: &Waker) -> OpenUniResult {
-        if let Poll::Ready(err) = self.local.poll(waker) {
+        if let Poll::Ready(err) = self.error(waker) {
             return Poll::Ready(Err(err));
         }
 
@@ -411,7 +424,7 @@ impl Driver {
     ) -> Poll<Result<(), ConnectionError>> {
         if !qconn.is_draining() {
             // Check if the application wants to close the connection.
-            if let Poll::Ready(err) = self.state.lock().closed(waker) {
+            if let Poll::Ready(err) = self.state.lock().close_requested(waker) {
                 // Close the connection and return the error.
                 return Poll::Ready(
                     match err {
@@ -565,7 +578,7 @@ impl Driver {
     }
 
     fn abort(&mut self, err: ConnectionError) {
-        let wakers = self.state.lock().local.abort(err);
+        let wakers = self.state.lock().close_requested.abort(err);
         for waker in wakers {
             waker.wake();
         }
@@ -669,7 +682,7 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
     ) {
         let state = self.state.lock();
 
-        let err = if let Poll::Ready(err) = state.local.poll(Waker::noop()) {
+        let err = if let Poll::Ready(err) = state.close_requested.poll(Waker::noop()) {
             err
         } else if let Some(local) = qconn.local_error() {
             let reason = String::from_utf8_lossy(&local.reason).to_string();
@@ -683,14 +696,16 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
             ConnectionError::Unknown("no error message".to_string())
         };
 
-        // Finally set the remote error once the connection is done.
-        let wakers = state.remote.abort(err.clone());
+        // Mark the connection closed only after the driver is done. In particular,
+        // a local close request must not make Connection::closed resolve before
+        // quiche has had an opportunity to emit CONNECTION_CLOSE.
+        let wakers = state.finish_close(err.clone());
         for waker in wakers {
             waker.wake();
         }
 
         // Also wake up any local wakers if the peer closed.
-        let wakers = state.local.abort(err);
+        let wakers = state.close_requested.abort(err);
         for waker in wakers {
             waker.wake();
         }
@@ -712,5 +727,28 @@ impl<T> DriverOpen<T> {
             create: Vec::new(),
             wakers: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closed_waits_for_driver_completion() {
+        let mut state = DriverState::new(false);
+        let waker = Waker::noop();
+        let err = ConnectionError::Local(42, "done".to_string());
+
+        assert!(state.closed(waker).is_pending());
+
+        state.close(err.clone());
+
+        assert!(state.close_requested(waker).is_ready());
+        assert!(state.closed(waker).is_pending());
+
+        state.finish_close(err);
+
+        assert!(state.closed(waker).is_ready());
     }
 }

--- a/rs/web-transport-quiche/src/ez/recv.rs
+++ b/rs/web-transport-quiche/src/ez/recv.rs
@@ -263,7 +263,7 @@ impl RecvStream {
         let mut driver = self.driver.lock();
 
         // Check if the connection is closed.
-        if let Poll::Ready(res) = driver.closed(waker) {
+        if let Poll::Ready(res) = driver.error(waker) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -330,7 +330,7 @@ impl RecvStream {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().closed(waker) {
+        if let Poll::Ready(res) = self.driver.lock().error(waker) {
             return Poll::Ready(Err(res.into()));
         }
 

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -251,7 +251,7 @@ impl SendStream {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().closed(cx.waker()) {
+        if let Poll::Ready(res) = self.driver.lock().error(cx.waker()) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -341,7 +341,7 @@ impl SendStream {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().closed(waker) {
+        if let Poll::Ready(res) = self.driver.lock().error(waker) {
             return Poll::Ready(Err(res.into()));
         }
 


### PR DESCRIPTION
## Summary

- separate the local close request from completed driver shutdown
- keep stream and handshake operations responsive to local close requests
- make `Connection::closed()` resolve from `on_conn_close`
- add a regression test proving local `close()` does not immediately complete `closed()`

## Root cause

`Connection::close()` and `Connection::closed()` used the same `ConnectionClosed` state. Filling that state woke public waiters before the driver called `quiche::Connection::close`, so dropping the connection after the documented `close(); closed().await` sequence could lose the `CONNECTION_CLOSE` frame.

## Impact

`closed().await` now waits until the QUIC driver has completed connection shutdown, ensuring it has had an opportunity to emit `CONNECTION_CLOSE`. Internal stream and handshake operations still observe close requests immediately.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p web-transport-quiche` (8 tests passed)

Closes #302
