### PR TITLE
fix(qmux): harden input validation

### DIFF
--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -204,6 +204,83 @@ describe("QMux02 (draft-02)", () => {
 		expect(() => Frame.decode(bytes, "qmux-02")).toThrow();
 	});
 
+	test("forbidden QUIC v1 transport parameters are rejected", () => {
+		for (const id of [0x00, 0x02, 0x03, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]) {
+			const bytes = new Uint8Array([
+				0xff,
+				0x51,
+				0x53,
+				0x30,
+				0x0d,
+				0x0a,
+				0x0d,
+				0x0a, // frame type
+				0x02, // payload length
+				id,
+				0x00, // empty parameter value
+			]);
+			expect(() => Frame.decode(bytes, "qmux-02")).toThrow("forbidden QUIC v1 transport parameter");
+		}
+	});
+
+	test("unknown extension transport parameters are ignored", () => {
+		const bytes = new Uint8Array([
+			0xff,
+			0x51,
+			0x53,
+			0x30,
+			0x0d,
+			0x0a,
+			0x0d,
+			0x0a, // frame type
+			0x03, // payload length
+			0x11,
+			0x01,
+			0xff, // unknown extension id=0x11, len=1
+		]);
+		expect(Frame.decode(bytes, "qmux-02")?.type).toBe("transport_parameters");
+	});
+
+	test("recognized integer transport parameters require exactly one varint", () => {
+		const empty = new Uint8Array([
+			0xff,
+			0x51,
+			0x53,
+			0x30,
+			0x0d,
+			0x0a,
+			0x0d,
+			0x0a,
+			0x02,
+			0x04,
+			0x00, // initial_max_data with an empty value
+		]);
+		expect(() => Frame.decode(empty, "qmux-02")).toThrow();
+
+		const trailing = new Uint8Array([
+			0xff,
+			0x51,
+			0x53,
+			0x30,
+			0x0d,
+			0x0a,
+			0x0d,
+			0x0a,
+			0x04,
+			0x04,
+			0x02,
+			0x01,
+			0x00, // initial_max_data=1 followed by a trailing byte
+		]);
+		expect(() => Frame.decode(trailing, "qmux-02")).toThrow("trailing bytes");
+	});
+
+	test("an unknown frame type is rejected without suppressing trailing frames", () => {
+		const record = new Uint8Array([0x02, 0x10, 0x01]);
+		expect(() => Frame.decodeRecord(record)).toThrow("Invalid QMux frame type");
+		expect(() => Frame.decode(new Uint8Array([0x02]), "qmux-02")).toThrow("Invalid QMux frame type");
+	});
+
 	test("reset_stream_at transport parameter round-trips (empty flag)", () => {
 		const on: Frame.Any = {
 			type: "transport_parameters",

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -564,13 +564,21 @@ function decodeTransportParams(buffer: Uint8Array): TransportParams {
 			continue;
 		}
 
-		if (paramData.byteLength < 1) {
-			continue; // Empty param, skip
+		// QMux permits only a subset of the transport parameters defined by
+		// QUIC v1. Unassigned IDs are extensions and remain ignorable.
+		if (id === 0x00n || id === 0x02n || id === 0x03n || (id >= 0x0an && id <= 0x10n)) {
+			throw new Error(`forbidden QUIC v1 transport parameter 0x${id.toString(16)}`);
 		}
 
-		let paramValue: bigint;
-		[v] = VarInt.decode(paramData);
-		paramValue = v.value;
+		if (!RECOGNIZED_PARAM_IDS.has(id)) {
+			continue;
+		}
+
+		const [paramValueVarInt, remaining] = VarInt.decode(paramData);
+		if (remaining.byteLength !== 0) {
+			throw new Error(`transport parameter 0x${id.toString(16)} has trailing bytes`);
+		}
+		const paramValue = paramValueVarInt.value;
 
 		switch (id) {
 			case 0x01n:
@@ -600,7 +608,8 @@ function decodeTransportParams(buffer: Uint8Array): TransportParams {
 			case MAX_RECORD_SIZE_ID:
 				params.maxRecordSize = paramValue;
 				break;
-			// Unknown params: skip
+			default:
+				throw new Error(`unhandled recognized transport parameter 0x${id.toString(16)}`);
 		}
 	}
 
@@ -706,6 +715,11 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 
 	[v, buffer] = VarInt.decode(buffer);
 	const frameType = v.value;
+
+	// PADDING
+	if (frameType === 0x00n) {
+		return null;
+	}
 
 	// STREAM frames: 0x08-0x0f
 	if (frameType >= 0x08n && frameType <= 0x0fn) {
@@ -887,8 +901,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		return { type: "datagram", data, lengthPrefixed: true };
 	}
 
-	// Unknown frame type
-	return null;
+	throw new Error(`Invalid QMux frame type: 0x${frameType.toString(16)}`);
 }
 
 /** Decode a single QMux frame, returning the frame and remaining buffer.
@@ -1076,6 +1089,5 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		return [{ type: "datagram", data, lengthPrefixed: true }, buffer];
 	}
 
-	// Unknown: skip remaining (can't delimit)
-	return [null, buffer.slice(buffer.byteLength)];
+	throw new Error(`Invalid QMux frame type: 0x${frameType.toString(16)}`);
 }

--- a/rs/qmux/src/proto/params.rs
+++ b/rs/qmux/src/proto/params.rs
@@ -76,6 +76,14 @@ impl TransportParams {
     // reset_stream_at (draft-ietf-quic-reliable-stream-reset): empty value.
     const RESET_STREAM_AT: VarInt = VarInt::from_u32(0x1d);
 
+    /// Whether `id` is defined by QUIC v1 but prohibited by QMux.
+    ///
+    /// IDs not listed here are extensions and remain ignorable unless QMux (or
+    /// another compatible extension) assigns them semantics.
+    fn is_forbidden_quic_v1(id: u64) -> bool {
+        matches!(id, 0x00 | 0x02 | 0x03 | 0x0a..=0x10)
+    }
+
     /// Encode transport parameters as a series of ID-length-value tuples.
     pub fn encode(&self) -> Result<Bytes, Error> {
         let mut buf = BytesMut::new();
@@ -222,6 +230,9 @@ impl TransportParams {
                         }
                         _ => unreachable!(),
                     }
+                }
+                id if Self::is_forbidden_quic_v1(id) => {
+                    return Err(Error::TransportParameter);
                 }
                 _ => {
                     // Unknown parameter, skip (already split off)
@@ -398,5 +409,27 @@ mod tests {
             TransportParams::decode(buf.freeze()),
             Err(Error::InvalidProtocol(_))
         ));
+    }
+
+    #[test]
+    fn forbidden_quic_v1_params_rejected() {
+        for id in [0x00, 0x02, 0x03, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10] {
+            let mut buf = BytesMut::new();
+            VarInt::from_u32(id).encode(&mut buf);
+            VarInt::from_u32(0).encode(&mut buf);
+            assert!(matches!(
+                TransportParams::decode(buf.freeze()),
+                Err(Error::TransportParameter)
+            ));
+        }
+    }
+
+    #[test]
+    fn unknown_extension_param_ignored() {
+        let mut buf = BytesMut::new();
+        VarInt::from_u32(0x11).encode(&mut buf);
+        VarInt::from_u32(1).encode(&mut buf);
+        buf.put_u8(0xff);
+        TransportParams::decode(buf.freeze()).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- reject QUIC v1 transport parameters that QMux forbids while continuing to ignore unknown extension IDs
- require recognized TypeScript integer transport parameters to contain exactly one varint
- reject unsupported QMux frame types instead of discarding the rest of a record
- add negative wire-format coverage in Rust and TypeScript

## Why

The QMux decoders accepted prohibited or malformed transport parameters. The TypeScript record decoder also treated an unknown frame as the end of the record, allowing it to suppress valid trailing frames.

This makes inbound validation match draft-ietf-quic-qmux-02 and ensures malformed input closes the connection through the existing protocol-error path.

## Validation

- `cargo test -p qmux --offline`
- `cargo clippy -p qmux --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all --check`
- `bun test js/qmux/src`
- `bun run --filter @moq/qmux check`
- `bunx biome check js/qmux/src/frame.ts js/qmux/src/frame.test.ts`

Closes #296
