### PR TITLE
docs(qmux): defer stream offset enforcement

### DIFF
--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -307,6 +307,9 @@ function encodeWebTransport(frame: Any): Uint8Array {
 function encodeQMux(frame: Any): Uint8Array {
 	switch (frame.type) {
 		case "stream": {
+			// TODO(#294): Keep draft-02's offset-less behavior for compatibility.
+			// Once draft-03 is published and supported, emit OFF with the
+			// per-stream send offset and validate received offsets/terminal state.
 			// Always set LEN bit (0x02), type = 0x0a | fin_bit
 			const frameType = VarInt.from(0x0a | (frame.fin ? 0x01 : 0x00));
 			const lengthVi = VarInt.from(frame.data.length);

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -486,6 +486,9 @@ impl Frame {
     fn encode_qmux(&self, buf: &mut BytesMut) -> Result<(), Error> {
         match self {
             Frame::Stream(s) => {
+                // TODO(#294): Keep draft-02's offset-less behavior for compatibility.
+                // Once draft-03 is published and supported, emit OFF with the
+                // per-stream send offset and validate received offsets/terminal state.
                 // Always LEN bit (0x02), never OFF bit. Type = 0x0a | fin_bit
                 let frame_type =
                     VarInt::from_u32(STREAM_BASE | 0x02 | if s.fin { 0x01 } else { 0 });


### PR DESCRIPTION
## Summary

- document that the Rust and TypeScript QMux encoders intentionally preserve draft-02's offset-less STREAM behavior
- leave a focused TODO for adding send-offset tracking and receive validation once draft-03 is published and supported
- keep issue #294 visible without introducing an unpublished wire version

## Rationale

Enforcing STREAM offsets under draft-02 would change the existing wire behavior and break backwards compatibility. This PR records the follow-up at the exact implementation sites without changing runtime behavior.

Refs #294.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/web-transport-target cargo check -p qmux --all-features`
- `TMPDIR=/tmp bun run --cwd js/qmux check`
