### PR TITLE
fix(qmux): encode stream offsets

### DIFF
--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -12,12 +12,15 @@ export type WireFormat = "webtransport" | "qmux-00" | "qmux-01" | "qmux-02";
 /** Maximum size of a single QMux frame on the wire. */
 export const MAX_FRAME_SIZE = 16384;
 
-/** Maximum payload per STREAM frame, accounting for frame overhead (24 bytes). */
-export const MAX_FRAME_PAYLOAD = MAX_FRAME_SIZE - 24;
+/** Maximum payload per STREAM frame, accounting for four 8-byte header varints. */
+export const MAX_FRAME_PAYLOAD = MAX_FRAME_SIZE - 32;
 
 export interface Data {
 	type: "stream";
 	id: Stream.Id;
+	/** Byte offset of this payload. QMux senders always encode it; receivers
+	 * preserve it without enforcing continuity yet. Defaults to zero when omitted. */
+	offset?: bigint;
 	data: Uint8Array;
 	fin: boolean;
 }
@@ -310,18 +313,18 @@ function encodeWebTransport(frame: Any): Uint8Array {
 function encodeQMux(frame: Any): Uint8Array {
 	switch (frame.type) {
 		case "stream": {
-			// TODO(#294): Keep draft-02's offset-less behavior for compatibility.
-			// Once draft-03 is published and supported, emit OFF with the
-			// per-stream send offset and validate received offsets/terminal state.
-			// Always set LEN bit (0x02), type = 0x0a | fin_bit
-			const frameType = VarInt.from(0x0a | (frame.fin ? 0x01 : 0x00));
+			// Always set OFF (0x04) and LEN (0x02). Continuity validation remains
+			// deferred on the receive path.
+			const frameType = VarInt.from(0x0e | (frame.fin ? 0x01 : 0x00));
+			const offsetVi = VarInt.from(frame.offset ?? 0n);
 			const lengthVi = VarInt.from(frame.data.length);
 
-			const maxSize = 8 + 8 + 8 + frame.data.length;
+			const maxSize = 8 + 8 + 8 + 8 + frame.data.length;
 			let buffer = new Uint8Array(new ArrayBuffer(maxSize), 0, 0);
 
 			buffer = frameType.encode(buffer);
 			buffer = frame.id.value.encode(buffer);
+			buffer = offsetVi.encode(buffer);
 			buffer = lengthVi.encode(buffer);
 
 			buffer = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength + frame.data.length);
@@ -736,9 +739,10 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 		[v, buffer] = VarInt.decode(buffer);
 		const id = new Stream.Id(v);
 
-		// Skip offset if present
+		let offset = 0n;
 		if (hasOff) {
 			[v, buffer] = VarInt.decode(buffer);
+			offset = v.value;
 		}
 
 		let data: Uint8Array;
@@ -750,7 +754,7 @@ function decodeQMux(buffer: Uint8Array): Any | null {
 			data = buffer;
 		}
 
-		return { type: "stream", id, data, fin: hasFin };
+		return { type: "stream", id, offset, data, fin: hasFin };
 	}
 
 	// RESET_STREAM
@@ -934,8 +938,10 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 		[v, buffer] = VarInt.decode(buffer);
 		const id = new Stream.Id(v);
 
+		let offset = 0n;
 		if (hasOff) {
 			[v, buffer] = VarInt.decode(buffer);
+			offset = v.value;
 		}
 
 		let data: Uint8Array;
@@ -948,7 +954,7 @@ function decodeQMuxOne(buffer: Uint8Array): [Any | null, Uint8Array] | null {
 			buffer = buffer.slice(buffer.byteLength);
 		}
 
-		return [{ type: "stream", id, data, fin: hasFin }, buffer];
+		return [{ type: "stream", id, offset, data, fin: hasFin }, buffer];
 	}
 
 	// RESET_STREAM

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -344,6 +344,46 @@ describe("Session integration (scripted peer)", () => {
 		session.close();
 	});
 
+	test("sequential stream writes and FIN carry increasing OFF values", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		const writer = writable.getWriter();
+		await writer.write(new Uint8Array([1, 2, 3]));
+		await writer.write(new Uint8Array([4, 5]));
+		await writer.close();
+
+		await waitFor(() => peer.received().filter((frame) => frame.type === "stream").length === 3);
+		const streams = peer.received().filter((frame): frame is Frame.Data => frame.type === "stream");
+		expect(streams.map((frame) => frame.offset)).toEqual([0n, 3n, 5n]);
+		expect(streams.map((frame) => frame.fin)).toEqual([false, false, true]);
+
+		const streamTypes = peer.sent.map((record) => record[0]).filter((type) => type >= 0x08 && type <= 0x0f);
+		expect(streamTypes).toEqual([0x0e, 0x0e, 0x0f]);
+		session.close();
+	});
+
+	test("receive offsets are preserved but not enforced yet", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		peer.send({ type: "stream", id, offset: 0n, data: new Uint8Array([1, 2]), fin: false });
+		peer.send({ type: "stream", id, offset: 99n, data: new Uint8Array([3]), fin: true });
+
+		const incoming = await session.incomingUnidirectionalStreams.getReader().read();
+		if (incoming.done || !incoming.value) throw new Error("expected incoming stream");
+		const reader = incoming.value.getReader();
+		const first = await reader.read();
+		const second = await reader.read();
+		expect(Array.from(first.value ?? [])).toEqual([1, 2]);
+		expect(Array.from(second.value ?? [])).toEqual([3]);
+		session.close();
+	});
+
 	test("close() sends APPLICATION_CLOSE, resolves closed, and is idempotent", async () => {
 		const { session, peer } = connect();
 		await session.ready;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1379,8 +1379,8 @@ export default class Session implements WebTransport {
 		for (let offset = 0; offset < data.byteLength; ) {
 			const remaining = data.byteLength - offset;
 			// Cap by both the static frame-payload ceiling and the peer's record limit
-			// (qmux-01 only — once params are received). Leave 32 bytes of headroom for
-			// the STREAM frame header (frame type + stream id + length varints).
+			// (record-framed QMux only — once params are received). Leave 32 bytes of
+			// headroom for the STREAM frame header (type, stream ID, offset, and length).
 			let chunkMax = Math.min(remaining, MAX_FRAME_PAYLOAD);
 			if (usesRecords(this.#version) && this.#paramsReceived) {
 				const peerLimit = Number(this.#peerParams.maxRecordSize) - 32;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1373,6 +1373,9 @@ export default class Session implements WebTransport {
 	}
 
 	async #sendStreamDataWithFlowControl(id: Stream.Id, streamId: bigint, data: Uint8Array) {
+		const flow = this.#streamFlow.get(streamId);
+		if (!flow) throw new Error(`missing flow state for stream ${streamId}`);
+
 		for (let offset = 0; offset < data.byteLength; ) {
 			const remaining = data.byteLength - offset;
 			// Cap by both the static frame-payload ceiling and the peer's record limit
@@ -1391,11 +1394,16 @@ export default class Session implements WebTransport {
 			const sendable = Number(allowed);
 
 			const chunk = data.subarray(offset, offset + sendable);
+			const sendOffset = flow.sendOffset;
 
 			try {
-				await this.#enqueueStreamFrame(streamId, { type: "stream", id, data: chunk, fin: false });
-				const flow = this.#streamFlow.get(streamId);
-				if (flow) flow.sendOffset += BigInt(sendable);
+				await this.#enqueueStreamFrame(streamId, {
+					type: "stream",
+					id,
+					offset: sendOffset,
+					data: chunk,
+					fin: false,
+				});
 			} catch (e) {
 				// Return claimed credits on send failure
 				if (sendable > 0) {
@@ -1406,6 +1414,7 @@ export default class Session implements WebTransport {
 				throw e;
 			}
 
+			flow.sendOffset += BigInt(sendable);
 			offset += sendable;
 		}
 	}
@@ -1426,7 +1435,12 @@ export default class Session implements WebTransport {
 	/** Send the FIN. Routed through the stream's own queue so it stays ordered
 	 *  after that stream's data (not via the control lane, which would jump ahead). */
 	async #sendStreamFin(id: Stream.Id) {
-		await this.#enqueueStreamFrame(id.value.value, { type: "stream", id, data: new Uint8Array(), fin: true });
+		const streamId = id.value.value;
+		const offset = isQmux(this.#version) ? this.#streamFlow.get(streamId)?.sendOffset : undefined;
+		if (isQmux(this.#version) && offset === undefined) {
+			throw new Error(`missing flow state for stream ${streamId}`);
+		}
+		await this.#enqueueStreamFrame(streamId, { type: "stream", id, offset, data: new Uint8Array(), fin: true });
 	}
 
 	/** Enqueue a DATAGRAM frame on the scheduler's bounded, lossy datagram lane —

--- a/js/qmux/src/wire-format.test.ts
+++ b/js/qmux/src/wire-format.test.ts
@@ -130,17 +130,19 @@ describe("WebTransport wire format", () => {
 
 describe("QMux draft-00 wire format", () => {
 	test("stream with LEN bit (no fin)", () => {
-		// 0x0a = STREAM | LEN, id=4, len=2, "hi"
-		const wire = bytes(0x0a, 0x04, 0x02, 0x68, 0x69);
+		// 0x0e = STREAM | OFF | LEN, id=4, offset=5, len=2, "hi"
+		const wire = bytes(0x0e, 0x04, 0x05, 0x02, 0x68, 0x69);
 		const frame: Frame.Data = {
 			type: "stream",
 			id: sid(4n),
+			offset: 5n,
 			data: bytes(0x68, 0x69),
 			fin: false,
 		};
 		const decoded = Frame.decode(wire, "qmux-00") as Frame.Data;
 		expect(decoded.type).toBe("stream");
 		expect(decoded.id.value.value).toBe(4n);
+		expect(decoded.offset).toBe(5n);
 		expect(arr(decoded.data)).toEqual([0x68, 0x69]);
 		expect(decoded.fin).toBe(false);
 
@@ -148,8 +150,8 @@ describe("QMux draft-00 wire format", () => {
 	});
 
 	test("stream with LEN and FIN bits", () => {
-		// 0x0b = STREAM | LEN | FIN
-		const wire = bytes(0x0b, 0x08, 0x03, 0x62, 0x79, 0x65);
+		// 0x0f = STREAM | OFF | LEN | FIN, offset=0
+		const wire = bytes(0x0f, 0x08, 0x00, 0x03, 0x62, 0x79, 0x65);
 		const frame: Frame.Data = {
 			type: "stream",
 			id: sid(8n),
@@ -159,10 +161,17 @@ describe("QMux draft-00 wire format", () => {
 		const decoded = Frame.decode(wire, "qmux-00") as Frame.Data;
 		expect(decoded.type).toBe("stream");
 		expect(decoded.id.value.value).toBe(8n);
+		expect(decoded.offset).toBe(0n);
 		expect(arr(decoded.data)).toEqual([0x62, 0x79, 0x65]);
 		expect(decoded.fin).toBe(true);
 
 		expect(arr(Frame.encode(frame, "qmux-00"))).toEqual(arr(wire));
+	});
+
+	test("stream without OFF still decodes as offset zero", () => {
+		const decoded = Frame.decode(bytes(0x0a, 0x04, 0x02, 0x68, 0x69), "qmux-00") as Frame.Data;
+		expect(decoded.offset).toBe(0n);
+		expect(arr(decoded.data)).toEqual([0x68, 0x69]);
 	});
 
 	test("max_data (2-byte varint payload)", () => {
@@ -247,7 +256,7 @@ describe("QMux draft-00 wire format", () => {
 	test("QMux00 encoding does NOT prepend a record size varint", () => {
 		// Regression guard for the WebSocket record-framing fix.
 		const cases: [Frame.Any, number][] = [
-			[{ type: "stream", id: sid(4n), data: bytes(0x68, 0x69), fin: false }, 0x0a],
+			[{ type: "stream", id: sid(4n), data: bytes(0x68, 0x69), fin: false }, 0x0e],
 			[{ type: "max_data", max: 1024n }, 0x10],
 			[{ type: "application_close", code: code(42n), reason: "bye" }, 0x1d],
 		];

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -62,6 +62,11 @@ const _: () = assert!(
 pub struct Stream {
     /// The stream this data belongs to.
     pub id: StreamId,
+    /// Byte offset of this payload within the stream.
+    ///
+    /// Senders populate this field and always emit the OFF bit for QMux. The
+    /// receive path preserves it but does not yet enforce continuity.
+    pub offset: u64,
     /// The payload bytes.
     pub data: Bytes,
     /// Whether this is the final frame on the stream.
@@ -265,9 +270,11 @@ impl Frame {
 
             let id = StreamId(VarInt::decode(data)?);
 
-            if has_off {
-                let _offset = VarInt::decode(data)?;
-            }
+            let offset = if has_off {
+                VarInt::decode(data)?.into_inner()
+            } else {
+                0
+            };
 
             let stream_data = if has_len {
                 let len = VarInt::decode(data)?.into_inner();
@@ -282,6 +289,7 @@ impl Frame {
 
             return Ok(Some(Frame::Stream(Stream {
                 id,
+                offset,
                 data: stream_data,
                 fin: has_fin,
             })));
@@ -486,14 +494,13 @@ impl Frame {
     fn encode_qmux(&self, buf: &mut BytesMut) -> Result<(), Error> {
         match self {
             Frame::Stream(s) => {
-                // TODO(#294): Keep draft-02's offset-less behavior for compatibility.
-                // Once draft-03 is published and supported, emit OFF with the
-                // per-stream send offset and validate received offsets/terminal state.
-                // Always LEN bit (0x02), never OFF bit. Type = 0x0a | fin_bit
+                // Always set OFF (0x04) and LEN (0x02). Receivers preserve the
+                // offset but intentionally defer continuity enforcement.
                 let frame_type =
-                    VarInt::from_u32(STREAM_BASE | 0x02 | if s.fin { 0x01 } else { 0 });
+                    VarInt::from_u32(STREAM_BASE | 0x04 | 0x02 | if s.fin { 0x01 } else { 0 });
                 frame_type.encode(buf);
                 s.id.0.encode(buf);
+                VarInt::try_from(s.offset)?.encode(buf);
                 VarInt::try_from(s.data.len())?.encode(buf);
                 buf.put_slice(&s.data);
             }
@@ -627,6 +634,7 @@ impl Frame {
                 let id = StreamId(VarInt::decode(&mut data)?);
                 Ok(Frame::Stream(Stream {
                     id,
+                    offset: 0,
                     data,
                     fin: false,
                 }))
@@ -635,6 +643,7 @@ impl Frame {
                 let id = StreamId(VarInt::decode(&mut data)?);
                 Ok(Frame::Stream(Stream {
                     id,
+                    offset: 0,
                     data,
                     fin: true,
                 }))
@@ -664,9 +673,11 @@ impl Frame {
 
             let id = StreamId(VarInt::decode(&mut data)?);
 
-            if has_off {
-                let _offset = VarInt::decode(&mut data)?;
-            }
+            let offset = if has_off {
+                VarInt::decode(&mut data)?.into_inner()
+            } else {
+                0
+            };
 
             let stream_data = if has_len {
                 let len = VarInt::decode(&mut data)?.into_inner();
@@ -680,6 +691,7 @@ impl Frame {
 
             return Ok(Some(Frame::Stream(Stream {
                 id,
+                offset,
                 data: stream_data,
                 fin: has_fin,
             })));

--- a/rs/qmux/src/proto/mod.rs
+++ b/rs/qmux/src/proto/mod.rs
@@ -17,8 +17,8 @@ pub use params::DEFAULT_MAX_RECORD_SIZE;
 pub const MAX_FRAME_SIZE: usize = 16384;
 
 /// Maximum payload size for a STREAM frame, accounting for frame overhead.
-/// Overhead: frame_type (up to 8) + stream_id (up to 8) + length (up to 8) = 24 bytes.
-pub const MAX_FRAME_PAYLOAD: usize = MAX_FRAME_SIZE - 24;
+/// Overhead: frame type, stream ID, offset, and length (up to 8 bytes each).
+pub const MAX_FRAME_PAYLOAD: usize = MAX_FRAME_SIZE - 32;
 
 /// Number of bytes a QUIC varint occupies when encoding `v`.
 pub(crate) const fn varint_size(v: u64) -> u64 {

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -291,6 +291,7 @@ mod tests {
     fn frame(id: StreamId, tag: u8) -> Frame {
         Frame::Stream(Stream {
             id,
+            offset: 0,
             data: Bytes::copy_from_slice(&[tag]),
             fin: false,
         })

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -578,6 +578,7 @@ mod writer_final_size_tests {
             .transmit(
                 Stream {
                     id,
+                    offset: 0,
                     data: Bytes::from_static(b"abc"),
                     fin: false,
                 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -2128,6 +2128,7 @@ impl generic::SendStream for SendStream {
 
             let frame = Stream {
                 id: self.id,
+                offset: self.offset,
                 data: buf.copy_to_bytes(to_send),
                 fin: false,
             };
@@ -2192,6 +2193,7 @@ impl generic::SendStream for SendStream {
 
         let frame = Stream {
             id: self.id,
+            offset: self.offset,
             data: Bytes::new(),
             fin: true,
         };
@@ -2572,6 +2574,55 @@ mod negotiate_tests {
 }
 
 #[cfg(test)]
+mod send_offset_tests {
+    use bytes::Bytes;
+    use tokio::sync::mpsc;
+    use web_transport_trait::SendStream as _;
+
+    use super::SendStream;
+    use crate::sched::PriorityQueue;
+    use crate::{Frame, StreamDir, StreamId};
+
+    #[tokio::test]
+    async fn sequential_writes_and_fin_carry_send_offsets() {
+        let id = StreamId::new(0, StreamDir::Uni, false);
+        let outbound = PriorityQueue::new(3);
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let (_stop_tx, stop_rx) = mpsc::unbounded_channel();
+        let mut send = SendStream {
+            id,
+            outbound: outbound.clone(),
+            outbound_priority: control,
+            inbound_stopped: stop_rx,
+            offset: 0,
+            priority: 0,
+            closed: None,
+            fin: false,
+            stream_credit: None,
+            conn_credit: None,
+        };
+
+        send.write(&[1, 2, 3]).await.unwrap();
+        send.write(&[4, 5]).await.unwrap();
+        send.finish().unwrap();
+
+        let expected: &[(u64, &[u8], bool)] =
+            &[(0, &[1, 2, 3], false), (3, &[4, 5], false), (5, &[], true)];
+        for &(offset, data, fin) in expected {
+            let frame = outbound.pop().await.expect("queued STREAM frame");
+            match frame {
+                Frame::Stream(stream) => {
+                    assert_eq!(stream.offset, offset);
+                    assert_eq!(stream.data, Bytes::copy_from_slice(data));
+                    assert_eq!(stream.fin, fin);
+                }
+                other => panic!("expected STREAM, got {other:?}"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod recv_open_tests {
     use std::time::Duration;
 
@@ -2647,8 +2698,13 @@ mod recv_open_tests {
     /// Encode a STREAM frame on a server-initiated uni stream (peer-initiated and
     /// receivable, since we're the client).
     fn uni_stream(index: u64, data: &'static [u8], fin: bool) -> Bytes {
+        uni_stream_at(index, 0, data, fin)
+    }
+
+    fn uni_stream_at(index: u64, offset: u64, data: &'static [u8], fin: bool) -> Bytes {
         Frame::Stream(Stream {
             id: StreamId::new(index, StreamDir::Uni, true),
+            offset,
             data: Bytes::from_static(data),
             fin,
         })
@@ -2694,6 +2750,20 @@ mod recv_open_tests {
             second.is_err(),
             "a late frame on a retired stream resurrected a new accepted stream"
         );
+    }
+
+    #[tokio::test]
+    async fn recv_stream_offsets_are_not_enforced_yet() {
+        let (session, tx) = scripted_session();
+
+        tx.send(uni_stream_at(0, 0, b"hello", false)).unwrap();
+        tx.send(uni_stream_at(0, 99, b"world", true)).unwrap();
+
+        let mut recv = tokio::time::timeout(Duration::from_secs(1), session.accept_uni())
+            .await
+            .expect("accept_uni timed out")
+            .expect("accept_uni failed");
+        assert_eq!(recv.read_all().await.unwrap().as_ref(), b"helloworld");
     }
 
     /// A FIN for a higher stream index arriving before the first frame of a lower
@@ -3138,6 +3208,7 @@ mod qmux02_recv_tests {
         // A STREAM frame ahead of any params.
         let stream = Frame::Stream(Stream {
             id: StreamId::new(0, StreamDir::Uni, false),
+            offset: 0,
             data: Bytes::from_static(b"hi"),
             fin: false,
         })
@@ -3230,6 +3301,7 @@ mod qmux02_recv_tests {
         let id = StreamId::new(0, StreamDir::Uni, false);
         let stream = Frame::Stream(Stream {
             id,
+            offset: 0,
             data: Bytes::from_static(b"hi"),
             fin: false,
         })

--- a/rs/qmux/tests/qmux01.rs
+++ b/rs/qmux/tests/qmux01.rs
@@ -80,6 +80,7 @@ fn record_round_trip_multiple_frames() {
     let frames = vec![
         Frame::Stream(Stream {
             id: stream_id,
+            offset: 0,
             data: Bytes::from_static(b"hello"),
             fin: false,
         }),

--- a/rs/qmux/tests/wire_format.rs
+++ b/rs/qmux/tests/wire_format.rs
@@ -47,6 +47,7 @@ fn assert_frames_eq(got: &Frame, want: &Frame, version: Version) {
     match (got, want) {
         (Frame::Stream(a), Frame::Stream(b)) => {
             assert_eq!(a.id.0.into_inner(), b.id.0.into_inner(), "stream id");
+            assert_eq!(a.offset, b.offset, "stream offset");
             assert_eq!(a.data.as_ref(), b.data.as_ref(), "stream data");
             assert_eq!(a.fin, b.fin, "stream fin");
         }
@@ -142,6 +143,7 @@ fn webtransport_stream_no_fin() {
     let bytes = [0x08, 0x04, b'h', b'i'];
     let frame = Frame::Stream(Stream {
         id: sid(4),
+        offset: 0,
         data: Bytes::from_static(b"hi"),
         fin: false,
     });
@@ -154,6 +156,7 @@ fn webtransport_stream_fin() {
     let bytes = [0x09, 0x08, b'b', b'y', b'e'];
     let frame = Frame::Stream(Stream {
         id: sid(8),
+        offset: 0,
         data: Bytes::from_static(b"bye"),
         fin: true,
     });
@@ -212,10 +215,11 @@ fn webtransport_connection_close() {
 
 #[test]
 fn qmux00_stream_with_len_no_fin() {
-    // 0x0a = STREAM | LEN (no OFF, no FIN), id=4, len=2, "hi".
-    let bytes = [0x0a, 0x04, 0x02, b'h', b'i'];
+    // 0x0e = STREAM | OFF | LEN (no FIN), id=4, offset=5, len=2, "hi".
+    let bytes = [0x0e, 0x04, 0x05, 0x02, b'h', b'i'];
     let frame = Frame::Stream(Stream {
         id: sid(4),
+        offset: 5,
         data: Bytes::from_static(b"hi"),
         fin: false,
     });
@@ -224,14 +228,35 @@ fn qmux00_stream_with_len_no_fin() {
 
 #[test]
 fn qmux00_stream_with_len_and_fin() {
-    // 0x0b = STREAM | LEN | FIN, id=8, len=3, "bye".
-    let bytes = [0x0b, 0x08, 0x03, b'b', b'y', b'e'];
+    // 0x0f = STREAM | OFF | LEN | FIN, id=8, offset=0, len=3, "bye".
+    let bytes = [0x0f, 0x08, 0x00, 0x03, b'b', b'y', b'e'];
     let frame = Frame::Stream(Stream {
         id: sid(8),
+        offset: 0,
         data: Bytes::from_static(b"bye"),
         fin: true,
     });
     assert_round_trip(Version::QMux00, &bytes, &frame);
+}
+
+#[test]
+fn qmux00_still_decodes_stream_without_off() {
+    // Receiver compatibility: absence of OFF still means offset zero, and the
+    // receive path does not enforce continuity yet.
+    let decoded = Frame::decode(
+        Bytes::from_static(&[0x0a, 0x04, 0x02, b'h', b'i']),
+        Version::QMux00,
+    )
+    .expect("legacy STREAM decodes")
+    .expect("STREAM is returned");
+
+    match decoded {
+        Frame::Stream(stream) => {
+            assert_eq!(stream.offset, 0);
+            assert_eq!(stream.data.as_ref(), b"hi");
+        }
+        other => panic!("expected stream, got {other:?}"),
+    }
 }
 
 #[test]
@@ -309,6 +334,7 @@ fn record_datagram_then_stream_decodes_both() {
         .unwrap();
     let stream = Frame::Stream(Stream {
         id: sid(4),
+        offset: 0,
         data: Bytes::from_static(b"bye"),
         fin: false,
     })
@@ -375,6 +401,7 @@ fn qmux02_reset_stream_at_in_record() {
     let reset_at = [0x24u8, 0x04, 0x2a, 0x40, 0x80, 0x40, 0x40];
     let stream = Frame::Stream(Stream {
         id: sid(8),
+        offset: 0,
         data: Bytes::from_static(b"bye"),
         fin: false,
     })
@@ -403,6 +430,7 @@ fn qmux02_wire_matches_qmux01() {
     let frames: Vec<Frame> = vec![
         Frame::Stream(Stream {
             id: sid(4),
+            offset: 0,
             data: Bytes::from_static(b"hi"),
             fin: true,
         }),
@@ -564,6 +592,7 @@ fn qmux00_encoding_has_no_record_size_prefix() {
     let cases: Vec<Frame> = vec![
         Frame::Stream(Stream {
             id: sid(4),
+            offset: 0,
             data: Bytes::from_static(b"hi"),
             fin: false,
         }),
@@ -577,7 +606,7 @@ fn qmux00_encoding_has_no_record_size_prefix() {
         let bytes = frame.encode(Version::QMux00).unwrap();
         // The first byte must match the encoder's frame-type tag directly — not a size varint.
         match frame {
-            Frame::Stream(_) => assert_eq!(bytes[0], 0x0a, "stream without fin = type 0x0a"),
+            Frame::Stream(_) => assert_eq!(bytes[0], 0x0e, "stream without fin = type 0x0e"),
             Frame::MaxData(_) => assert_eq!(bytes[0], 0x10, "max_data = type 0x10"),
             Frame::ApplicationClose(_) => {
                 assert_eq!(bytes[0], 0x1d, "application_close = type 0x1d")


### PR DESCRIPTION
## Summary

- emit the QUIC STREAM `OFF` bit and offset field for every QMux STREAM frame in Rust and TypeScript
- track each stream's sent-byte offset across sequential writes and put the final offset on FIN
- preserve decoded offsets while deliberately deferring receive-side continuity and terminal-state enforcement
- account for the additional offset varint in the maximum STREAM payload calculation

## Why

QMux senders previously emitted `LEN` without `OFF`, so every frame implicitly claimed offset zero. Multi-frame streams therefore produced invalid offsets for conforming peers even though both implementations already tracked or could track sent bytes per stream.

The legacy `webtransport` wire format is unchanged. QMux receivers still accept frames without `OFF` and still concatenate gaps or overlaps for now; enforcement remains a follow-up.

Refs #294.

## Validation

- `CARGO_TARGET_DIR=/tmp/web-transport-target cargo test -p qmux --all-features`
- `CARGO_TARGET_DIR=/tmp/web-transport-target cargo clippy -p qmux --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `TMPDIR=/tmp bun test --cwd js/qmux` (103 tests)
- `TMPDIR=/tmp bun run --cwd js/qmux check`
- `TMPDIR=/tmp bun run check`
