### PR TITLE
fix(qmux): normalize native WebSocketStream binary input

### DIFF
--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -17,7 +17,7 @@ class FakePeer {
 
 	readonly url: string;
 	readonly opened: Promise<{
-		readable: ReadableStream<Uint8Array | string>;
+		readable: ReadableStream<Uint8Array | ArrayBuffer | string>;
 		writable: WritableStream<Uint8Array>;
 		protocol: string;
 		extensions: string;
@@ -25,7 +25,7 @@ class FakePeer {
 	readonly closed: Promise<{ closeCode?: number; reason?: string }>;
 	#closedResolve: (info: { closeCode?: number; reason?: string }) => void;
 	#closedReject: (err: Error) => void;
-	#recv!: ReadableStreamDefaultController<Uint8Array | string>;
+	#recv!: ReadableStreamDefaultController<Uint8Array | ArrayBuffer | string>;
 	#writeBlocked: Promise<void> | undefined;
 	#unblockWrites: (() => void) | undefined;
 
@@ -36,7 +36,7 @@ class FakePeer {
 	constructor(url: string) {
 		this.url = url;
 		FakePeer.last = this;
-		const readable = new ReadableStream<Uint8Array | string>({
+		const readable = new ReadableStream<Uint8Array | ArrayBuffer | string>({
 			start: (c) => {
 				this.#recv = c;
 			},
@@ -90,6 +90,11 @@ class FakePeer {
 	 * (e.g. the no-length 0x30 datagram form). */
 	sendRaw(bytes: Uint8Array) {
 		this.#recv.enqueue(bytes);
+	}
+	/** Inject a binary record with the shape Chromium's native WebSocketStream
+	 * uses for incoming binary messages. */
+	sendArrayBuffer(frame: Frame.Any) {
+		this.#recv.enqueue(Uint8Array.from(Frame.encode(frame, "qmux-01")).buffer);
 	}
 	/** All frames the Session has written so far, decoded. */
 	received(): Frame.Any[] {
@@ -415,6 +420,17 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "datagram", data: new Uint8Array([9, 8, 7]) });
 		const { value } = await session.datagrams.readable.getReader().read();
 		expect(Array.from(value as Uint8Array)).toEqual([9, 8, 7]);
+		session.close();
+	});
+
+	test("native WebSocketStream ArrayBuffer records are normalized before QMux decoding", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.sendArrayBuffer({ type: "datagram", data: new Uint8Array([4, 5, 6]) });
+		const { value } = await session.datagrams.readable.getReader().read();
+		expect(Array.from(value as Uint8Array)).toEqual([4, 5, 6]);
 		session.close();
 	});
 

--- a/js/web-socket-stream/src/index.ts
+++ b/js/web-socket-stream/src/index.ts
@@ -48,6 +48,30 @@ export interface WebSocketStreamLike {
 	setHighWaterMark?(bytes: number): void;
 }
 
+/** Chromium's native API yields binary messages as `ArrayBuffer`. The public
+ *  `WebSocketStreamLike` shape exposes normalized `Uint8Array` chunks so callers
+ *  see the same data type whether the native implementation or ponyfill wins. */
+type NativeWebSocketStreamData = WebSocketStreamData | ArrayBuffer;
+
+interface NativeWebSocketStreamOpenEvent {
+	readable: ReadableStream<NativeWebSocketStreamData>;
+	writable: WritableStream<WebSocketStreamData>;
+	extensions: string;
+	protocol: string;
+}
+
+interface NativeWebSocketStreamLike {
+	readonly url: string;
+	readonly opened: Promise<NativeWebSocketStreamOpenEvent>;
+	readonly closed: Promise<WebSocketStreamCloseEvent>;
+	close(closeInfo?: WebSocketStreamCloseInfo): void;
+}
+
+type NativeWebSocketStreamConstructor = new (
+	url: string,
+	options?: Pick<WebSocketStreamOptions, "protocols" | "signal">,
+) => NativeWebSocketStreamLike;
+
 /** The slice of the `WebSocket` API this ponyfill relies on. Both the browser
  *  `WebSocket` and Node's `ws` satisfy it. */
 export interface WebSocketLike {
@@ -219,12 +243,27 @@ export class WebSocketStream implements WebSocketStreamLike {
  *  socket). */
 export function openWebSocketStream(url: string | URL, options: WebSocketStreamOptions = {}): WebSocketStreamLike {
 	const href = typeof url === "string" ? url : url.toString();
-	const Native = (globalThis as { WebSocketStream?: typeof WebSocketStream }).WebSocketStream;
+	const Native = (globalThis as { WebSocketStream?: NativeWebSocketStreamConstructor }).WebSocketStream;
 	// Only delegate to a *genuinely* native global — if `install()` put this very
 	// ponyfill on the global, fall through so ponyfill-only options (e.g.
 	// highWaterMark) aren't dropped on the floor.
 	if (Native && Native !== WebSocketStream && !options.webSocket) {
-		return new Native(href, { protocols: options.protocols, signal: options.signal });
+		const native = new Native(href, { protocols: options.protocols, signal: options.signal });
+		return {
+			url: native.url,
+			opened: native.opened.then((event) => ({
+				...event,
+				readable: event.readable.pipeThrough(
+					new TransformStream<NativeWebSocketStreamData, WebSocketStreamData>({
+						transform(chunk, controller) {
+							controller.enqueue(chunk instanceof ArrayBuffer ? new Uint8Array(chunk) : chunk);
+						},
+					}),
+				),
+			})),
+			closed: native.closed,
+			close: (closeInfo) => native.close(closeInfo),
+		};
 	}
 	return new WebSocketStream(href, options);
 }


### PR DESCRIPTION
## Summary

- normalize Chromium native `WebSocketStream` `ArrayBuffer` messages to `Uint8Array` at the transport boundary
- keep the public `WebSocketStreamLike` readable consistent across native and ponyfill implementations
- add an end-to-end QMux regression using a native-shaped stream fake

## Root cause

Chromium's native `WebSocketStream` yields binary messages as `ArrayBuffer`, while QMux and the shared transport type expected `Uint8Array | string`. An `ArrayBuffer` could therefore reach `VarInt.decode`, where the decoder accessed `.buffer` and passed `undefined` to `DataView`.

## Impact

Native Chromium WebSocket sessions can decode binary QMux records without intermittently crashing. Text-frame protocol validation and ponyfill behavior are unchanged.

## Testing

- `bun test js/qmux/src js/web-socket-stream/src` (115 passing)
- `bun run --cwd js/qmux check`
- `bun run --cwd js/web-socket-stream check`
- `bunx biome check js/web-socket-stream/src/index.ts js/qmux/src/session.test.ts`

Closes moq-dev/moq.pro#654
