### PR TITLE
Narrow QMux public API

### DIFF
--- a/rs/qmux/CHANGELOG.md
+++ b/rs/qmux/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- *(qmux)* the `Transport` trait now splits into `TransportWriter` + `TransportReader` halves via `Transport::split`; `send`/`recv`/`close` moved onto those halves and `TransportWriter::maintain` was added for timer-driven work (e.g. WebSocket keep-alive). Custom `Transport` implementations must adopt the new shape; the built-in TCP/TLS/Unix/WebSocket transports and `Session::connect`/`accept` are unaffected.
+- *(qmux)* the `Transport` trait now splits into `Writer` + `Reader` halves via `Transport::split`; `send`/`recv`/`close` moved onto those halves and `Writer::maintain` was added for timer-driven work (e.g. WebSocket keep-alive). Custom `Transport` implementations must adopt the new shape; the built-in TCP/TLS/Unix/WebSocket transports and `Session::connect`/`accept` are unaffected.
+- *(qmux)* the wire-format `proto` module is now internal. Use the session and stream APIs instead of constructing or matching protocol frames directly.
+- *(qmux)* `Version` and `KeepAlive` are now `#[non_exhaustive]`, and `StreamId` is now opaque with `StreamId::into_inner` for reading its encoded value. This prevents future protocol versions and configuration fields from causing incidental API breaks.
 
 ## [0.3.1](https://github.com/moq-dev/web-transport/compare/qmux-v0.2.0...qmux-v0.3.1) - 2026-06-25
 

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -72,7 +72,7 @@ pub struct Config {
     /// [`max_record_size`](Config::max_record_size). Datagrams are a
     /// record-framed-draft feature (QMux01+); this is ignored on QMux00 and the
     /// legacy `webtransport` format. Default:
-    /// [`DEFAULT_MAX_RECORD_SIZE`](crate::proto::DEFAULT_MAX_RECORD_SIZE).
+    /// 16382 bytes.
     pub max_datagram_frame_size: u64,
 
     /// How long [`Session::connect`](crate::Session::connect) /

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -10,7 +10,7 @@ mod alpn;
 mod config;
 mod credit;
 mod error;
-pub mod proto;
+mod proto;
 mod protocol;
 mod sched;
 mod session;
@@ -35,6 +35,8 @@ pub mod tls;
 #[cfg(feature = "ws")]
 pub mod ws;
 
+// Re-export the WebSocket dependencies so downstream integrations can use the
+// exact versions compatible with QMux's public WebSocket types.
 #[cfg(feature = "ws")]
 pub use tokio_tungstenite;
 

--- a/rs/qmux/src/proto/frame.rs
+++ b/rs/qmux/src/proto/frame.rs
@@ -30,8 +30,6 @@ const CONNECTION_CLOSE: VarInt = VarInt::from_u32(0x1c);
 // varint costs 1-2 bytes. Both forms decode.
 const DATAGRAM_LEN: VarInt = VarInt::from_u32(0x31);
 
-const PADDING: VarInt = VarInt::from_u32(0x00);
-
 // QX_TRANSPORT_PARAMETERS magic: "\xffQMX\r\n\r\n"
 // This exceeds u32 range, so we use try_from at decode time and a pre-computed const for encode.
 const QX_TRANSPORT_PARAMETERS: u64 = 0x3f5153300d0a0d0a;
@@ -179,7 +177,6 @@ impl From<Bytes> for Datagram {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Frame {
-    Padding,
     ResetStream(ResetStream),
     StopSending(StopSending),
     ConnectionClose(ConnectionClose),
@@ -212,14 +209,12 @@ impl Frame {
     /// the transport layer is responsible for delimiting records (size
     /// varint on TCP/TLS; implicit on WebSocket message boundaries).
     pub fn encode(&self, version: Version) -> Result<Bytes, Error> {
-        // Reject record-layer frames (PADDING, QX_PING, DATAGRAM) for versions
+        // Reject record-layer frames (QX_PING, DATAGRAM) for versions
         // that don't use records, so a misrouted call can't accidentally emit
         // draft-01+ wire bytes on a draft-00 / webtransport session.
         if !version.uses_records() {
             match self {
-                Frame::Padding | Frame::Ping(_) | Frame::Datagram(_) => {
-                    return Err(Error::InvalidFrameType(0))
-                }
+                Frame::Ping(_) | Frame::Datagram(_) => return Err(Error::InvalidFrameType(0)),
                 _ => {}
             }
         }
@@ -572,9 +567,6 @@ impl Frame {
                 let payload = params.encode()?;
                 VarInt::try_from(payload.len())?.encode(buf);
                 buf.put_slice(&payload);
-            }
-            Frame::Padding => {
-                PADDING.encode(buf);
             }
             Frame::Ping(ping) => {
                 if ping.response {

--- a/rs/qmux/src/proto/mod.rs
+++ b/rs/qmux/src/proto/mod.rs
@@ -4,6 +4,9 @@ mod frame;
 mod params;
 mod version;
 
+#[cfg(test)]
+mod wire_format_tests;
+
 pub use frame::*;
 pub(crate) use params::*;
 pub use version::*;

--- a/rs/qmux/src/proto/version.rs
+++ b/rs/qmux/src/proto/version.rs
@@ -1,6 +1,7 @@
 /// The wire format version used for frame encoding/decoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
+#[non_exhaustive]
 pub enum Version {
     /// Legacy "webtransport" wire format (WebSocket only).
     /// Frame type as u8, no flow control, simplified STREAM/RESET_STREAM/CONNECTION_CLOSE.

--- a/rs/qmux/src/proto/wire_format_tests.rs
+++ b/rs/qmux/src/proto/wire_format_tests.rs
@@ -20,9 +20,13 @@
 //! encodes as `0x44 0x00`.
 
 use bytes::Bytes;
-use qmux::proto::{ApplicationClose, ConnectionClose, Frame, ResetStream, StopSending, Stream};
-use qmux::{Error, StreamId, Version};
 use web_transport_proto::VarInt;
+
+use super::{
+    ApplicationClose, ConnectionClose, Frame, Ping, ResetStream, StopSending, Stream,
+    DEFAULT_MAX_RECORD_SIZE,
+};
+use crate::{Error, StreamId, Version};
 
 /// Round-trip helper: hard-coded bytes ↔ expected frame, both directions.
 fn assert_round_trip(version: Version, bytes: &[u8], expected: &Frame) {
@@ -131,6 +135,54 @@ fn sid(v: u64) -> StreamId {
 
 fn code(v: u64) -> VarInt {
     VarInt::try_from(v).unwrap()
+}
+
+/// Round-trip multiple frames concatenated inside one record body.
+///
+/// Records can carry several frames, so `decode_record` must keep parsing
+/// until the buffer is exhausted and stop cleanly at the boundary.
+#[test]
+fn record_round_trip_multiple_frames() {
+    let frames = vec![
+        Frame::Stream(Stream {
+            id: sid(0),
+            offset: 0,
+            data: Bytes::from_static(b"hello"),
+            fin: false,
+        }),
+        Frame::Ping(Ping {
+            sequence: 42,
+            response: false,
+        }),
+        Frame::MaxData(1024),
+    ];
+
+    let mut body = bytes::BytesMut::new();
+    for frame in &frames {
+        body.extend_from_slice(&frame.encode(Version::QMux01).unwrap());
+    }
+
+    let decoded = Frame::decode_record(body.freeze()).unwrap();
+    assert_eq!(decoded.len(), 3);
+
+    match &decoded[0] {
+        Frame::Stream(stream) => {
+            assert_eq!(stream.data.as_ref(), b"hello");
+            assert!(!stream.fin);
+        }
+        other => panic!("expected Stream, got {other:?}"),
+    }
+    match &decoded[1] {
+        Frame::Ping(ping) => {
+            assert_eq!(ping.sequence, 42);
+            assert!(!ping.response);
+        }
+        other => panic!("expected Ping, got {other:?}"),
+    }
+    match &decoded[2] {
+        Frame::MaxData(value) => assert_eq!(*value, 1024),
+        other => panic!("expected MaxData, got {other:?}"),
+    }
 }
 
 // --------------------------------------------------------------------------
@@ -568,7 +620,7 @@ fn qmux00_transport_parameters_initial_max_data_only() {
             // decode() seeds with DEFAULT_MAX_RECORD_SIZE per draft-01.
             assert_eq!(p.initial_max_stream_data_bidi_local, 0);
             assert_eq!(p.initial_max_streams_bidi, 0);
-            assert_eq!(p.max_record_size, qmux::proto::DEFAULT_MAX_RECORD_SIZE);
+            assert_eq!(p.max_record_size, DEFAULT_MAX_RECORD_SIZE);
             p
         }
         other => panic!("expected TransportParameters, got {other:?}"),

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1243,8 +1243,6 @@ impl<R: Reader> SessionState<R> {
             | Frame::StreamDataBlocked { .. }
             | Frame::StreamsBlockedBidi(_)
             | Frame::StreamsBlockedUni(_) => {}
-            // PADDING is a no-op
-            Frame::Padding => {}
             // QX_PING: respond to requests, ignore responses.
             Frame::Ping(ping) => {
                 // Draft-02 tightens the sequence-number rules.

--- a/rs/qmux/src/stream.rs
+++ b/rs/qmux/src/stream.rs
@@ -11,7 +11,7 @@ pub enum StreamDir {
 
 /// A QUIC-style stream identifier encoding direction and initiator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct StreamId(pub VarInt);
+pub struct StreamId(pub(crate) VarInt);
 
 impl StreamId {
     /// Create a new stream ID with the given sequence number, direction, and initiator.
@@ -24,6 +24,11 @@ impl StreamId {
             stream_id |= 0x01;
         }
         StreamId(VarInt::try_from(stream_id).expect("stream ID too large"))
+    }
+
+    /// Return the encoded QUIC stream ID value.
+    pub fn into_inner(self) -> u64 {
+        self.0.into_inner()
     }
 
     /// Returns the stream direction (bidirectional or unidirectional).

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -8,6 +8,11 @@ use crate::Error;
 /// For WebSocket, this maps to individual WS binary messages.
 /// For TCP/TLS byte streams, the transport handles frame delimiting.
 ///
+/// Use [`Stream`] for arbitrary [`AsyncRead`](tokio::io::AsyncRead) +
+/// [`AsyncWrite`](tokio::io::AsyncWrite) byte streams. Implement this trait when
+/// integrating a transport with its own message boundaries, framing, or
+/// lifecycle that the built-in byte-stream and WebSocket adapters do not cover.
+///
 /// A transport splits into independently-owned send and receive halves so the
 /// session can drive them on separate tasks: a write blocked on transport
 /// backpressure must never stall reads (and vice versa). This decoupling is what

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -15,6 +15,7 @@ use crate::{alpn, Config, Error, Session, Version};
 /// hours. Set this to send periodic Pings and close the session if no
 /// frame arrives within `timeout`.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct KeepAlive {
     /// How often to send a Ping frame to the peer.
     pub interval: Duration,

--- a/rs/qmux/tests/qmux01.rs
+++ b/rs/qmux/tests/qmux01.rs
@@ -4,11 +4,8 @@
 
 use std::time::Duration;
 
-use bytes::Bytes;
-use qmux::proto::{Frame, Ping, Stream};
-use qmux::{StreamId, Version};
+use qmux::Version;
 use tokio::net::TcpListener;
-use web_transport_proto::VarInt;
 use web_transport_trait::{RecvStream, SendStream, Session as _};
 
 /// Byte-level wire snapshot: QMux00 must NOT prepend a size varint, QMux01 must.
@@ -68,57 +65,6 @@ async fn wire_format_size_prefix_qmux01_only() {
         qmux01_bytes[size_len], 0xff,
         "expected QX_TRANSPORT_PARAMETERS frame type after the {size_len}-byte size varint"
     );
-}
-
-/// Round-trip multiple frames concatenated inside one record body.
-///
-/// Records can carry several frames, so `decode_record` must keep parsing
-/// until the buffer is exhausted and stop cleanly at the boundary.
-#[test]
-fn record_round_trip_multiple_frames() {
-    let stream_id = StreamId(VarInt::from_u32(0));
-    let frames = vec![
-        Frame::Stream(Stream {
-            id: stream_id,
-            offset: 0,
-            data: Bytes::from_static(b"hello"),
-            fin: false,
-        }),
-        Frame::Ping(Ping {
-            sequence: 42,
-            response: false,
-        }),
-        Frame::MaxData(1024),
-    ];
-
-    // Concatenate the encoded frames as a single record body — the same way the
-    // wire layer would lay them out inside one record.
-    let mut body = bytes::BytesMut::new();
-    for frame in &frames {
-        body.extend_from_slice(&frame.encode(Version::QMux01).unwrap());
-    }
-
-    let decoded = Frame::decode_record(body.freeze()).unwrap();
-    assert_eq!(decoded.len(), 3);
-
-    match &decoded[0] {
-        Frame::Stream(s) => {
-            assert_eq!(s.data.as_ref(), b"hello");
-            assert!(!s.fin);
-        }
-        other => panic!("expected Stream, got {other:?}"),
-    }
-    match &decoded[1] {
-        Frame::Ping(p) => {
-            assert_eq!(p.sequence, 42);
-            assert!(!p.response);
-        }
-        other => panic!("expected Ping, got {other:?}"),
-    }
-    match &decoded[2] {
-        Frame::MaxData(v) => assert_eq!(*v, 1024),
-        other => panic!("expected MaxData, got {other:?}"),
-    }
 }
 
 /// QMux00 round-trip over TCP, exercising the legacy wire format.


### PR DESCRIPTION
## Summary

- make QMux wire-format protocol modules private while preserving their byte-level regression tests as crate-local tests
- keep `Transport`, `Reader`, and `Writer` public for downstream custom transport implementations, and clarify when to implement the trait versus wrapping an `AsyncRead + AsyncWrite` stream
- future-proof `Version`, `KeepAlive`, and `StreamId` against incidental semver breaks
- preserve the `tokio_tungstenite` and `tungstenite` re-exports used by downstream MoQ crates

## Why

`cargo-semver-checks` treated internal frame representation changes as public API breaks because `qmux::proto` re-exported all frame types. New QMux drafts also necessarily add `Version` variants. This narrows the public compatibility contract to the session, stream, adapter, and intentionally extensible transport APIs.

This is a one-time breaking cleanup for the next QMux minor release; subsequent internal frame changes and new version variants should no longer create unrelated semver failures.

## Impact

Downstream code constructing or matching `qmux::proto` frames must move to the session and stream APIs. Custom `Transport` implementations remain supported. `StreamId` callers can use `into_inner()` to read the encoded value.

## Validation

- `cargo check -p qmux --all-targets --all-features --offline`
- `cargo test -p qmux --all-features --offline`
- `cargo clippy -p qmux --lib --all-features --offline -- -D warnings`
- `cargo fmt --all --check`

The repository-wide `just check` and `just fix` commands were attempted but could not start because another process held the shared Cargo build lock.
