### PR TITLE
fix(wasm): send datagrams via createWritable(), not deprecated .writable when available

### DIFF
--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -1,9 +1,11 @@
 use bytes::Bytes;
-use js_sys::{Reflect, Uint8Array};
+use js_sys::{Function, Reflect, Uint8Array};
 use url::Url;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    WebTransport, WebTransportBidirectionalStream, WebTransportCloseInfo, WebTransportSendStream,
+    WebTransport, WebTransportBidirectionalStream, WebTransportCloseInfo,
+    WebTransportDatagramDuplexStream, WebTransportSendStream, WritableStream,
 };
 
 use crate::{Error, RecvStream, SendStream};
@@ -21,6 +23,22 @@ pub struct Session {
     inner: WebTransport,
     url: Url,
     protocol: Option<String>,
+}
+
+/// The datagram writer. The current spec exposes it via `createWritable()`; the
+/// `.writable` property is deprecated, non-standard, and unimplemented by Safari
+/// (there `.writable` is `undefined`, so datagram sending throws). Prefer
+/// `createWritable()`, falling back to `.writable` for browsers that still have it.
+/// MDN — the `.writable` deprecation note and the feature-detect example:
+/// <https://developer.mozilla.org/en-US/docs/Web/API/WebTransportDatagramDuplexStream/writable>
+/// <https://developer.mozilla.org/en-US/docs/Web/API/WebTransport/datagrams#writing_an_outgoing_datagram>
+fn datagram_writable(dg: &WebTransportDatagramDuplexStream) -> WritableStream {
+    Reflect::get(dg, &"createWritable".into())
+        .ok()
+        .and_then(|f| f.dyn_into::<Function>().ok())
+        .and_then(|f| f.call0(dg).ok())
+        .and_then(|ws| ws.dyn_into::<WritableStream>().ok())
+        .unwrap_or_else(|| dg.writable())
 }
 
 impl Session {
@@ -85,7 +103,7 @@ impl Session {
 
     /// Send a datagram over the network.
     pub async fn send_datagram(&self, payload: Bytes) -> Result<(), Error> {
-        let mut writer = Writer::new(&self.inner.datagrams().writable())?;
+        let mut writer = Writer::new(&datagram_writable(&self.inner.datagrams()))?;
         writer.write(&Uint8Array::from(payload.as_ref())).await?;
         Ok(())
     }


### PR DESCRIPTION
Ran into this issue when using the web_transport_wasm crate & testing in a iOS PWA. 

### Summary
Send datagrams through WebTransportDatagramDuplexStream.createWritable() (current spec) instead of the deprecated .writable fall back to .writable for browsers that still expose it reach createWritable via Reflect (no web-sys binding yet), matching the existing protocol/sendOrder stopgaps

### Root cause
WebTransportDatagramDuplexStream.writable is [deprecated and non-standard](https://developer.mozilla.org/en-US/docs/Web/API/WebTransportDatagramDuplexStream/writable), and Safari/WebKit does not implement it. On Safari datagrams.writable is undefined, so Writer::new(&datagrams().writable()) throws TypeError: undefined is not an object and send_datagram fails. Chrome still exposes the deprecated property, so datagram sending worked there and the breakage was Safari-only. recv_datagram uses datagrams.readable, which Safari implements, so receiving is unaffected.

https://developer.mozilla.org/en-US/docs/Web/API/WebTransport/datagrams#writing_an_outgoing_datagram shows an example that implements the same fallback pattern as shown here. 

### Impact
Datagram sending works on Safari (desktop and iOS) in addition to Chrome. Chrome behavior and datagram receiving are unchanged, and the .writable fallback keeps older browsers working.

### Testing
before — Safari (desktop + iOS) 0/N datagrams (datagrams.writable undefined), Chrome N/N
after — Safari and Chrome both N/N (reliable streams worked throughout, isolating the fault to the datagram writable)