### PR TITLE
test(qmux): add cross-language interop smoke

### DIFF
--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -19,8 +19,10 @@
 	"scripts": {
 		"build": "rimraf dist && tsc && tsx ../common/package.ts",
 		"dev": "tsc --watch",
-		"check": "tsc --noEmit",
+		"check": "tsc --project tsconfig.tests.json --noEmit",
 		"example": "tsx examples/client.ts",
+		"test": "bun test src",
+		"test:interop": "bun test tests/interop.test.ts",
 		"release": "bun ../common/release.ts"
 	},
 	"devDependencies": {

--- a/js/qmux/tests/interop.test.ts
+++ b/js/qmux/tests/interop.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+import Session, { type Version } from "../src/session.ts";
+
+const ROOT = resolve(import.meta.dir, "../../..");
+const PROTOCOL = "qmux-interop";
+const PAYLOAD_LEN = 1_200_000;
+const CLIENT_SEED = 17;
+const SERVER_SEED = 29;
+const OPERATION_TIMEOUT_MS = 15_000;
+
+function payload(seed: number): Uint8Array {
+	const bytes = new Uint8Array(PAYLOAD_LEN);
+	for (let index = 0; index < bytes.byteLength; index++) {
+		bytes[index] = (index * 31 + seed) % 251;
+	}
+	return bytes;
+}
+
+function expectPayload(actual: Uint8Array, seed: number): void {
+	expect(actual.byteLength).toBe(PAYLOAD_LEN);
+	for (let index = 0; index < actual.byteLength; index++) {
+		if (actual[index] !== (index * 31 + seed) % 251) {
+			throw new Error(`payload mismatch at byte ${index}`);
+		}
+	}
+}
+
+async function withTimeout<T>(label: string, promise: Promise<T>, timeoutMs = OPERATION_TIMEOUT_MS): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`timed out: ${label}`)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+async function readLine(stream: ReadableStream<Uint8Array>): Promise<string> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffered = "";
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) throw new Error("Rust interop server exited before reporting its URL");
+			buffered += decoder.decode(value, { stream: true });
+			const newline = buffered.indexOf("\n");
+			if (newline !== -1) return buffered.slice(0, newline).trim();
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let length = 0;
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+			length += value.byteLength;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const result = new Uint8Array(length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+async function runVersion(version: Version): Promise<void> {
+	const server = Bun.spawn(
+		["cargo", "run", "--quiet", "-p", "qmux", "--example", "interop-server", "--features", "ws", "--", version],
+		{
+			cwd: ROOT,
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+	const stderr = new Response(server.stderr).text();
+
+	try {
+		// The first build can be cold when this test is run directly, so server
+		// startup gets a larger bound than individual protocol operations.
+		const url = await withTimeout("starting the Rust interop server", readLine(server.stdout), 60_000);
+		expect(url).toStartWith("ws://127.0.0.1:");
+
+		const session = new Session(url, {
+			protocols: [PROTOCOL],
+			versions: { [PROTOCOL]: version },
+			requireProtocol: true,
+			// Small receive windows force the Rust sender to observe and react to
+			// MAX_DATA/MAX_STREAM_DATA updates during the large reverse transfer.
+			config: {
+				maxData: 64n * 1024n,
+				maxStreamDataBidiLocal: 32n * 1024n,
+				maxStreamDataBidiRemote: 32n * 1024n,
+				maxStreamDataUni: 32n * 1024n,
+			},
+		});
+		await withTimeout("opening the QMux session", session.ready);
+		expect(session.protocol).toBe(PROTOCOL);
+
+		const outgoing = await withTimeout(
+			"creating the client unidirectional stream",
+			session.createUnidirectionalStream(),
+		);
+		const outgoingWriter = outgoing.getWriter();
+		await withTimeout("writing the client flow-control payload", outgoingWriter.write(payload(CLIENT_SEED)));
+		await withTimeout("finishing the client unidirectional stream", outgoingWriter.close());
+
+		const incomingReader = session.incomingUnidirectionalStreams.getReader();
+		const incoming = await withTimeout("accepting the server unidirectional stream", incomingReader.read());
+		incomingReader.releaseLock();
+		expect(incoming.done).toBe(false);
+		if (incoming.value === undefined) throw new Error("server unidirectional stream was missing");
+		expectPayload(
+			await withTimeout("reading the server flow-control payload", readAll(incoming.value)),
+			SERVER_SEED,
+		);
+
+		const bidi = await withTimeout("creating the bidirectional stream", session.createBidirectionalStream());
+		const bidiWriter = bidi.writable.getWriter();
+		await withTimeout(
+			"writing the bidirectional request",
+			bidiWriter.write(new TextEncoder().encode(`ping:${version}`)),
+		);
+		await withTimeout("finishing the bidirectional request", bidiWriter.close());
+		const bidiResponse = await withTimeout("reading the bidirectional response", readAll(bidi.readable));
+		expect(new TextDecoder().decode(bidiResponse)).toBe(`pong:${version}`);
+
+		if (version === "qmux-00") {
+			expect(session.datagrams.maxDatagramSize).toBe(0);
+		} else {
+			expect(session.datagrams.maxDatagramSize).toBeGreaterThan(0);
+			const datagramReader = session.datagrams.readable.getReader();
+			const fromRust = await withTimeout("receiving the Rust datagram", datagramReader.read());
+			datagramReader.releaseLock();
+			expect(fromRust.done).toBe(false);
+			expect(new TextDecoder().decode(fromRust.value)).toBe("rust-datagram");
+
+			const datagramWriter = session.datagrams.writable.getWriter();
+			await datagramWriter.write(new TextEncoder().encode("typescript-datagram"));
+			datagramWriter.releaseLock();
+		}
+
+		session.close({ closeCode: 42, reason: "interop complete" });
+		expect(await withTimeout("closing the TypeScript session", session.closed)).toEqual({
+			closeCode: 42,
+			reason: "interop complete",
+		});
+
+		const exitCode = await withTimeout("waiting for the Rust interop server", server.exited);
+		if (exitCode !== 0) {
+			throw new Error(`Rust interop server exited with ${exitCode}:\n${await stderr}`);
+		}
+	} catch (error) {
+		server.kill();
+		await server.exited;
+		const diagnostics = await stderr;
+		throw new Error(`${error instanceof Error ? error.message : String(error)}\n${diagnostics}`);
+	}
+}
+
+test("TypeScript client interoperates with the Rust WebSocket server across supported drafts", async () => {
+	for (const version of ["qmux-02", "qmux-01", "qmux-00"] as const) {
+		await runVersion(version);
+	}
+}, 120_000);

--- a/js/qmux/tsconfig.tests.json
+++ b/js/qmux/tsconfig.tests.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*", "tests/**/*"]
+}

--- a/justfile
+++ b/justfile
@@ -60,6 +60,8 @@ test:
 	cargo test --workspace --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport-wasm --all-targets --all-features
+	bun run --cwd js/qmux test
+	bun run --cwd js/qmux test:interop
 
 # Automatically fix some issues.
 fix:

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -45,3 +45,7 @@ web-transport-trait = { workspace = true }
 [[example]]
 name = "h3qx"
 required-features = ["tcp"]
+
+[[example]]
+name = "interop-server"
+required-features = ["ws"]

--- a/rs/qmux/examples/interop-server.rs
+++ b/rs/qmux/examples/interop-server.rs
@@ -1,0 +1,128 @@
+//! WebSocket server used by the cross-language QMux smoke test.
+//!
+//! The TypeScript client starts this example once per supported QMux draft. The
+//! server accepts only the requested draft, so completing the scenario proves
+//! the WebSocket subprotocol negotiation and both implementations' wire formats
+//! agree.
+
+use std::io::Write as _;
+use std::time::Duration;
+
+use anyhow::{bail, Context as _};
+use bytes::Bytes;
+use qmux::{Session, Version};
+use tokio::net::TcpListener;
+use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
+
+const PROTOCOL: &str = "qmux-interop";
+const PAYLOAD_LEN: usize = 1_200_000;
+const CLIENT_SEED: usize = 17;
+const SERVER_SEED: usize = 29;
+const TIMEOUT: Duration = Duration::from_secs(15);
+
+fn parse_version(value: &str) -> anyhow::Result<Version> {
+    match value {
+        "qmux-00" => Ok(Version::QMux00),
+        "qmux-01" => Ok(Version::QMux01),
+        "qmux-02" => Ok(Version::QMux02),
+        _ => bail!("unsupported QMux version: {value}"),
+    }
+}
+
+fn payload(seed: usize) -> Vec<u8> {
+    (0..PAYLOAD_LEN)
+        .map(|index| ((index * 31 + seed) % 251) as u8)
+        .collect()
+}
+
+async fn run(session: Session, version: Version) -> anyhow::Result<()> {
+    if session.protocol() != Some(PROTOCOL) {
+        bail!("unexpected negotiated protocol: {:?}", session.protocol());
+    }
+
+    // TypeScript -> Rust, large enough to require both stream- and
+    // connection-level flow-control updates with the default Rust windows.
+    let mut recv = tokio::time::timeout(TIMEOUT, session.accept_uni())
+        .await
+        .context("timed out accepting the client unidirectional stream")??;
+    let received = tokio::time::timeout(TIMEOUT, recv.read_all())
+        .await
+        .context("timed out reading the client flow-control payload")??;
+    if received.as_ref() != payload(CLIENT_SEED) {
+        bail!("client flow-control payload did not match");
+    }
+
+    // Rust -> TypeScript. The client advertises deliberately small receive
+    // windows, so this cannot finish unless it consumes and replenishes credit.
+    let mut send = tokio::time::timeout(TIMEOUT, session.open_uni())
+        .await
+        .context("timed out opening the server unidirectional stream")??;
+    let response = payload(SERVER_SEED);
+    tokio::time::timeout(TIMEOUT, send.write_all(&response))
+        .await
+        .context("timed out writing the server flow-control payload")??;
+    send.finish()?;
+
+    // Exercise both halves of one bidirectional stream and FIN propagation.
+    let (mut send, mut recv) = tokio::time::timeout(TIMEOUT, session.accept_bi())
+        .await
+        .context("timed out accepting the bidirectional stream")??;
+    let request = tokio::time::timeout(TIMEOUT, recv.read_all())
+        .await
+        .context("timed out reading the bidirectional request")??;
+    let expected = format!("ping:{}", version.alpn());
+    if request.as_ref() != expected.as_bytes() {
+        bail!("unexpected bidirectional request");
+    }
+    let response = format!("pong:{}", version.alpn());
+    tokio::time::timeout(TIMEOUT, send.write_all(response.as_bytes()))
+        .await
+        .context("timed out writing the bidirectional response")??;
+    send.finish()?;
+
+    // DATAGRAM is available only on record-framed drafts (QMux01+).
+    if version.uses_records() {
+        session.send_datagram(Bytes::from_static(b"rust-datagram"))?;
+        let datagram = tokio::time::timeout(TIMEOUT, session.recv_datagram())
+            .await
+            .context("timed out receiving the TypeScript datagram")??;
+        if datagram.as_ref() != b"typescript-datagram" {
+            bail!("unexpected TypeScript datagram");
+        }
+    } else if session.max_datagram_size() != 0 {
+        bail!("QMux00 unexpectedly negotiated datagram support");
+    }
+
+    let closed = tokio::time::timeout(TIMEOUT, session.closed())
+        .await
+        .context("timed out waiting for the TypeScript client to close")?;
+    match closed {
+        qmux::Error::ConnectionClosed { code, reason }
+            if code.into_inner() == 42 && reason == "interop complete" => {}
+        other => bail!("unexpected session close: {other}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let raw_version = std::env::args()
+        .nth(1)
+        .context("usage: interop-server <qmux-00|qmux-01|qmux-02>")?;
+    let version = parse_version(&raw_version)?;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    println!("ws://{addr}/interop");
+    std::io::stdout().flush()?;
+
+    let (socket, _) = listener.accept().await?;
+    let session = qmux::ws::Server::new()
+        .with_protocol(PROTOCOL, &[version])
+        .require_protocol()
+        .accept(socket)
+        .await?;
+
+    run(session, version).await
+}


### PR DESCRIPTION
## Summary

- run the existing TypeScript QMux unit suite from `just test`
- add a real Rust WebSocket server / TypeScript client interop smoke test for QMux 00, 01, and 02
- cover large unidirectional streams in both directions, bidirectional streams, datagrams, negotiation, and graceful close

## Why

The Rust and TypeScript implementations previously had strong isolated coverage, but no automated test exercised them against each other over a real WebSocket. The repository's main test command also type-checked the TypeScript QMux package without running its existing unit tests.

## Validation

- `nix develop --command just check`
- `nix develop --command just test`
- `cargo test -p qmux --all-features`
- `cargo clippy -p qmux --all-targets --all-features -- -D warnings`

