### PR TITLE
fix(qmux): enforce websocket record limits

### DIFF
--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -537,6 +537,34 @@ describe("Session integration (scripted peer)", () => {
 		expect(sentClose(peer)?.type).toBe("connection_close");
 	});
 
+	test("an oversized WebSocket record rejects closed before frame decoding", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		// An all-zero record is otherwise valid PADDING, so only the negotiated
+		// record-size limit should make this fatal.
+		peer.sendRaw(new Uint8Array(Number(DEFAULT_MAX_RECORD_SIZE) + 1));
+
+		await waitFor(() => peer.has("connection_close"));
+		await expectSessionFailure(session);
+		expect(sentCloseCode(peer)).toBe(1002);
+	});
+
+	test("draft-01 rejects max_record_size below the default minimum", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+
+		peer.send({
+			type: "transport_parameters",
+			params: peerParams({ maxRecordSize: DEFAULT_MAX_RECORD_SIZE - 1n }),
+		});
+
+		await waitFor(() => peer.has("connection_close"));
+		await expectSessionFailure(session);
+		expect(sentCloseCode(peer)).toBe(1002);
+	});
+
 	test("an unnegotiated RESET_STREAM_AT rejects closed and tells the peer why (1002)", async () => {
 		// The peer negotiates qmux-01, which never advertises `reset_stream_at`, so
 		// a RESET_STREAM_AT (0x24) frame is a protocol violation. Hand-built bytes:

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -695,6 +695,11 @@ export default class Session implements WebTransport {
 		this.#lastRecvAt = Date.now();
 		try {
 			if (usesRecords(this.#version)) {
+				if (BigInt(data.byteLength) > this.#ourParams.maxRecordSize) {
+					throw new Error(
+						`record exceeds our max_record_size (${data.byteLength} > ${this.#ourParams.maxRecordSize})`,
+					);
+				}
 				// Record-framed drafts: each WS message is a record with one or more frames
 				const frames = Frame.decodeRecord(data);
 				for (const frame of frames) {
@@ -804,10 +809,10 @@ export default class Session implements WebTransport {
 
 	#handleTransportParameters(params: TransportParams) {
 		if (this.#paramsReceived) return;
-		// Draft-02: an advertised max_record_size MUST NOT go below the default
-		// minimum. Omitted values decode to the default, so only an explicit
+		// Record-framed drafts: an advertised max_record_size MUST NOT go below the
+		// default minimum. Omitted values decode to the default, so only an explicit
 		// smaller value trips this (TRANSPORT_PARAMETER_ERROR).
-		if (this.#version === "qmux-02" && params.maxRecordSize < Frame.DEFAULT_MAX_RECORD_SIZE) {
+		if (usesRecords(this.#version) && params.maxRecordSize < Frame.DEFAULT_MAX_RECORD_SIZE) {
 			throw new Error("max_record_size below the default minimum");
 		}
 		this.#paramsReceived = true;

--- a/rs/qmux/src/error.rs
+++ b/rs/qmux/src/error.rs
@@ -53,8 +53,8 @@ pub enum Error {
     ProtocolViolation,
 
     /// A transport parameter carried an illegal value — QMux's
-    /// TRANSPORT_PARAMETER_ERROR. Draft-02 raises this when a peer advertises a
-    /// `max_record_size` below the default minimum.
+    /// TRANSPORT_PARAMETER_ERROR. Record-framed drafts raise this when a peer
+    /// advertises a `max_record_size` below the default minimum.
     #[error("transport parameter error")]
     TransportParameter,
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -1304,10 +1304,10 @@ impl<R: Reader> SessionState<R> {
         }
         self.params_received = true;
 
-        // Draft-02: a peer that advertises `max_record_size` MUST NOT go below the
-        // default minimum. Values omit to the default (decode seeds it), so only an
-        // explicit smaller value trips this. Earlier drafts didn't enforce it.
-        if self.config.version == Version::QMux02
+        // Record-framed drafts: a peer that advertises `max_record_size` MUST NOT go
+        // below the default minimum. Omitted values decode to the default, so only
+        // an explicit smaller value trips this.
+        if self.config.version.uses_records()
             && params.max_record_size < crate::proto::DEFAULT_MAX_RECORD_SIZE
         {
             return Err(Error::TransportParameter);
@@ -3234,23 +3234,24 @@ mod qmux02_recv_tests {
         assert!(matches!(server.closed().await, Error::ProtocolViolation));
     }
 
-    /// A `max_record_size` below the default minimum is a TRANSPORT_PARAMETER_ERROR.
+    /// A `max_record_size` below the default minimum is a TRANSPORT_PARAMETER_ERROR
+    /// on every record-framed draft.
     #[tokio::test]
     async fn max_record_size_below_default_rejected() {
-        let (accept, mut raw) = raw_accept(Config::new(Version::QMux02));
+        for version in [Version::QMux01, Version::QMux02] {
+            let (accept, mut raw) = raw_accept(Config::new(version));
 
-        let mut params = Config::new(Version::QMux02).to_transport_params();
-        params.max_record_size = 100; // below DEFAULT_MAX_RECORD_SIZE (16382)
-        let frame = Frame::TransportParameters(params)
-            .encode(Version::QMux02)
-            .unwrap();
-        raw.write_all(&record(&frame)).await.unwrap();
-        raw.flush().await.unwrap();
+            let mut params = Config::new(version).to_transport_params();
+            params.max_record_size = 100; // below DEFAULT_MAX_RECORD_SIZE (16382)
+            let frame = Frame::TransportParameters(params).encode(version).unwrap();
+            raw.write_all(&record(&frame)).await.unwrap();
+            raw.flush().await.unwrap();
 
-        assert!(matches!(
-            accept.await.unwrap(),
-            Err(Error::TransportParameter)
-        ));
+            assert!(matches!(
+                accept.await.unwrap(),
+                Err(Error::TransportParameter)
+            ));
+        }
     }
 
     /// A QX_PING response echoing a sequence we never sent is a PROTOCOL_VIOLATION.

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -583,7 +583,7 @@ mod ws_transport {
 
     use super::{Reader, Transport, Writer};
     use crate::ws::KeepAlive;
-    use crate::Error;
+    use crate::{Error, Version};
 
     type Message = tungstenite::Message;
 
@@ -614,13 +614,17 @@ mod ws_transport {
     pub(crate) struct WsTransport<T> {
         ws: T,
         keep_alive: Option<KeepAlive>,
+        record_limit: Option<usize>,
     }
 
     impl<T> WsTransport<T> {
-        pub fn new(ws: T) -> Self {
+        pub fn new(ws: T, version: Version, max_record_size: u64) -> Self {
             Self {
                 ws,
                 keep_alive: None,
+                record_limit: version
+                    .uses_records()
+                    .then(|| usize::try_from(max_record_size).unwrap_or(usize::MAX)),
             }
         }
 
@@ -713,7 +717,7 @@ mod ws_transport {
                 None => (None, None),
             };
             let (tx, rx) = mpsc::channel(WS_RECV_CHANNEL_CAPACITY);
-            let pump = tokio::spawn(ws_pump(stream, deadline, tx));
+            let pump = tokio::spawn(ws_pump(stream, deadline, self.record_limit, tx));
             (WsWriter { sink, ping }, WsReader { rx, pump })
         }
     }
@@ -779,6 +783,7 @@ mod ws_transport {
     async fn ws_pump<S>(
         mut stream: S,
         mut deadline: Option<DeadlineState>,
+        record_limit: Option<usize>,
         tx: mpsc::Sender<Result<Bytes, Error>>,
     ) where
         S: futures::Stream<Item = Result<Message, tungstenite::Error>> + Unpin + Send + 'static,
@@ -825,6 +830,14 @@ mod ws_transport {
 
             match message {
                 Message::Binary(data) => {
+                    if record_limit.is_some_and(|limit| data.len() > limit) {
+                        // Release the oversized allocation before waiting for room to
+                        // report the terminal error. In particular, never let it enter
+                        // the bounded record queue while the session is backpressured.
+                        drop(data);
+                        let _ = tx.send(Err(Error::FrameTooLarge)).await;
+                        return;
+                    }
                     if tx.send(Ok(data)).await.is_err() {
                         return; // session gone
                     }
@@ -894,7 +907,7 @@ mod ws_transport {
 
             let ka = KeepAlive::new(Duration::from_millis(10), Duration::from_millis(50));
             let (tx, mut rx) = mpsc::channel(1);
-            let pump = tokio::spawn(ws_pump(stream, Some(DeadlineState::new(ka)), tx));
+            let pump = tokio::spawn(ws_pump(stream, Some(DeadlineState::new(ka)), None, tx));
 
             // Model a session wedged on a full accept channel: don't read for well
             // over the 50ms keep-alive timeout while the pump is parked on delivery.
@@ -922,7 +935,7 @@ mod ws_transport {
 
             let ka = KeepAlive::new(Duration::from_millis(10), Duration::from_millis(50));
             let (tx, mut rx) = mpsc::channel(4);
-            let pump = tokio::spawn(ws_pump(stream, Some(DeadlineState::new(ka)), tx));
+            let pump = tokio::spawn(ws_pump(stream, Some(DeadlineState::new(ka)), None, tx));
 
             let result = tokio::time::timeout(Duration::from_secs(1), rx.recv())
                 .await
@@ -943,13 +956,30 @@ mod ws_transport {
             let _feed = feed;
 
             let (tx, mut rx) = mpsc::channel(4);
-            let pump = tokio::spawn(ws_pump(stream, None, tx));
+            let pump = tokio::spawn(ws_pump(stream, None, None, tx));
 
             // No deadline, so recv stays pending well past any keep-alive window.
             let pending = tokio::time::timeout(Duration::from_millis(100), rx.recv()).await;
             assert!(pending.is_err(), "recv must not resolve without activity");
 
             pump.abort();
+        }
+
+        #[tokio::test]
+        async fn rejects_record_exceeding_max_before_queueing() {
+            let (feed, stream) = mock_stream();
+            feed.unbounded_send(Ok(Message::Binary(Bytes::from_static(b"oversized"))))
+                .unwrap();
+
+            let (tx, mut rx) = mpsc::channel(1);
+            let pump = tokio::spawn(ws_pump(stream, None, Some(4), tx));
+
+            assert!(matches!(rx.recv().await, Some(Err(Error::FrameTooLarge))));
+            assert!(
+                rx.recv().await.is_none(),
+                "pump must stop after the violation"
+            );
+            pump.await.unwrap();
         }
     }
 }

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -89,11 +89,9 @@ where
     /// this returns synchronously without awaiting in-band parameters.
     pub fn connect(self) -> Session {
         let (version, protocol) = alpn::parse(self.alpn.as_deref());
-        Session::new(
-            self.into_transport(),
-            false,
-            Config::negotiated(version, protocol),
-        )
+        let config = Config::negotiated(version, protocol);
+        let transport = self.into_transport(config.version, config.max_record_size);
+        Session::new(transport, false, config)
     }
 
     /// Wrap as a server-side session.
@@ -102,15 +100,13 @@ where
     /// negotiated subprotocol, so this returns synchronously.
     pub fn accept(self) -> Session {
         let (version, protocol) = alpn::parse(self.alpn.as_deref());
-        Session::new(
-            self.into_transport(),
-            true,
-            Config::negotiated(version, protocol),
-        )
+        let config = Config::negotiated(version, protocol);
+        let transport = self.into_transport(config.version, config.max_record_size);
+        Session::new(transport, true, config)
     }
 
-    fn into_transport(self) -> WsTransport<T> {
-        let transport = WsTransport::new(self.ws);
+    fn into_transport(self, version: Version, max_record_size: u64) -> WsTransport<T> {
+        let transport = WsTransport::new(self.ws, version, max_record_size);
         match self.keep_alive {
             Some(ka) => transport.with_keep_alive(ka),
             None => transport,
@@ -252,16 +248,14 @@ impl Client {
             ));
         }
 
+        let config = Config::negotiated(version, protocol);
+        let transport = WsTransport::new(ws_stream, config.version, config.max_record_size);
         let transport = match self.keep_alive {
-            Some(ka) => WsTransport::new(ws_stream).with_keep_alive(ka),
-            None => WsTransport::new(ws_stream),
+            Some(ka) => transport.with_keep_alive(ka),
+            None => transport,
         };
         // Protocol came from the negotiated subprotocol, so no in-band wait.
-        Ok(Session::new(
-            transport,
-            false,
-            Config::negotiated(version, protocol),
-        ))
+        Ok(Session::new(transport, false, config))
     }
 }
 
@@ -409,15 +403,13 @@ impl Server {
             .take()
             .expect("negotiated must be set after successful handshake");
 
+        let config = Config::negotiated(version, protocol);
+        let transport = WsTransport::new(ws, config.version, config.max_record_size);
         let transport = match self.keep_alive {
-            Some(ka) => WsTransport::new(ws).with_keep_alive(ka),
-            None => WsTransport::new(ws),
+            Some(ka) => transport.with_keep_alive(ka),
+            None => transport,
         };
         // Protocol came from the negotiated subprotocol, so no in-band wait.
-        Ok(Session::new(
-            transport,
-            true,
-            Config::negotiated(version, protocol),
-        ))
+        Ok(Session::new(transport, true, config))
     }
 }


### PR DESCRIPTION
## Summary

- enforce the locally advertised `max_record_size` on inbound WebSocket records in Rust before they enter the receive queue
- reject oversized WebSocket records before frame decoding in the TypeScript implementation
- apply the minimum `max_record_size` validation to both QMux01 and QMux02
- retain the existing backwards-compatible receive-offset behavior

## Root cause

WebSocket message boundaries act as implicit QMux record boundaries, but the Rust WebSocket transport did not receive the session's record limit and the TypeScript receive path decoded messages without checking their size. This allowed records larger than the advertised limit and let the Rust read-ahead queue amplify their memory use.

## Validation

- `just test` — full native workspace, WASM, TypeScript, and Rust/TypeScript interop suites passed
- `cargo clippy -p qmux --all-targets --all-features -- -D warnings`
- `bun run --cwd js/qmux check`
- all QMux feature combinations in the repository check passed

`just fix` was attempted as required, but the workspace-wide clippy-fix phase was blocked locally because this machine has not accepted the Xcode license. It produced no additional edits; the focused clippy and full test gate passed.
