### PR TITLE
fix(node): republish with napi-rs 3.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,18 +43,18 @@
     },
     "js/web-transport": {
       "name": "@moq/web-transport",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "devDependencies": {
         "@napi-rs/cli": "^3",
         "@types/node": "^26.1.0",
         "typescript": "7.0.1-rc",
       },
       "optionalDependencies": {
-        "@moq/web-transport-darwin-arm64": "0.1.3",
-        "@moq/web-transport-darwin-x64": "0.1.3",
-        "@moq/web-transport-linux-arm64-gnu": "0.1.3",
-        "@moq/web-transport-linux-x64-gnu": "0.1.3",
-        "@moq/web-transport-win32-x64-msvc": "0.1.3",
+        "@moq/web-transport-darwin-arm64": "0.1.4",
+        "@moq/web-transport-darwin-x64": "0.1.4",
+        "@moq/web-transport-linux-arm64-gnu": "0.1.4",
+        "@moq/web-transport-linux-x64-gnu": "0.1.4",
+        "@moq/web-transport-win32-x64-msvc": "0.1.4",
       },
     },
   },
@@ -190,16 +190,6 @@
     "@moq/web-socket-stream": ["@moq/web-socket-stream@workspace:js/web-socket-stream"],
 
     "@moq/web-transport": ["@moq/web-transport@workspace:js/web-transport"],
-
-    "@moq/web-transport-darwin-arm64": ["@moq/web-transport-darwin-arm64@0.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MSKd2lmgjABS6A4CoaYA2m5XibJFUi3hzz/5TTrWAiRHU8t6WV5iHcPKLMblgXi+QSZ7iLlEL0tXzmN9u0qkJw=="],
-
-    "@moq/web-transport-darwin-x64": ["@moq/web-transport-darwin-x64@0.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Kml/EUk8EWiKNkBRcLR8JEpMOqxEpDEHHaDlLd+ro84BY/MAgiJGiVKebGZI6QP2C2OalfAqZZQ0Eh8bB6w62Q=="],
-
-    "@moq/web-transport-linux-arm64-gnu": ["@moq/web-transport-linux-arm64-gnu@0.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Y3/Uko9N3X1b68hTgKVrLwpbMgtbvert0ADvIoziE1wczMcoORsys6dE9APH1jeZaXYgLAN5sVf7fdSMFI6HAQ=="],
-
-    "@moq/web-transport-linux-x64-gnu": ["@moq/web-transport-linux-x64-gnu@0.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-WVFRgrhrQUWEKM4uBgBwfz1vGmGOU7DtM38VqlW1+6+bEm6+a0jMJ/6HUBz1bEdzzKZsVcVoT66cZoymyvzjHA=="],
-
-    "@moq/web-transport-win32-x64-msvc": ["@moq/web-transport-win32-x64-msvc@0.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yPWBiujSW4bOByb1kfVyBd28MWoLpKneqel4k5KqW941Ofc6H/czegvtmDiFswx1KH531EjKljmuyilH+2g8Rw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 

--- a/js/web-transport/npm/darwin-arm64/package.json
+++ b/js/web-transport/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport-darwin-arm64",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"cpu": [
 		"arm64"
 	],

--- a/js/web-transport/npm/darwin-x64/package.json
+++ b/js/web-transport/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport-darwin-x64",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"cpu": [
 		"x64"
 	],

--- a/js/web-transport/npm/linux-arm64-gnu/package.json
+++ b/js/web-transport/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport-linux-arm64-gnu",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"cpu": [
 		"arm64"
 	],

--- a/js/web-transport/npm/linux-x64-gnu/package.json
+++ b/js/web-transport/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport-linux-x64-gnu",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"cpu": [
 		"x64"
 	],

--- a/js/web-transport/npm/win32-x64-msvc/package.json
+++ b/js/web-transport/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport-win32-x64-msvc",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"cpu": [
 		"x64"
 	],

--- a/js/web-transport/package.json
+++ b/js/web-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq/web-transport",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "WebTransport polyfill for Node.js via QUIC/HTTP3",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",
@@ -36,11 +36,11 @@
 		"typescript": "7.0.1-rc"
 	},
 	"optionalDependencies": {
-		"@moq/web-transport-darwin-x64": "0.1.3",
-		"@moq/web-transport-darwin-arm64": "0.1.3",
-		"@moq/web-transport-win32-x64-msvc": "0.1.3",
-		"@moq/web-transport-linux-x64-gnu": "0.1.3",
-		"@moq/web-transport-linux-arm64-gnu": "0.1.3"
+		"@moq/web-transport-darwin-x64": "0.1.4",
+		"@moq/web-transport-darwin-arm64": "0.1.4",
+		"@moq/web-transport-win32-x64-msvc": "0.1.4",
+		"@moq/web-transport-linux-x64-gnu": "0.1.4",
+		"@moq/web-transport-linux-arm64-gnu": "0.1.4"
 	},
 	"keywords": [
 		"webtransport",

--- a/rs/web-transport-node/CHANGELOG.md
+++ b/rs/web-transport-node/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Require napi-rs 3.10.0 or newer to prevent cross-isolate `Buffer` drops from crashing Node.js and Deno processes ([#319](https://github.com/moq-dev/web-transport/issues/319))
+
 ## [0.0.4](https://github.com/moq-dev/web-transport/compare/web-transport-node-v0.0.3...web-transport-node-v0.0.4) - 2026-06-22
 
 ### Fixed

--- a/rs/web-transport-node/Cargo.toml
+++ b/rs/web-transport-node/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 bytes = "1"
 http = "1"
-napi = { version = "3", features = ["async", "napi8"] }
+napi = { version = "3.10.0", features = ["async", "napi8"] }
 napi-derive = "3"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["sync"] }


### PR DESCRIPTION
## Summary

- require napi-rs 3.10.0 or newer for the Node addon
- bump `@moq/web-transport` and all five native packages to 0.1.4
- refresh the workspace lockfile for the pre-release package versions

## Root cause

The 0.1.3 native binaries were built before napi-rs 3.10.0 fixed cross-thread custom-GC routing for `Buffer` and `TypedArray` drops. When multiple worker isolates loaded the addon, a buffer could be released through the wrong isolate and abort the process.

Publishing 0.1.4 rebuilds every supported native target with the fixed napi-rs runtime. No WebTransport implementation change is required.

Fixes #319.

## Validation

- `nix develop --command cargo check -p web-transport-node`
- `nix develop --command bun run --cwd js/web-transport check`
- `nix develop --command just fix`
- `nix develop --command just check`
