### PR TITLE
fix(quiche): drop ClientBuilder::with_metrics, which silently ignored its argument

### DIFF
--- a/rs/web-transport-quiche/src/client.rs
+++ b/rs/web-transport-quiche/src/client.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 use web_transport_proto::ConnectRequest;
 
-use crate::{
-    ez::{self, DefaultMetrics, Metrics},
-    h3, Connection, Settings,
-};
+use crate::{ez, h3, Connection, Settings};
 
 /// An error returned when connecting to a WebTransport endpoint.
 #[derive(thiserror::Error, Debug, Clone)]
@@ -32,24 +29,24 @@ impl From<std::io::Error> for ClientError {
 }
 
 /// Construct a WebTransport client using sane defaults.
-pub struct ClientBuilder<M: Metrics = DefaultMetrics>(ez::ClientBuilder<M>);
+///
+/// Unlike [ServerBuilder](crate::ServerBuilder), there is no `with_metrics`
+/// counterpart. `tokio-quiche` hardcodes its own `DefaultMetrics` on the client
+/// path, so custom [Metrics](ez::Metrics) are server-only.
+pub struct ClientBuilder(ez::ClientBuilder);
 
-impl Default for ClientBuilder<DefaultMetrics> {
+impl Default for ClientBuilder {
     fn default() -> Self {
-        Self(ez::ClientBuilder::default())
+        Self::new()
     }
 }
 
-impl ClientBuilder<DefaultMetrics> {
-    /// Create a new client builder with custom metrics.
-    ///
-    /// Use [ClientBuilder::default] if you don't care about metrics.
-    pub fn with_metrics<M: Metrics>(m: M) -> ClientBuilder<M> {
-        ClientBuilder(ez::ClientBuilder::with_metrics(m))
+impl ClientBuilder {
+    /// Create a new client builder.
+    pub fn new() -> Self {
+        Self(ez::ClientBuilder::new())
     }
-}
 
-impl<M: Metrics> ClientBuilder<M> {
     /// Listen for incoming packets on the given socket.
     ///
     /// Defaults to an ephemeral port if not specified.

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -7,7 +7,7 @@ use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use crate::ez::tls::{ClientHook, ClientVerify};
 use crate::ez::DriverState;
 
-use super::{Connection, ConnectionError, DefaultMetrics, Driver, Lock, Metrics, Settings};
+use super::{Connection, ConnectionError, Driver, Lock, Settings};
 
 // Local buffer between the application and the driver task — *not* the QUIC
 // datagram queue (configured via `Settings::dgram_send_max_queue_len`). It
@@ -19,29 +19,32 @@ use super::{Connection, ConnectionError, DefaultMetrics, Driver, Lock, Metrics, 
 pub(super) const DGRAM_CHANNEL_CAPACITY: usize = 64;
 
 /// Construct a QUIC client using sane defaults.
-pub struct ClientBuilder<M: Metrics = DefaultMetrics> {
+///
+/// Unlike [ServerBuilder](super::ServerBuilder), there is no metrics
+/// counterpart. `tokio-quiche` hardcodes its own `DefaultMetrics` inside
+/// `quic::connect_with_config`, so there is no client-side hook to attach a
+/// custom [Metrics](super::Metrics) implementation to.
+pub struct ClientBuilder {
     settings: Settings,
     socket: Option<tokio::net::UdpSocket>,
     tls: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
     verify: ClientVerify,
-    metrics: M,
 }
 
-impl Default for ClientBuilder<DefaultMetrics> {
+impl Default for ClientBuilder {
     fn default() -> Self {
-        Self::with_metrics(DefaultMetrics)
+        Self::new()
     }
 }
 
-impl<M: Metrics> ClientBuilder<M> {
-    /// Create a new client builder with custom metrics.
-    pub fn with_metrics(m: M) -> Self {
+impl ClientBuilder {
+    /// Create a new client builder.
+    pub fn new() -> Self {
         let mut settings = Settings::default();
         settings.verify_peer = true;
 
         Self {
             settings,
-            metrics: m,
             socket: None,
             tls: None,
             verify: ClientVerify::Default,
@@ -57,10 +60,7 @@ impl<M: Metrics> ClientBuilder<M> {
 
         Ok(Self {
             socket: Some(socket),
-            settings: self.settings,
-            metrics: self.metrics,
-            tls: self.tls,
-            verify: self.verify,
+            ..self
         })
     }
 
@@ -90,10 +90,7 @@ impl<M: Metrics> ClientBuilder<M> {
     ) -> Self {
         Self {
             tls: Some((chain, key)),
-            settings: self.settings,
-            metrics: self.metrics,
-            socket: self.socket,
-            verify: self.verify,
+            ..self
         }
     }
 


### PR DESCRIPTION
## What

`ClientBuilder::with_metrics(m)` stored `m` in a `metrics: M` field that was never read. The client never passed it to tokio-quiche, so any caller supplying a custom `Metrics` implementation silently got `DefaultMetrics` behavior with no error or warning.

This removes the field, the `M` type parameter, and the method from both `ez::ClientBuilder` and the public `ClientBuilder`, replacing them with a plain `new()`.

## Why it was invisible

Every constructor moved the field explicitly (`metrics: self.metrics`), which counts as a read for the `dead_code` lint. Rewriting those literals as `..self` makes `warning: field 'metrics' is never read` appear — that's how this was found, and the constructors now use `..self`.

## Why remove rather than wire it through

tokio-quiche 0.19 has no supported way to attach metrics to a client connection:

- `quic::connect_with_config` **hardcodes** `DefaultMetrics` when constructing the packet router (`src/quic/mod.rs:266`). There is no metrics parameter on the client path, unlike the server's `listen_with_capabilities(listeners, params, metrics)`.
- `InboundPacketRouter` is `pub` but lives in a private `mod router`; `ClientConnector` is `pub(crate)`. Both unreachable.
- `raw::wrap_quiche_conn` is the only public function taking metrics, but its own docs describe it as a low-level escape hatch: the caller must build the `quiche::Connection` and manually pump inbound packets through a channel. Routing the client through it would mean reimplementing the packet router and handshake driving, and would lose the GSO/GRO capabilities that `connect` currently sets up — too much to pay to make one builder method honest.

Metrics being server-only is consistent with the trait's shape, which is dominated by listener-level counters (`connections_in_memory`, `failed_handshakes`). Both types now document this so it doesn't get re-added.

## Compatibility

Technically a breaking public API change, but low-risk:

- `with_metrics` had **zero callers** in the repo — no tests, examples, or docs.
- Every existing caller uses `ClientBuilder::default()` and is unaffected.
- The crate is pre-1.0 (0.4.3).
- `new()` + `Default` matches the existing `web-transport-noq::ClientBuilder` convention.

## Testing

- `cargo clippy -p web-transport-quiche --all-targets -- -D warnings` — clean
- `cargo fmt` — clean
- `cargo test -p web-transport-quiche` — all 10 pass, including `cert_hash_accept`, `custom_roots_accept`, and `datagram_round_trip`, which drive the rewritten constructors end-to-end

Note: a full `just check` currently fails on `rs/qmux/tests/ws_reassembly.rs`, an unrelated in-progress file in my working tree that is not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)