### PR TITLE
fix(qmux): make write_buf cancel safe so a dropped write can't lose bytes

### DIFF
--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -309,11 +309,21 @@ impl Permit {
     /// Append `frame` to `id`'s FIFO using the reserved slot. Never blocks.
     ///
     /// Consumes the permit, so the reservation can't be reused or double-sent.
-    pub fn send(mut self, priority: u8, id: StreamId, frame: Frame) {
-        self.armed = false;
+    /// Fails if the queue closed while the permit was outstanding: the consumer
+    /// has already stopped popping, so enqueuing here would strand the frame and
+    /// report success for data that will never be sent.
+    pub fn send(mut self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
         let mut inner = self.queue.inner.lock().unwrap();
+        if inner.closed {
+            // Release the lock before returning: `self` still counts as armed, so
+            // its `Drop` re-locks to hand the slot back.
+            drop(inner);
+            return Err(Error::Closed);
+        }
+        self.armed = false;
         // `reserve` already counted this frame against `len`.
         self.queue.enqueue_locked(&mut inner, priority, id, frame);
+        Ok(())
     }
 }
 
@@ -373,8 +383,7 @@ mod tests {
         id: StreamId,
         frame: Frame,
     ) -> Result<(), Error> {
-        q.reserve().await?.send(priority, id, frame);
-        Ok(())
+        q.reserve().await?.send(priority, id, frame)
     }
 
     #[tokio::test]
@@ -545,7 +554,7 @@ mod tests {
         tokio::task::yield_now().await;
         assert!(!blocked.is_finished(), "reserve should block while full");
 
-        permit.send(5, a, frame(a, 1));
+        permit.send(5, a, frame(a, 1)).unwrap();
         // Still full: the permit became a real frame rather than freeing the slot.
         tokio::task::yield_now().await;
         assert!(
@@ -592,6 +601,36 @@ mod tests {
         q.pop().await.unwrap();
         push(&q, 5, a, frame(a, 2)).await.unwrap();
         assert_eq!(tag_of(&q.pop().await.unwrap()), 2);
+    }
+
+    /// A permit reserved before `close` must not enqueue after it: `pop` has
+    /// already reported the queue drained and the consumer is gone, so the frame
+    /// would sit there forever while the writer was told it was sent.
+    #[tokio::test]
+    async fn send_after_close_fails() {
+        let q = PriorityQueue::new(4);
+        let a = sid(0);
+
+        let permit = q.reserve().await.unwrap();
+        q.close();
+
+        // The consumer has already given up on this queue.
+        assert!(q.pop().await.is_none());
+        assert!(matches!(permit.send(5, a, frame(a, 1)), Err(Error::Closed)));
+        assert!(
+            q.pop().await.is_none(),
+            "a rejected send must queue nothing"
+        );
+    }
+
+    /// Dropping a permit after close must not panic or underflow `len`.
+    #[tokio::test]
+    async fn drop_after_close_is_clean() {
+        let q = PriorityQueue::new(4);
+        let permit = q.reserve().await.unwrap();
+        q.close();
+        drop(permit);
+        assert!(q.pop().await.is_none());
     }
 
     #[tokio::test]

--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -70,8 +70,8 @@ pub struct PriorityQueue {
 }
 
 impl PriorityQueue {
-    /// Create a queue holding at most `capacity` frames total before `push`
-    /// blocks.
+    /// Create a queue holding at most `capacity` frames total before `reserve`
+    /// blocks. Outstanding [`Permit`]s count against the bound.
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: Arc::new(Mutex::new(Inner {
@@ -86,13 +86,18 @@ impl PriorityQueue {
         }
     }
 
-    /// Append a frame to `id`'s FIFO, blocking while the queue is full.
+    /// Reserve one slot, blocking while the queue is full.
     ///
-    /// Cancel-safe: the mutation happens synchronously right before returning,
-    /// so if the caller's `select!` drops this future before it resolves, no
-    /// frame is enqueued (matching the old `outbound.send` race against
-    /// `inbound_stopped`).
-    pub async fn push(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
+    /// Await this *before* building the frame: the returned [`Permit`] enqueues
+    /// synchronously, so a caller can move bytes out of a source buffer and into
+    /// the queue with no await in between. Awaiting capacity and committing the
+    /// frame in one step instead (the obvious `push(frame).await`) leaves a
+    /// window where a cancelled future has already taken the caller's bytes but
+    /// not queued them, silently punching a hole in the stream.
+    ///
+    /// Cancel-safe: the slot is claimed synchronously right before returning, so
+    /// dropping this future reserves nothing.
+    pub async fn reserve(&self) -> Result<Permit, Error> {
         loop {
             // Register interest *before* checking, so a `notify_one` that fires
             // between our check and `.await` isn't lost.
@@ -103,8 +108,13 @@ impl PriorityQueue {
                     return Err(Error::Closed);
                 }
                 if inner.len < self.capacity {
-                    self.push_locked(&mut inner, priority, id, frame);
-                    return Ok(());
+                    // Hold the slot against the capacity bound until the permit
+                    // is used or dropped.
+                    inner.len += 1;
+                    return Ok(Permit {
+                        queue: self.clone(),
+                        armed: true,
+                    });
                 }
             }
             notified.await;
@@ -126,6 +136,14 @@ impl PriorityQueue {
     }
 
     fn push_locked(&self, inner: &mut Inner, priority: u8, id: StreamId, frame: Frame) {
+        self.enqueue_locked(inner, priority, id, frame);
+        inner.len += 1;
+    }
+
+    /// Append `frame` to `id`'s FIFO without touching `len`. Callers own the
+    /// capacity accounting: `push_now` bumps it after the fact, while a
+    /// [`Permit`] already reserved its slot in `reserve`.
+    fn enqueue_locked(&self, inner: &mut Inner, priority: u8, id: StreamId, frame: Frame) {
         match inner.streams.get_mut(&id) {
             Some(slot) => {
                 // Already scheduled (its band points at `id`); just append.
@@ -138,7 +156,6 @@ impl PriorityQueue {
                 inner.arm(id, priority);
             }
         }
-        inner.len += 1;
         self.non_empty.notify_one();
     }
 
@@ -276,6 +293,43 @@ impl PriorityQueue {
     }
 }
 
+/// One reserved slot in a [`PriorityQueue`], from [`PriorityQueue::reserve`].
+///
+/// Holds its slot against the capacity bound until [`Permit::send`] fills it or
+/// it is dropped, which returns the slot. Separating the (awaited) reservation
+/// from the (synchronous) send is what lets a caller commit bytes to the queue
+/// without an await in between, so a cancelled write can't lose them.
+pub struct Permit {
+    queue: PriorityQueue,
+    /// Cleared by `send`; a permit still armed at drop returns its slot.
+    armed: bool,
+}
+
+impl Permit {
+    /// Append `frame` to `id`'s FIFO using the reserved slot. Never blocks.
+    ///
+    /// Consumes the permit, so the reservation can't be reused or double-sent.
+    pub fn send(mut self, priority: u8, id: StreamId, frame: Frame) {
+        self.armed = false;
+        let mut inner = self.queue.inner.lock().unwrap();
+        // `reserve` already counted this frame against `len`.
+        self.queue.enqueue_locked(&mut inner, priority, id, frame);
+    }
+}
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        {
+            let mut inner = self.queue.inner.lock().unwrap();
+            inner.len -= 1;
+        }
+        self.queue.has_space.notify_one();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,14 +365,26 @@ mod tests {
         }
     }
 
+    /// Reserve and send in one step. The scheduling tests care about ordering and
+    /// capacity, not the cancellation split, so they read better without it.
+    async fn push(
+        q: &PriorityQueue,
+        priority: u8,
+        id: StreamId,
+        frame: Frame,
+    ) -> Result<(), Error> {
+        q.reserve().await?.send(priority, id, frame);
+        Ok(())
+    }
+
     #[tokio::test]
     async fn higher_priority_first() {
         let q = PriorityQueue::new(8);
         let lo = sid(0);
         let hi = sid(1);
 
-        q.push(10, lo, frame(lo, b'l')).await.unwrap();
-        q.push(200, hi, frame(hi, b'h')).await.unwrap();
+        push(&q, 10, lo, frame(lo, b'l')).await.unwrap();
+        push(&q, 200, hi, frame(hi, b'h')).await.unwrap();
 
         // High priority drains first.
         assert_eq!(tag_of(&q.pop().await.unwrap()), b'h');
@@ -331,10 +397,10 @@ mod tests {
         let a = sid(0);
         let b = sid(1);
 
-        q.push(5, a, frame(a, 1)).await.unwrap();
-        q.push(5, a, frame(a, 2)).await.unwrap();
-        q.push(5, b, frame(b, 1)).await.unwrap();
-        q.push(5, b, frame(b, 2)).await.unwrap();
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+        push(&q, 5, a, frame(a, 2)).await.unwrap();
+        push(&q, 5, b, frame(b, 1)).await.unwrap();
+        push(&q, 5, b, frame(b, 2)).await.unwrap();
 
         // Round-robin between equal-priority streams: a, b, a, b.
         assert_eq!(id_of(&q.pop().await.unwrap()), a);
@@ -349,7 +415,7 @@ mod tests {
         let a = sid(0);
 
         for i in 0..4u8 {
-            q.push(5, a, frame(a, i)).await.unwrap();
+            push(&q, 5, a, frame(a, i)).await.unwrap();
         }
         for i in 0..4u8 {
             assert_eq!(tag_of(&q.pop().await.unwrap()), i);
@@ -363,9 +429,9 @@ mod tests {
         let hi = sid(1);
 
         // Two frames each, lo enqueued first.
-        q.push(10, lo, frame(lo, 1)).await.unwrap();
-        q.push(10, lo, frame(lo, 2)).await.unwrap();
-        q.push(20, hi, frame(hi, 1)).await.unwrap();
+        push(&q, 10, lo, frame(lo, 1)).await.unwrap();
+        push(&q, 10, lo, frame(lo, 2)).await.unwrap();
+        push(&q, 20, hi, frame(hi, 1)).await.unwrap();
 
         // Promote lo above hi; its frames keep their order.
         q.set_priority(lo, 100);
@@ -395,10 +461,10 @@ mod tests {
     async fn close_unblocks_push() {
         let q = PriorityQueue::new(1);
         let a = sid(0);
-        q.push(5, a, frame(a, 1)).await.unwrap();
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
 
         let q2 = q.clone();
-        let handle = tokio::spawn(async move { q2.push(5, sid(1), frame(sid(1), 2)).await });
+        let handle = tokio::spawn(async move { push(&q2, 5, sid(1), frame(sid(1), 2)).await });
         tokio::task::yield_now().await;
         q.close();
         assert!(matches!(handle.await.unwrap(), Err(Error::Closed)));
@@ -408,11 +474,11 @@ mod tests {
     async fn backpressure_blocks_at_capacity() {
         let q = PriorityQueue::new(2);
         let a = sid(0);
-        q.push(5, a, frame(a, 1)).await.unwrap();
-        q.push(5, a, frame(a, 2)).await.unwrap();
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+        push(&q, 5, a, frame(a, 2)).await.unwrap();
 
         let q2 = q.clone();
-        let pushing = tokio::spawn(async move { q2.push(5, a, frame(a, 3)).await });
+        let pushing = tokio::spawn(async move { push(&q2, 5, a, frame(a, 3)).await });
         tokio::task::yield_now().await;
         assert!(!pushing.is_finished(), "push should block while full");
 
@@ -427,9 +493,9 @@ mod tests {
         let a = sid(0);
         let b = sid(1);
 
-        q.push(5, a, frame(a, 1)).await.unwrap();
-        q.push(5, a, frame(a, 2)).await.unwrap();
-        q.push(5, b, frame(b, 9)).await.unwrap();
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+        push(&q, 5, a, frame(a, 2)).await.unwrap();
+        push(&q, 5, b, frame(b, 9)).await.unwrap();
 
         // Reset `a`: its queued frames vanish, `b`'s survive.
         assert_eq!(q.remove(a), 2);
@@ -445,12 +511,12 @@ mod tests {
         let q = PriorityQueue::new(2);
         let a = sid(0);
         let b = sid(1);
-        q.push(5, a, frame(a, 1)).await.unwrap();
-        q.push(5, a, frame(a, 2)).await.unwrap();
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+        push(&q, 5, a, frame(a, 2)).await.unwrap();
 
         // Queue is full; a push for `b` blocks.
         let q2 = q.clone();
-        let pushing = tokio::spawn(async move { q2.push(5, b, frame(b, 1)).await });
+        let pushing = tokio::spawn(async move { push(&q2, 5, b, frame(b, 1)).await });
         tokio::task::yield_now().await;
         assert!(!pushing.is_finished(), "push should block while full");
 
@@ -464,5 +530,80 @@ mod tests {
     async fn remove_unknown_stream_is_noop() {
         let q = PriorityQueue::new(8);
         assert_eq!(q.remove(sid(99)), 0); // must not panic or underflow
+    }
+
+    #[tokio::test]
+    async fn reserved_permit_holds_capacity() {
+        let q = PriorityQueue::new(1);
+        let a = sid(0);
+
+        // An un-sent permit still occupies the queue's only slot.
+        let permit = q.reserve().await.unwrap();
+
+        let q2 = q.clone();
+        let blocked = tokio::spawn(async move { q2.reserve().await.map(|_| ()) });
+        tokio::task::yield_now().await;
+        assert!(!blocked.is_finished(), "reserve should block while full");
+
+        permit.send(5, a, frame(a, 1));
+        // Still full: the permit became a real frame rather than freeing the slot.
+        tokio::task::yield_now().await;
+        assert!(
+            !blocked.is_finished(),
+            "sending a permit must not free its slot"
+        );
+
+        q.pop().await.unwrap();
+        blocked.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropped_permit_returns_capacity() {
+        let q = PriorityQueue::new(1);
+
+        let q2 = q.clone();
+        let blocked = tokio::spawn(async move { q2.reserve().await.map(|_| ()) });
+
+        {
+            let _permit = q.reserve().await.unwrap();
+            tokio::task::yield_now().await;
+            assert!(!blocked.is_finished(), "reserve should block while full");
+            // Dropped here: the caller changed its mind (or was cancelled).
+        }
+
+        // The freed slot must wake the waiter, or a cancelled write wedges the
+        // queue forever.
+        blocked.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_reserve_holds_nothing() {
+        let q = PriorityQueue::new(1);
+        let a = sid(0);
+
+        // Fill the queue, then abandon a blocked reserve.
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+        tokio::select! {
+            _ = q.reserve() => panic!("reserve should not succeed while full"),
+            _ = tokio::task::yield_now() => {}
+        }
+
+        // The abandoned reserve must not have leaked the slot it was waiting for.
+        q.pop().await.unwrap();
+        push(&q, 5, a, frame(a, 2)).await.unwrap();
+        assert_eq!(tag_of(&q.pop().await.unwrap()), 2);
+    }
+
+    #[tokio::test]
+    async fn close_unblocks_reserve() {
+        let q = PriorityQueue::new(1);
+        let a = sid(0);
+        push(&q, 5, a, frame(a, 1)).await.unwrap();
+
+        let q2 = q.clone();
+        let handle = tokio::spawn(async move { q2.reserve().await.map(|_| ()) });
+        tokio::task::yield_now().await;
+        q.close();
+        assert!(matches!(handle.await.unwrap(), Err(Error::Closed)));
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -2121,33 +2121,31 @@ impl generic::SendStream for SendStream {
         while buf.has_remaining() {
             let chunk_len = buf.chunk().len().min(MAX_FRAME_PAYLOAD) as u64;
 
-            // Claim flow control credit
+            // Wait for queue capacity and flow-control credit *before* taking any
+            // bytes out of `buf`. Callers race this future against other work (moq
+            // re-prioritizes a stream mid-write), so every await here has to leave
+            // the caller's buffer untouched: dropping the future returns the permit
+            // and claims no credit, and the caller just retries. Taking the bytes
+            // first and awaiting after would let a cancel strand them — gone from
+            // `buf` but never queued, a silent hole the peer decodes as garbage.
+            let permit = tokio::select! {
+                result = self.outbound.reserve() => result?,
+                Some(stop) = self.inbound_stopped.recv() => return Err(self.recv_stop(stop.code)),
+            };
+
             let allowed = self.claim_credit(chunk_len).await?;
             let to_send = allowed as usize;
 
+            // Committed: no await between taking the bytes and queueing them.
             let frame = Stream {
                 id: self.id,
                 offset: self.offset,
                 data: buf.copy_to_bytes(to_send),
                 fin: false,
             };
-
-            tokio::select! {
-                result = self.outbound.push(self.priority, self.id, frame.into()) => {
-                    if result.is_err() {
-                        // Release credit since data was never sent
-                        self.release_credit(to_send as u64);
-                        return Err(Error::Closed);
-                    }
-                    self.offset += to_send as u64;
-                    total += to_send;
-                }
-                Some(stop) = self.inbound_stopped.recv() => {
-                    // Release credit since data was never sent
-                    self.release_credit(to_send as u64);
-                    return Err(self.recv_stop(stop.code));
-                }
-            }
+            permit.send(self.priority, self.id, frame.into());
+            self.offset += to_send as u64;
+            total += to_send;
         }
 
         Ok(total)
@@ -2618,6 +2616,166 @@ mod send_offset_tests {
                 other => panic!("expected STREAM, got {other:?}"),
             }
         }
+    }
+}
+
+/// `write_buf` must not lose bytes when its future is dropped.
+///
+/// Callers race writes against other work — moq's publisher selects a write
+/// against the stream's priority-change channel, which fires on every group
+/// boundary — so a write parked on a full queue or on flow control gets
+/// cancelled and retried constantly. Cancelling has to leave the caller's buffer
+/// untouched: a byte taken from `buf` but never queued is a silent hole in the
+/// stream, which the peer decodes as a truncated or garbage frame on an
+/// otherwise healthy, cleanly-finished stream.
+#[cfg(test)]
+mod write_cancel_tests {
+    use bytes::{Buf, Bytes};
+    use tokio::sync::mpsc;
+    use web_transport_trait::SendStream as _;
+
+    use super::SendStream;
+    use crate::credit::Credit;
+    use crate::sched::PriorityQueue;
+    use crate::{Frame, StreamDir, StreamId};
+
+    fn send_stream(
+        outbound: PriorityQueue,
+        stream_credit: Option<Credit>,
+        conn_credit: Option<Credit>,
+    ) -> SendStream {
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let (_stop_tx, stop_rx) = mpsc::unbounded_channel();
+        SendStream {
+            id: StreamId::new(0, StreamDir::Uni, false),
+            outbound,
+            outbound_priority: control,
+            inbound_stopped: stop_rx,
+            offset: 0,
+            priority: 0,
+            closed: None,
+            fin: false,
+            stream_credit,
+            conn_credit,
+        }
+    }
+
+    /// Drive `write_buf` while repeatedly cancelling it, mirroring moq's
+    /// publisher racing a write against its priority-change channel. Returns the
+    /// bytes taken from the buffer.
+    ///
+    /// Note we can't measure via `write_buf`'s return value: it reports bytes
+    /// queued by *this call*, so cancelling during a later chunk's wait discards
+    /// the running total for chunks already queued. That loses the count, not the
+    /// data (`write_all` re-checks the buffer rather than trusting the count), so
+    /// the queue itself is the source of truth for what actually got sent.
+    async fn cancel_writes(send: &mut SendStream, buf: &mut Bytes) -> usize {
+        let start = buf.remaining();
+        for _ in 0..50 {
+            tokio::select! {
+                result = send.write_buf(buf) => { result.expect("write_buf"); }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+        start - buf.remaining()
+    }
+
+    /// Total STREAM payload bytes sitting in the queue.
+    async fn drain(outbound: &PriorityQueue) -> usize {
+        outbound.close();
+        let mut queued = 0;
+        while let Some(frame) = outbound.pop().await {
+            if let Frame::Stream(stream) = frame {
+                queued += stream.data.len();
+            }
+        }
+        queued
+    }
+
+    /// Cancelled while waiting for outbound queue capacity. A write that never
+    /// gets a slot must not take anything from the buffer; before the
+    /// reserve/permit split each cancelled call had already `copy_to_bytes`'d a
+    /// ~16 KB chunk out of `buf` and dropped it on the floor.
+    #[tokio::test]
+    async fn cancelled_write_blocked_on_queue_consumes_nothing() {
+        // Capacity 1, already occupied and never drained: every write parks.
+        let outbound = PriorityQueue::new(1);
+        let mut filler = send_stream(outbound.clone(), None, None);
+        filler.write(&[0xFF]).await.unwrap();
+
+        let mut send = send_stream(outbound.clone(), None, None);
+        let mut buf = Bytes::from(vec![0xAB_u8; 1024 * 1024]);
+        let consumed = cancel_writes(&mut send, &mut buf).await;
+
+        assert_eq!(
+            consumed, 0,
+            "write_buf never got a queue slot but still took {consumed} bytes \
+             from the buffer",
+        );
+    }
+
+    /// A write that never reaches the wire must not spend flow-control credit
+    /// either. Claiming credit and *then* awaiting a queue slot strands the claim
+    /// when the wait is cancelled, and since the peer only replenishes credit for
+    /// data it actually received, a stream cancelled often enough starves itself
+    /// into a permanent stall.
+    #[tokio::test]
+    async fn cancelled_write_blocked_on_queue_spends_no_credit() {
+        const WINDOW: u64 = 64 * 1024;
+
+        let outbound = PriorityQueue::new(1);
+        let mut filler = send_stream(outbound.clone(), None, None);
+        filler.write(&[0xFF]).await.unwrap();
+
+        let stream_credit = Credit::new(WINDOW);
+        let conn_credit = Credit::new(WINDOW);
+        let mut send = send_stream(
+            outbound,
+            Some(stream_credit.clone()),
+            Some(conn_credit.clone()),
+        );
+
+        let mut buf = Bytes::from(vec![0xAB_u8; 1024 * 1024]);
+        cancel_writes(&mut send, &mut buf).await;
+
+        // Nothing was queued, so the whole window must still be available.
+        assert_eq!(
+            stream_credit.try_claim(WINDOW),
+            WINDOW,
+            "cancelled writes leaked stream credit",
+        );
+        assert_eq!(
+            conn_credit.try_claim(WINDOW),
+            WINDOW,
+            "cancelled writes leaked connection credit",
+        );
+    }
+
+    /// Cancelled while waiting for flow-control credit, with the queue draining
+    /// normally: every byte taken from the buffer must be in the queue.
+    #[tokio::test]
+    async fn cancelled_write_blocked_on_credit_queues_what_it_consumes() {
+        // Roomy queue; an exhausted, never-replenished window is what blocks.
+        let outbound = PriorityQueue::new(64);
+        let stream_credit = Credit::new(32 * 1024);
+        let conn_credit = Credit::new(64 * 1024 * 1024);
+
+        let mut send = send_stream(outbound.clone(), Some(stream_credit), Some(conn_credit));
+        let mut buf = Bytes::from(vec![0xAB_u8; 1024 * 1024]);
+        let consumed = cancel_writes(&mut send, &mut buf).await;
+        let queued = drain(&outbound).await;
+
+        assert_eq!(
+            consumed,
+            queued,
+            "write_buf took {consumed} bytes from the buffer but only {queued} \
+             reached the queue — {} bytes silently dropped by cancellation",
+            consumed.saturating_sub(queued),
+        );
+        assert!(
+            consumed > 0,
+            "expected the window's worth of data to get through"
+        );
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -2143,7 +2143,11 @@ impl generic::SendStream for SendStream {
                 data: buf.copy_to_bytes(to_send),
                 fin: false,
             };
-            permit.send(self.priority, self.id, frame.into());
+            if let Err(err) = permit.send(self.priority, self.id, frame.into()) {
+                // The session closed while we held the permit; the data was never sent.
+                self.release_credit(to_send as u64);
+                return Err(err);
+            }
             self.offset += to_send as u64;
             total += to_send;
         }

--- a/rs/web-transport-quinn/src/send.rs
+++ b/rs/web-transport-quinn/src/send.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 
 use crate::{ClosedStream, SessionError, WriteError};
 
@@ -166,15 +166,16 @@ impl web_transport_trait::SendStream for SendStream {
         Self::write(self, buf).await
     }
 
-    async fn write_buf<B: Buf + Send>(&mut self, buf: &mut B) -> Result<usize, Self::Error> {
-        // This can avoid making a copy when Buf is Bytes, as Quinn will allocate anyway.
-        let size = buf.chunk().len();
-        let chunk = buf.copy_to_bytes(size);
-        self.write_chunk(chunk).await?;
-        Ok(size)
-    }
+    // `write_buf` is deliberately left to the trait's default, which writes out of
+    // `buf.chunk()` and advances only by what Quinn accepted. Overriding it to
+    // `copy_to_bytes` up front and then await the zero-copy `write_chunk` would be
+    // faster but loses data: `write_chunk` is not cancel safe, so a caller that
+    // drops the future (moq re-prioritizes a stream mid-write) strands the chunk —
+    // gone from `buf` but never sent, a silent hole in the stream.
 
     async fn write_chunk(&mut self, chunk: Bytes) -> Result<(), Self::Error> {
+        // Sound to keep zero-copy here: the caller hands over ownership, so there is
+        // no buffer position to get out of sync with a cancelled write.
         self.write_chunk(chunk).await
     }
 

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -138,11 +138,24 @@ pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
 pub trait SendStream: MaybeSend {
     type Error: Error;
 
-    /// Write some of the buffer to the stream.
+    /// Write some of the buffer to the stream, returning how many bytes were
+    /// written. See [`write_buf`](Self::write_buf) for the cancel-safety contract,
+    /// which this shares.
     fn write(&mut self, buf: &[u8])
         -> impl Future<Output = Result<usize, Self::Error>> + MaybeSend;
 
-    /// Write the given buffer to the stream, advancing the internal position.
+    /// Write some of the given buffer to the stream, advancing it by the number of
+    /// bytes written. This may be less than the whole buffer, so callers loop (or
+    /// use [`write_all`](Self::write_all)).
+    ///
+    /// # Cancel safety
+    ///
+    /// Implementations must be cancel safe: if the returned future is dropped
+    /// before it resolves, `buf` must not have been advanced past what the peer
+    /// will actually receive. Callers race writes against other work, so a byte
+    /// taken from `buf` but never sent becomes a silent hole in the stream, which
+    /// the peer decodes as a truncated or garbage frame. Wait for send capacity
+    /// *before* consuming from `buf`, never after.
     fn write_buf<B: Buf + MaybeSend>(
         &mut self,
         buf: &mut B,

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -151,11 +151,13 @@ pub trait SendStream: MaybeSend {
     /// # Cancel safety
     ///
     /// Implementations must be cancel safe: if the returned future is dropped
-    /// before it resolves, `buf` must not have been advanced past what the peer
-    /// will actually receive. Callers race writes against other work, so a byte
-    /// taken from `buf` but never sent becomes a silent hole in the stream, which
-    /// the peer decodes as a truncated or garbage frame. Wait for send capacity
-    /// *before* consuming from `buf`, never after.
+    /// before it resolves, `buf` must not have been advanced past the bytes the
+    /// implementation accepted for sending. (Whether they reach the peer is a
+    /// separate matter — a reset or a dead connection can still discard accepted
+    /// bytes.) Callers race writes against other work, so a byte taken from `buf`
+    /// but never accepted becomes a silent hole in the stream, which the peer
+    /// decodes as a truncated or garbage frame. Wait for send capacity *before*
+    /// consuming from `buf`, never after.
     fn write_buf<B: Buf + MaybeSend>(
         &mut self,
         buf: &mut B,


### PR DESCRIPTION
## Root cause

`SendStream::write_buf` took bytes out of the caller's buffer with `copy_to_bytes` and *only then* awaited queue capacity. Dropping that future stranded the chunk: gone from `buf`, never queued, `offset` never advanced. Nothing reported an error, so the stream stayed live and finished cleanly **with a hole in the middle**, which the peer decodes as a truncated or garbage frame.

```rust
let allowed = self.claim_credit(chunk_len).await?;
let frame = Stream { data: buf.copy_to_bytes(to_send), .. };  // bytes leave `buf` here
tokio::select! {
    result = self.outbound.push(..) => { .. }                  // ...and are lost if cancelled here
    Some(stop) = self.inbound_stopped.recv() => { .. }
}
```

Callers hit this constantly rather than rarely. moq's publisher races `write_all` against a stream's priority-change channel, which fires on every group boundary of every track, while qmux's outbound queue holds **8 frames for the whole session**. On a link slower than the broadcast the queue is always full, so the write is always parked and the cancel window is always open.

This is moq-dev/moq#2265: a flood of `WrongSize`/`FrameTooLarge` evictions and then a fatal decode error. It was reported as WebSocket-specific, but the WebSocket transport is not at fault — it is simply slow enough to keep the queue full.

## The fix

Split the wait from the commit, mirroring `mpsc::Sender::reserve`. `PriorityQueue::reserve` awaits a slot and returns a `Permit` that enqueues synchronously, so nothing leaves `buf` until it is certain to be queued:

```rust
let permit = tokio::select! {                        // await capacity — `buf` untouched
    result = self.outbound.reserve() => result?,
    Some(stop) = self.inbound_stopped.recv() => return Err(self.recv_stop(stop.code)),
};
let allowed = self.claim_credit(chunk_len).await?;   // await credit — `buf` untouched

// Committed: no await between taking the bytes and queueing them.
let frame = Stream { data: buf.copy_to_bytes(to_send), .. };
permit.send(self.priority, self.id, frame.into());
```

`push` is gone; reserving is the only way in, which makes holding bytes across an await unrepresentable rather than merely discouraged. `sched` is a private module, so there's no semver exposure.

This also fixes a **flow-control leak** on the same path: credit was claimed before the await, so a cancelled write spent credit on data it never sent. The peer only replenishes credit for data it *received*, so a stream cancelled often enough starved itself into a permanent stall.

## QUIC had the same bug

`web-transport-quinn`'s `write_buf` override consumed from `buf` and then awaited quinn's `write_chunk`, which quinn documents as *"not cancellation safe. Even if this does not resolve, some bytes may have been written."* Same silent data loss; it only bites once quinn's flow-control window fills, which is why QUIC looked clean in the bug report.

The trait's own default `write_buf` was **already correct** (write from `buf.chunk()`, advance only by what was accepted). The override deviated from it for a zero-copy win and reintroduced the bug, so dropping the override both fixes it and removes code. The zero-copy `write_chunk` impl stays: there the caller hands over ownership, so there's no buffer position to desync.

Both implementations independently got this wrong against an unwritten rule, so the cancel-safety contract is now documented on `SendStream::write_buf`.

## Tests

Three regression tests in `session.rs`. Reverting `write_buf` to its old shape fails immediately:

```
write_buf never got a queue slot but still took 817600 bytes from the buffer
```

They measure bytes that actually reached the queue, not `write_buf`'s return value — cancelling during a later chunk discards the running count for chunks already queued, which loses the count but not the data (`write_all` re-checks the buffer rather than trusting it).

`cancelled_write_blocked_on_queue_spends_no_credit` covers the flow-control leak.

## Caveats

- **The quinn change has no regression test.** That crate has no test scaffolding, and a real one needs a live connection with a deliberately exhausted window — disproportionate for what is now a deletion. It rests on quinn's documented contract plus the trait default it now shares with every other implementation.
- **moq can't consume this yet**: it pins `qmux = "0.3"` and this is on 0.4. Needs a release plus a dep bump (0.3→0.4 carries the `Transport` Writer/Reader split and the `Config::new` signature change).

Fixes moq-dev/moq#2265 (transport half; the `export ts` fatal-on-bad-frame resilience issue is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)