### PR TITLE
feat(qmux): add server-side Session.accept() (JS)

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -1,6 +1,6 @@
 # @moq/qmux
 
-A [WebTransport](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport_API) polyfill for browsers, using WebSockets as the underlying transport with [QMux](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html) (draft-ietf-quic-qmux-02, negotiating down to draft-01 and draft-00) framing.
+A [WebTransport](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport_API) implementation using WebSockets as the underlying transport with [QMux](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html) (draft-ietf-quic-qmux-02, negotiating down to draft-01 and draft-00) framing: a polyfill in browsers, and a server on any runtime that can accept a WebSocket.
 
 QMux brings QUIC's multiplexed streams and flow control to reliable, ordered byte-stream transports like WebSockets. This allows WebTransport applications to seamlessly fall back when QUIC/UDP is blocked by network middleboxes.
 

--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -23,6 +23,39 @@ await transport.ready
 const stream = await transport.createBidirectionalStream()
 ```
 
+### Servers
+
+`Session.accept` runs the other role, over a WebSocket your server has already accepted. The host
+performs the upgrade, so it — not this library — chooses the subprotocol; `selectSubprotocol` picks
+the value to accept from what the client offered, and the session reads the wire-format version back
+off the socket.
+
+```ts
+import Session, { selectSubprotocol } from "@moq/qmux"
+
+Deno.serve((req) => {
+	const protocol = selectSubprotocol(req.headers.get("sec-websocket-protocol"), {
+		protocols: ["moq-lite-04"],
+		versions: { "moq-lite-04": null },
+	})
+	if (!protocol) return new Response("no supported protocol", { status: 400 })
+
+	const { socket, response } = Deno.upgradeWebSocket(req, { protocol })
+	const session = Session.accept(socket)
+	handle(session) // a WebTransport, same as the client side
+	return response
+})
+```
+
+Any already-accepted `WebSocket` works — `Deno.upgradeWebSocket`, Node's `ws`, or a
+`WebSocketStream`. Accepting the upgrade without a negotiated subprotocol falls back to the legacy
+`webtransport` wire format, so reject the request when `selectSubprotocol` returns `undefined`
+rather than accepting a socket the peer's framing won't match. If your host doesn't expose the
+negotiated value on the socket, pass it explicitly as `{ protocol }`.
+
+The result is an ordinary `WebTransport`: the only difference from a client session is which half of
+the stream-id space each side owns.
+
 ### Detecting a dropped session
 
 `closed` follows the WebTransport contract:

--- a/js/qmux/src/index.ts
+++ b/js/qmux/src/index.ts
@@ -2,7 +2,8 @@ import type { Version } from "./session.ts";
 import Session from "./session.ts";
 
 export { SessionError } from "./error.ts";
-export type { Config, SessionOptions, Version } from "./session.ts";
+export type { AcceptOptions, Config, SessionOptions, Version } from "./session.ts";
+export { selectSubprotocol } from "./session.ts";
 
 /** Options forwarded to every `Session` constructed by [[install]]. */
 export interface InstallOptions {

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { WebSocketLike, WebSocketStreamLike } from "@moq/web-socket-stream";
 import { SessionError } from "./error.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
@@ -33,7 +34,12 @@ class FakePeer {
 	sent: Uint8Array[] = [];
 	closeInfo: { closeCode?: number; reason?: string } | undefined;
 
-	constructor(url: string) {
+	/** `options` mirrors the native `WebSocketStream` constructor, which
+	 *  `openWebSocketStream` calls with `{protocols, signal}` — hence `protocol`
+	 *  (the *negotiated* value, which only `Session.accept` tests set) rather than
+	 *  a positional argument that call would fill in. */
+	constructor(url: string, options?: { protocol?: string }) {
+		const protocol = options?.protocol ?? "qmux-01";
 		this.url = url;
 		FakePeer.last = this;
 		const readable = new ReadableStream<Uint8Array | ArrayBuffer | string>({
@@ -47,7 +53,7 @@ class FakePeer {
 				this.sent.push(chunk);
 			},
 		});
-		this.opened = Promise.resolve({ readable, writable, protocol: "qmux-01", extensions: "" });
+		this.opened = Promise.resolve({ readable, writable, protocol, extensions: "" });
 		const closed = Promise.withResolvers<{ closeCode?: number; reason?: string }>();
 		this.closed = closed.promise;
 		this.#closedResolve = closed.resolve;
@@ -105,6 +111,34 @@ class FakePeer {
 	}
 	count(type: Frame.Any["type"]): number {
 		return this.received().filter((f) => f.type === type).length;
+	}
+}
+
+/** A plain `WebSocket` as a server host hands it over: already open, with the
+ *  subprotocol picked during the upgrade. `Session.accept` has to wrap this
+ *  itself — there's no `WebSocketStream` in sight. */
+class FakeServerSocket implements WebSocketLike {
+	binaryType = "blob";
+	bufferedAmount = 0;
+	readyState = 1; // OPEN
+	extensions = "";
+	sent: Array<string | ArrayBufferLike | ArrayBufferView> = [];
+
+	onopen: ((ev: unknown) => void) | null = null;
+	onmessage: ((ev: { data: unknown }) => void) | null = null;
+	onerror: ((ev: unknown) => void) | null = null;
+	onclose: ((ev: { code?: number; reason?: string }) => void) | null = null;
+
+	constructor(
+		readonly url: string,
+		readonly protocol: string,
+	) {}
+
+	send(data: string | ArrayBufferLike | ArrayBufferView): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.readyState = 3; // CLOSED
 	}
 }
 
@@ -1074,5 +1108,131 @@ describe("Session integration (scripted peer)", () => {
 		const err = await settleTo(session.createBidirectionalStream());
 		expect(err).toBeInstanceOf(Error);
 		expect((err as Error).message).toBe("Connection closed: 5 done");
+	});
+});
+
+/** Hand `Session.accept` a scripted socket, standing in for one a host handed us
+ *  after an HTTP upgrade. The subprotocol is already negotiated at this point, so
+ *  the peer reports it rather than the session advertising it. */
+function accept(options?: { config?: Config; protocol?: string }): { session: Session; peer: FakePeer } {
+	const peer = new FakePeer("wss://example/test", { protocol: options?.protocol });
+	const session = Session.accept(peer as unknown as WebSocketStreamLike, {
+		// Idle timer off so a stray interval can't interfere with the test.
+		config: { maxIdleTimeout: 0n, ...options?.config },
+	});
+	return { session, peer };
+}
+
+/** The first STREAM frame the session put on the wire. */
+async function firstStreamId(peer: FakePeer): Promise<Stream.Id> {
+	await waitFor(() => peer.has("stream"));
+	return (peer.received().find((f) => f.type === "stream") as Frame.Data).id;
+}
+
+describe("Session.accept (server role)", () => {
+	test("streams we open are server-initiated", async () => {
+		// The whole point of the role: a server minting client-initiated ids would
+		// collide with the client's own streams.
+		const { session, peer } = accept();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array([1]));
+
+		const id = await firstStreamId(peer);
+		expect(id.serverInitiated).toBe(true);
+		expect(id.dir).toBe(Stream.Dir.Uni);
+		session.close();
+	});
+
+	test("bidi streams we open are server-initiated", async () => {
+		const { session, peer } = accept();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const stream = await session.createBidirectionalStream();
+		await stream.writable.getWriter().write(new Uint8Array([1]));
+
+		const id = await firstStreamId(peer);
+		expect(id.serverInitiated).toBe(true);
+		expect(id.dir).toBe(Stream.Dir.Bi);
+		session.close();
+	});
+
+	test("a client-initiated stream arrives as an incoming stream", async () => {
+		const { session, peer } = accept();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		// Client-initiated (isServer: false) — the mirror of what a client session
+		// accepts, and what a client session would reject as a violation.
+		peer.send({
+			type: "stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, false),
+			data: new Uint8Array([7, 8, 9]),
+			fin: true,
+		});
+
+		const reader = session.incomingUnidirectionalStreams.getReader();
+		const { value: incoming } = await reader.read();
+		const { value } = await (incoming as ReadableStream<Uint8Array>).getReader().read();
+		expect(value).toEqual(new Uint8Array([7, 8, 9]));
+		reader.releaseLock();
+		session.close();
+	});
+
+	test("a peer using our own role's stream ids is a protocol violation", async () => {
+		const { session, peer } = accept();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		// Only the server may open server-initiated uni streams; a client sending
+		// one is either confused or spoofing our side of the id space.
+		peer.send({
+			type: "stream",
+			id: Stream.Id.create(0n, Stream.Dir.Uni, true),
+			data: new Uint8Array([1]),
+			fin: false,
+		});
+
+		await waitFor(() => peer.has("connection_close"));
+		expect(sentCloseCode(peer)).toBe(1002);
+		await expectSessionFailure(session);
+	});
+
+	test("the wire format comes from the socket's negotiated subprotocol", async () => {
+		const { session, peer } = accept({ protocol: "qmux-01.moq-lite-04" });
+		await session.ready;
+		expect(session.protocol).toBe("moq-lite-04");
+		// A QMux draft was negotiated, so we owe the peer our parameters.
+		await waitFor(() => peer.has("transport_parameters"));
+		session.close();
+	});
+
+	test("the protocol option stands in for a socket that doesn't report one", async () => {
+		// Without the override this negotiates the legacy `webtransport` wire format
+		// and misreads every QMux frame the peer sends.
+		const peer = new FakePeer("wss://example/test", { protocol: "" });
+		const session = Session.accept(peer as unknown as WebSocketStreamLike, {
+			config: { maxIdleTimeout: 0n },
+			protocol: "qmux-01.moq-lite-04",
+		});
+		await session.ready;
+		expect(session.protocol).toBe("moq-lite-04");
+		await waitFor(() => peer.has("transport_parameters"));
+		session.close();
+	});
+
+	test("a plain WebSocket is adopted, not just a WebSocketStream", async () => {
+		// What Deno.upgradeWebSocket / `ws` actually hand back.
+		const ws = new FakeServerSocket("wss://example/test", "qmux-01");
+		const session = Session.accept(ws, { config: { maxIdleTimeout: 0n } });
+		await session.ready;
+
+		await waitFor(() => ws.sent.length > 0);
+		const [params] = Frame.decodeRecord(ws.sent[0] as Uint8Array);
+		expect(params.type).toBe("transport_parameters");
+		session.close();
 	});
 });

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1201,6 +1201,23 @@ describe("Session.accept (server role)", () => {
 		await expectSessionFailure(session);
 	});
 
+	test("ArrayBuffer chunks decode on a transport we were handed directly", async () => {
+		// `openWebSocketStream` normalizes the native API's ArrayBuffer chunks, but
+		// accept() gets the transport as-is — and Chromium's WebSocketStream yields
+		// ArrayBuffer. Without normalization in the read loop this throws
+		// "Expected ArrayBuffer for the first argument" out of the varint decoder
+		// and the session never opens a stream.
+		const { session, peer } = accept();
+		await session.ready;
+		peer.sendArrayBuffer({ type: "transport_parameters", params: peerParams() });
+
+		// Decoding the params is what grants the stream-count credit this claims.
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array([1]));
+		expect((await firstStreamId(peer)).serverInitiated).toBe(true);
+		session.close();
+	});
+
 	test("the wire format comes from the socket's negotiated subprotocol", async () => {
 		const { session, peer } = accept({ protocol: "qmux-01.moq-lite-04" });
 		await session.ready;

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -755,7 +755,7 @@ export default class Session implements WebTransport {
 		);
 	}
 
-	async #readLoop(reader: ReadableStreamDefaultReader<Uint8Array | string>) {
+	async #readLoop(reader: ReadableStreamDefaultReader<Uint8Array | ArrayBuffer | string>) {
 		try {
 			while (true) {
 				const { value, done } = await reader.read();
@@ -767,7 +767,12 @@ export default class Session implements WebTransport {
 					this.#abort(1003, "text frames are not valid for QMux");
 					return;
 				}
-				this.#onData(value);
+				// `openWebSocketStream` normalizes the native API's ArrayBuffer chunks,
+				// but a transport handed straight to the constructor or [[accept]]
+				// hasn't been through it — and Chromium's WebSocketStream yields
+				// ArrayBuffer. Normalize here so every inbound path reaches the decoder
+				// as a Uint8Array.
+				this.#onData(value instanceof ArrayBuffer ? new Uint8Array(value) : value);
 			}
 		} catch (err) {
 			this.#closeReason ??= err instanceof Error ? err : new Error("WebSocketStream read error");

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1,4 +1,9 @@
-import { openWebSocketStream, type WebSocketStreamLike } from "@moq/web-socket-stream";
+import {
+	openWebSocketStream,
+	type WebSocketLike,
+	WebSocketStream,
+	type WebSocketStreamLike,
+} from "@moq/web-socket-stream";
 import { Credit, replenishWindow } from "./credit.ts";
 import { SessionError } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
@@ -303,8 +308,36 @@ export interface SessionOptions extends WebTransportOptions {
 	sendBufferSize?: number;
 }
 
+/** Options for accepting a QMux Session on an already-negotiated socket.
+ *
+ * The handshake is done by the time [[Session.accept]] is called, so the
+ * subprotocol options ([[SessionOptions.protocols]], `versions`,
+ * `requireProtocol`) don't apply — see [[selectSubprotocol]], which consumes
+ * them during the upgrade instead.
+ */
+export interface AcceptOptions extends Pick<SessionOptions, "config" | "sendBufferSize"> {
+	/** The negotiated `Sec-WebSocket-Protocol` value, for hosts that don't expose
+	 *  it on the socket.
+	 *
+	 *  [[Session.accept]] reads `socket.protocol` by default, which is where the
+	 *  wire-format version comes from. Set this when the socket reports an empty
+	 *  protocol despite one having been negotiated — otherwise the session falls
+	 *  back to the legacy `webtransport` wire format and the peer's QMux frames
+	 *  are misread. Pass the full wire value (e.g. `"qmux-02.moq-lite-04"`), not
+	 *  the bare app protocol. */
+	protocol?: string;
+}
+
 /** Default send-buffer high-water mark (bytes) for the WebSocketStream ponyfill. */
 const DEFAULT_SEND_BUFFER_SIZE = 64 * 1024;
+
+/** Present the caller's socket as a `WebSocketStreamLike`, whichever they passed.
+ *
+ * A `WebSocketStream` (native or ponyfill) already has the shape; a plain
+ * `WebSocket` gets wrapped, which takes ownership of its event handlers. */
+function toWebSocketStream(socket: WebSocketLike | WebSocketStreamLike, highWaterMark: number): WebSocketStreamLike {
+	return "opened" in socket ? socket : WebSocketStream.adopt(socket, { highWaterMark });
+}
 
 /** Get the subprotocol prefix for a QMux wire-format version. */
 function versionPrefix(version: Version): string {
@@ -384,6 +417,51 @@ export function resolveSubprotocols(
 	return out;
 }
 
+/** Choose the `Sec-WebSocket-Protocol` value to accept from a client's offer.
+ *
+ * The server role performs the WebSocket handshake itself (`Deno.upgradeWebSocket`,
+ * `ws`, `Bun.serve`, ...), so it — not this library — picks the subprotocol. This
+ * is the server-side mirror of [[resolveSubprotocols]]: it expands the same
+ * `protocols` + `versions` pair into the wire forms this session supports, in
+ * preference order, and returns the first one the client offered. Pass the result
+ * to the host's upgrade call, then hand the accepted socket to [[Session.accept]],
+ * which derives the wire-format version from it.
+ *
+ * `offered` accepts the raw `Sec-WebSocket-Protocol` header (comma-separated) or
+ * an already-split list. Returns `undefined` when nothing matches, which the
+ * caller should turn into a failed upgrade rather than accepting the socket:
+ * completing the handshake with no subprotocol negotiates the legacy
+ * `webtransport` wire format, which is unlikely to be what the client wanted.
+ *
+ * Preference is ours, not the client's — the first entry in `protocols` that the
+ * client also offered wins, matching the Rust `qmux::ws::Server`.
+ *
+ * @example
+ * ```ts
+ * const protocol = selectSubprotocol(req.headers.get("sec-websocket-protocol"), {
+ *   protocols: ["moq-transport-17"],
+ *   versions: { "moq-transport-17": null },
+ * });
+ * if (!protocol) return new Response("no supported protocol", { status: 400 });
+ * const { socket, response } = Deno.upgradeWebSocket(req, { protocol });
+ * ```
+ */
+export function selectSubprotocol(
+	offered: string | readonly string[] | null | undefined,
+	options?: Pick<SessionOptions, "protocols" | "versions" | "requireProtocol">,
+): string | undefined {
+	const wanted = typeof offered === "string" ? offered.split(",") : (offered ?? []);
+	const client = new Set(wanted.map((p) => p.trim()).filter((p) => p !== ""));
+	if (client.size === 0) return undefined;
+
+	const ours = resolveSubprotocols(
+		options?.protocols ?? [],
+		options?.versions ?? {},
+		options?.requireProtocol ?? false,
+	);
+	return ours.find((p) => client.has(p));
+}
+
 /** Pick the QMux wire-format version from a negotiated subprotocol. */
 function detectVersion(negotiated: string): WireFormat {
 	for (const v of QMUX_VERSIONS) {
@@ -451,7 +529,13 @@ export default class Session implements WebTransport {
 	#wss?: WebSocketStreamLike;
 	#scheduler?: SendScheduler;
 	#sendBufferSize: number;
+	// The stream-id role: false dials (client), true accepts (server). Set by
+	// [[Session.accept]]; every id we mint and every id we allow the peer to mint
+	// keys off it.
 	#isServer = false;
+	// [[AcceptOptions.protocol]]: stands in for `socket.protocol` when the host
+	// doesn't expose the negotiated subprotocol.
+	#protocolOverride?: string;
 	#closed?: Error;
 	#closeReason?: Error;
 
@@ -530,7 +614,7 @@ export default class Session implements WebTransport {
 	#lastPingRecv?: bigint;
 	#idleTimer?: ReturnType<typeof setInterval>;
 
-	/** Open a QMux session over WebSocket against `url`.
+	/** Open a QMux session as the **client**, dialing `url`.
 	 *
 	 * The polyfill constructs the underlying `WebSocket` itself. Pass the
 	 * application-level ALPNs in `options.protocols` plus a `versions`
@@ -541,8 +625,13 @@ export default class Session implements WebTransport {
 	 * Once the handshake completes, the QMux wire-format version is derived
 	 * from the negotiated `Sec-WebSocket-Protocol`. `.protocol` exposes the
 	 * application protocol with the QMux prefix stripped.
+	 *
+	 * Pass an already-connected `WebSocket` (or `WebSocketStream`) instead of a
+	 * URL to run the client role over a socket you opened yourself — the
+	 * subprotocol was chosen when you created it, so `options.protocols` and
+	 * `options.versions` are ignored. See [[Session.accept]] for the server role.
 	 */
-	constructor(url: string | URL, options?: SessionOptions) {
+	constructor(source: string | URL | WebSocketLike | WebSocketStreamLike, options?: SessionOptions) {
 		if (options?.requireUnreliable) {
 			throw new Error("not allowed to use WebSocket; requireUnreliable is true");
 		}
@@ -550,11 +639,12 @@ export default class Session implements WebTransport {
 			console.warn("serverCertificateHashes is not supported; trying anyway");
 		}
 
-		const subprotocols = resolveSubprotocols(
-			options?.protocols ?? [],
-			options?.versions ?? {},
-			options?.requireProtocol ?? false,
-		);
+		const dial = typeof source === "string" || source instanceof URL;
+		// Resolve before any other setup so a bad protocols/versions pairing throws
+		// from the constructor rather than failing the handshake later.
+		const subprotocols = dial
+			? resolveSubprotocols(options?.protocols ?? [], options?.versions ?? {}, options?.requireProtocol ?? false)
+			: [];
 
 		// Merge user config with defaults
 		this.#config = { ...DEFAULT_CONFIG, ...options?.config };
@@ -588,24 +678,58 @@ export default class Session implements WebTransport {
 		this.#incomingUnidirectionalQueue = new IncomingStreamQueue<ReadableStream<Uint8Array>>();
 		this.incomingUnidirectionalStreams = this.#incomingUnidirectionalQueue.readable;
 
-		this.#connect(toWebSocketUrl(url), subprotocols);
+		this.#attach(
+			dial
+				? // Open the transport via `WebSocketStream` — native when present (real
+					// backpressure), else the ponyfill over a plain `WebSocket`. One code
+					// path for both, so the path exercised in tests is the one Chromium
+					// runs natively.
+					openWebSocketStream(toWebSocketUrl(source as string | URL), {
+						protocols: subprotocols,
+						highWaterMark: this.#sendBufferSize,
+					})
+				: toWebSocketStream(source as WebSocketLike | WebSocketStreamLike, this.#sendBufferSize),
+		);
 	}
 
-	/** Open the transport via `WebSocketStream` — native when present (real
-	 *  backpressure), else the ponyfill over a plain `WebSocket`. One code path
-	 *  for both, so the path exercised in tests is the one Chromium runs natively. */
-	#connect(url: string, subprotocols: string[]) {
-		const wss = openWebSocketStream(url, {
-			protocols: subprotocols,
-			highWaterMark: this.#sendBufferSize,
-		});
+	/** Open a QMux session as the **server**, over a socket you have already
+	 *  accepted from an HTTP upgrade.
+	 *
+	 * The host performs the WebSocket handshake (`Deno.upgradeWebSocket`, `ws`,
+	 * ...), so by the time you get here the subprotocol is already negotiated:
+	 * the wire-format version and `.protocol` are read off the socket rather than
+	 * advertised. Use [[selectSubprotocol]] to pick that value during the upgrade.
+	 *
+	 * The returned session is a `WebTransport`, identical to a client session
+	 * apart from the stream-id role — so it accepts peer-initiated streams and
+	 * opens server-initiated ones.
+	 *
+	 * @example
+	 * ```ts
+	 * const { socket, response } = Deno.upgradeWebSocket(req, { protocol });
+	 * const session = Session.accept(socket, { config });
+	 * await session.ready;
+	 * ```
+	 */
+	static accept(socket: WebSocketLike | WebSocketStreamLike, options?: AcceptOptions): Session {
+		const session = new Session(socket, options);
+		// Applied after construction, which is safe because both transports settle
+		// `opened` asynchronously: #startSession, every stream id, and every inbound
+		// frame are interpreted strictly later than this.
+		session.#isServer = true;
+		session.#protocolOverride = options?.protocol;
+		return session;
+	}
+
+	/** Drive the session off an opened transport, whichever way we got it. */
+	#attach(wss: WebSocketStreamLike) {
 		this.#wss = wss;
 
 		wss.opened.then(
 			(conn) => {
 				// The session may have been closed before the socket finished opening.
 				if (this.#closed) return;
-				this.#startSession(conn.protocol, new WritableStreamSink(conn.writable));
+				this.#startSession(this.#protocolOverride ?? conn.protocol, new WritableStreamSink(conn.writable));
 				void this.#readLoop(conn.readable.getReader());
 			},
 			(err: unknown) => {

--- a/js/qmux/src/subprotocol.test.ts
+++ b/js/qmux/src/subprotocol.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveSubprotocols } from "./session.ts";
+import { resolveSubprotocols, selectSubprotocol } from "./session.ts";
 
 // The bare version ALPNs the polyfill appends when `requireProtocol` is false.
 const BARE = ["qmux-02", "qmux-01", "qmux-00", "webtransport"];
@@ -47,5 +47,51 @@ describe("resolveSubprotocols", () => {
 
 	test("a bare entry with no versions mapping throws", () => {
 		expect(() => resolveSubprotocols(["moq-lite-04"], {}, true)).toThrow();
+	});
+});
+
+describe("selectSubprotocol", () => {
+	const OPTIONS = { protocols: ["moq-lite-04"], versions: { "moq-lite-04": null }, requireProtocol: true };
+
+	test("picks the offered pair", () => {
+		expect(selectSubprotocol(["qmux-01.moq-lite-04"], OPTIONS)).toBe("qmux-01.moq-lite-04");
+	});
+
+	test("parses a raw comma-separated header", () => {
+		// What `req.headers.get("sec-websocket-protocol")` actually hands back.
+		expect(selectSubprotocol("qmux-00.moq-lite-04, qmux-01.moq-lite-04", OPTIONS)).toBe("qmux-01.moq-lite-04");
+	});
+
+	test("our preference wins, not the client's", () => {
+		// The client lists qmux-00 first; we prefer the newest draft we support.
+		// Matching the client's order here would silently pin every session to the
+		// oldest draft any peer still offers.
+		expect(selectSubprotocol(["qmux-00.moq-lite-04", "qmux-02.moq-lite-04"], OPTIONS)).toBe("qmux-02.moq-lite-04");
+	});
+
+	test("falls back to a bare version ALPN when the client pins no app protocol", () => {
+		expect(selectSubprotocol(["qmux-01"], { protocols: ["moq-lite-04"], versions: { "moq-lite-04": null } })).toBe(
+			"qmux-01",
+		);
+	});
+
+	test("requireProtocol refuses a client offering only bare ALPNs", () => {
+		expect(selectSubprotocol(["qmux-01", "webtransport"], OPTIONS)).toBeUndefined();
+	});
+
+	test("no overlap yields undefined", () => {
+		expect(selectSubprotocol(["qmux-01.something-else"], OPTIONS)).toBeUndefined();
+	});
+
+	test("an absent or empty header yields undefined", () => {
+		// A client that offered nothing can't be speaking a version we chose for it.
+		expect(selectSubprotocol(null, OPTIONS)).toBeUndefined();
+		expect(selectSubprotocol("", OPTIONS)).toBeUndefined();
+		expect(selectSubprotocol([], OPTIONS)).toBeUndefined();
+		expect(selectSubprotocol(undefined, OPTIONS)).toBeUndefined();
+	});
+
+	test("a legacy client gets the webtransport wire format by default", () => {
+		expect(selectSubprotocol("webtransport", {})).toBe("webtransport");
 	});
 });

--- a/js/qmux/tests/interop.test.ts
+++ b/js/qmux/tests/interop.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
 import { resolve } from "node:path";
-import Session, { type Version } from "../src/session.ts";
+import type {
+	WebSocketStreamCloseEvent,
+	WebSocketStreamCloseInfo,
+	WebSocketStreamLike,
+	WebSocketStreamOpenEvent,
+} from "@moq/web-socket-stream";
+import type { ServerWebSocket } from "bun";
+import Session, { selectSubprotocol, type Version } from "../src/session.ts";
 
 const ROOT = resolve(import.meta.dir, "../../..");
 const PROTOCOL = "qmux-interop";
@@ -178,5 +185,199 @@ async function runVersion(version: Version): Promise<void> {
 test("TypeScript client interoperates with the Rust WebSocket server across supported drafts", async () => {
 	for (const version of ["qmux-02", "qmux-01", "qmux-00"] as const) {
 		await runVersion(version);
+	}
+}, 120_000);
+
+/** Bun's `ServerWebSocket` is handler-based rather than a `WebSocket`, so it
+ *  can't be adopted directly. Presenting it as a `WebSocketStreamLike` is the
+ *  escape hatch every non-standard host has — and what makes `Session.accept`
+ *  usable from `Bun.serve` at all. */
+class BunSocketStream implements WebSocketStreamLike {
+	readonly url = "";
+	readonly opened: Promise<WebSocketStreamOpenEvent>;
+	readonly closed: Promise<WebSocketStreamCloseEvent>;
+	#opened = Promise.withResolvers<WebSocketStreamOpenEvent>();
+	#closed = Promise.withResolvers<WebSocketStreamCloseEvent>();
+	#incoming!: ReadableStreamDefaultController<Uint8Array | string>;
+	#socket?: ServerWebSocket<{ stream: BunSocketStream }>;
+
+	readonly #readable = new ReadableStream<Uint8Array | string>({
+		start: (controller) => {
+			this.#incoming = controller;
+		},
+	});
+
+	constructor(readonly protocol: string) {
+		this.opened = this.#opened.promise;
+		this.closed = this.#closed.promise;
+		this.opened.catch(() => {});
+	}
+
+	/** The upgrade completed: hand the session its streams. */
+	attach(socket: ServerWebSocket<{ stream: BunSocketStream }>): void {
+		this.#socket = socket;
+		const writable = new WritableStream<Uint8Array | string>({
+			write: (chunk) => {
+				socket.send(chunk);
+			},
+			close: () => socket.close(),
+			abort: () => socket.close(),
+		});
+		this.#opened.resolve({ readable: this.#readable, writable, extensions: "", protocol: this.protocol });
+	}
+
+	push(data: string | Buffer): void {
+		// Bun hands back a Buffer; copy to a plain Uint8Array view of just this
+		// message rather than passing the pooled buffer through.
+		this.#incoming.enqueue(typeof data === "string" ? data : new Uint8Array(data));
+	}
+
+	finish(closeCode: number, reason: string): void {
+		try {
+			this.#incoming.close();
+		} catch {}
+		this.#opened.reject(new Error("socket closed before opening"));
+		this.#closed.resolve({ closeCode, reason });
+	}
+
+	close(info: WebSocketStreamCloseInfo = {}): void {
+		this.#socket?.close(info.closeCode, info.reason);
+	}
+}
+
+/** The mirror of `runVersion`: the TypeScript side accepts and the Rust client
+ *  dials, so `Session.accept` owns the server half of the stream-id space. */
+async function runServerVersion(version: Version): Promise<void> {
+	const sessions = Promise.withResolvers<Session>();
+
+	const server = Bun.serve<{ stream: BunSocketStream }, never>({
+		port: 0,
+		fetch(req, server) {
+			const protocol = selectSubprotocol(req.headers.get("sec-websocket-protocol"), {
+				protocols: [PROTOCOL],
+				versions: { [PROTOCOL]: version },
+				requireProtocol: true,
+			});
+			if (!protocol) return new Response("no supported protocol", { status: 400 });
+
+			const stream = new BunSocketStream(protocol);
+			// Bun's socket doesn't report the negotiated subprotocol, so the session
+			// is told directly — the wire format is derived from it.
+			sessions.resolve(
+				Session.accept(stream, {
+					protocol,
+					// Small receive windows force the Rust sender to observe and react to
+					// MAX_DATA/MAX_STREAM_DATA updates during the large transfer.
+					config: {
+						maxData: 64n * 1024n,
+						maxStreamDataBidiLocal: 32n * 1024n,
+						maxStreamDataBidiRemote: 32n * 1024n,
+						maxStreamDataUni: 32n * 1024n,
+					},
+				}),
+			);
+			if (server.upgrade(req, { data: { stream }, headers: { "sec-websocket-protocol": protocol } })) return;
+			return new Response("upgrade failed", { status: 500 });
+		},
+		websocket: {
+			open: (ws) => ws.data.stream.attach(ws),
+			message: (ws, message) => ws.data.stream.push(message),
+			close: (ws, code, reason) => ws.data.stream.finish(code, reason),
+		},
+	});
+
+	const client = Bun.spawn(
+		[
+			"cargo",
+			"run",
+			"--quiet",
+			"-p",
+			"qmux",
+			"--example",
+			"interop-client",
+			"--features",
+			"ws",
+			"--",
+			`ws://127.0.0.1:${server.port}/interop`,
+			version,
+		],
+		{ cwd: ROOT, stdout: "pipe", stderr: "pipe" },
+	);
+	const stderr = new Response(client.stderr).text();
+
+	try {
+		// The first build can be cold, so the dial gets a larger bound than the
+		// individual protocol operations.
+		const session = await withTimeout("accepting the Rust client's session", sessions.promise, 60_000);
+		await withTimeout("opening the QMux session", session.ready);
+		expect(session.protocol).toBe(PROTOCOL);
+
+		const incomingReader = session.incomingUnidirectionalStreams.getReader();
+		const incoming = await withTimeout("accepting the client unidirectional stream", incomingReader.read(), 60_000);
+		incomingReader.releaseLock();
+		if (incoming.value === undefined) throw new Error("client unidirectional stream was missing");
+		expectPayload(
+			await withTimeout("reading the client flow-control payload", readAll(incoming.value)),
+			CLIENT_SEED,
+		);
+
+		const outgoing = await withTimeout(
+			"creating the server unidirectional stream",
+			session.createUnidirectionalStream(),
+		);
+		const outgoingWriter = outgoing.getWriter();
+		await withTimeout("writing the server flow-control payload", outgoingWriter.write(payload(SERVER_SEED)));
+		await withTimeout("finishing the server unidirectional stream", outgoingWriter.close());
+
+		const bidiReader = session.incomingBidirectionalStreams.getReader();
+		const bidi = await withTimeout("accepting the bidirectional stream", bidiReader.read());
+		bidiReader.releaseLock();
+		if (bidi.value === undefined) throw new Error("bidirectional stream was missing");
+		const request = await withTimeout("reading the bidirectional request", readAll(bidi.value.readable));
+		expect(new TextDecoder().decode(request)).toBe(`ping:${version}`);
+		const bidiWriter = bidi.value.writable.getWriter();
+		await withTimeout(
+			"writing the bidirectional response",
+			bidiWriter.write(new TextEncoder().encode(`pong:${version}`)),
+		);
+		await withTimeout("finishing the bidirectional response", bidiWriter.close());
+
+		if (version === "qmux-00") {
+			expect(session.datagrams.maxDatagramSize).toBe(0);
+		} else {
+			expect(session.datagrams.maxDatagramSize).toBeGreaterThan(0);
+			const datagramReader = session.datagrams.readable.getReader();
+			const fromRust = await withTimeout("receiving the Rust datagram", datagramReader.read());
+			datagramReader.releaseLock();
+			expect(new TextDecoder().decode(fromRust.value)).toBe("rust-datagram");
+
+			const datagramWriter = session.datagrams.writable.getWriter();
+			await datagramWriter.write(new TextEncoder().encode("typescript-datagram"));
+			datagramWriter.releaseLock();
+		}
+
+		session.close({ closeCode: 42, reason: "interop complete" });
+		expect(await withTimeout("closing the TypeScript session", session.closed)).toEqual({
+			closeCode: 42,
+			reason: "interop complete",
+		});
+
+		const exitCode = await withTimeout("waiting for the Rust interop client", client.exited);
+		if (exitCode !== 0) {
+			throw new Error(`Rust interop client exited with ${exitCode}:\n${await stderr}`);
+		}
+	} catch (error) {
+		client.kill();
+		await client.exited;
+		const diagnostics = await stderr;
+		throw new Error(`${error instanceof Error ? error.message : String(error)}\n${diagnostics}`);
+	} finally {
+		server.stop(true);
+	}
+}
+
+test("A TypeScript server interoperates with the Rust WebSocket client across supported drafts", async () => {
+	for (const version of ["qmux-02", "qmux-01", "qmux-00"] as const) {
+		await runServerVersion(version);
 	}
 }, 120_000);

--- a/js/web-socket-stream/README.md
+++ b/js/web-socket-stream/README.md
@@ -54,6 +54,23 @@ import { WebSocketStream } from "@moq/web-socket-stream"
 const wss = new WebSocketStream("wss://example.com", { webSocket: WebSocket, highWaterMark: 32 * 1024 })
 ```
 
+### Adopting an existing socket
+
+A server has no URL to dial: the socket arrives from an HTTP upgrade, already open and with its
+subprotocol negotiated. `adopt` wraps one in place, resolving `opened` without waiting for an
+`onopen` that has already fired:
+
+```ts
+import { WebSocketStream } from "@moq/web-socket-stream"
+
+const { socket, response } = Deno.upgradeWebSocket(req)
+const wss = WebSocketStream.adopt(socket)
+const { readable, writable } = await wss.opened
+```
+
+Adoption takes ownership of the socket's event handlers, so adopt it before anything else reads from
+it — messages delivered beforehand are dropped by the platform rather than buffered.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.

--- a/js/web-socket-stream/src/index.test.ts
+++ b/js/web-socket-stream/src/index.test.ts
@@ -221,3 +221,91 @@ describe("WebSocketStream ponyfill", () => {
 		}
 	});
 });
+
+describe("WebSocketStream.adopt", () => {
+	/** A socket handed over by a server after the upgrade: already OPEN, with the
+	 *  subprotocol chosen during the handshake. */
+	function accepted(protocol = "p1"): FakeWebSocket {
+		const ws = new FakeWebSocket("wss://x/y", protocol);
+		ws.readyState = 1; // OPEN
+		return ws;
+	}
+
+	test("an already-open socket resolves opened without an onopen event", async () => {
+		// The server's socket opened before we ever saw it, so `onopen` has already
+		// fired (or never will). Waiting for it would hang the session forever.
+		const wss = WebSocketStream.adopt(accepted());
+		const { protocol } = await wss.opened;
+		expect(protocol).toBe("p1");
+	});
+
+	test("adopted sockets carry data both ways", async () => {
+		const ws = accepted();
+		const wss = WebSocketStream.adopt(ws);
+		const { readable, writable } = await wss.opened;
+
+		await writable.getWriter().write(new Uint8Array([1, 2, 3]));
+		expect(ws.sent).toEqual([new Uint8Array([1, 2, 3])]);
+
+		ws.message(new Uint8Array([4, 5]).buffer);
+		const { value } = await readable.getReader().read();
+		expect(value).toEqual(new Uint8Array([4, 5]));
+	});
+
+	test("url and binaryType come off the adopted socket", async () => {
+		const ws = accepted();
+		const wss = WebSocketStream.adopt(ws);
+		expect(wss.url).toBe("wss://x/y");
+		expect(ws.binaryType).toBe("arraybuffer");
+	});
+
+	test("a socket still connecting waits for onopen", async () => {
+		// Deno hands back a CONNECTING socket: the upgrade response hasn't been
+		// written yet. Settling `opened` from readyState here would be premature.
+		const ws = new FakeWebSocket("wss://x/y", "p1");
+		const wss = WebSocketStream.adopt(ws);
+		let opened = false;
+		void wss.opened.then(() => {
+			opened = true;
+		});
+		await tick();
+		expect(opened).toBe(false);
+
+		ws.open();
+		await wss.opened;
+		expect(opened).toBe(true);
+	});
+
+	test("adopting a closed socket rejects opened rather than hanging", async () => {
+		const ws = new FakeWebSocket("wss://x/y", "p1");
+		ws.readyState = 3; // CLOSED
+		const wss = WebSocketStream.adopt(ws);
+		expect(wss.opened).rejects.toThrow(/already closed/);
+		expect(await wss.closed).toEqual({ closeCode: 1006, reason: "" });
+	});
+
+	test("backpressure applies to an adopted socket", async () => {
+		const ws = accepted();
+		ws.bufferedAmount = 100;
+		const wss = WebSocketStream.adopt(ws, { highWaterMark: 10 });
+		expect(wss.highWaterMark).toBe(10);
+
+		const { writable } = await wss.opened;
+		let written = false;
+		void writable
+			.getWriter()
+			.write(new Uint8Array([1]))
+			.then(() => {
+				written = true;
+			});
+		await tick(2);
+		expect(written).toBe(false); // parked until the buffer drains
+
+		// The ponyfill re-checks `bufferedAmount` on a timer, so poll rather than
+		// assume how many turns the drain takes.
+		ws.bufferedAmount = 0;
+		const deadline = Date.now() + 1000;
+		while (!written && Date.now() < deadline) await tick();
+		expect(written).toBe(true);
+	});
+});

--- a/js/web-socket-stream/src/index.ts
+++ b/js/web-socket-stream/src/index.ts
@@ -76,6 +76,9 @@ type NativeWebSocketStreamConstructor = new (
  *  `WebSocket` and Node's `ws` satisfy it. */
 export interface WebSocketLike {
 	binaryType: string;
+	/** Absent on some server-side implementations; only used to report
+	 *  {@link WebSocketStreamLike.url} for an adopted socket. */
+	readonly url?: string;
 	readonly bufferedAmount: number;
 	readonly readyState: number;
 	readonly protocol: string;
@@ -104,6 +107,7 @@ export interface WebSocketStreamOptions {
 	highWaterMark?: number;
 }
 
+const CONNECTING = 0;
 const OPEN = 1;
 const DEFAULT_HIGH_WATER_MARK = 64 * 1024;
 
@@ -137,14 +141,20 @@ export class WebSocketStream implements WebSocketStreamLike {
 	#ws: WebSocketLike;
 	#highWaterMark: number;
 
-	constructor(url: string, options: WebSocketStreamOptions = {}) {
-		this.url = url;
-
-		const Ctor = options.webSocket ?? (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket;
-		if (!Ctor) {
-			throw new Error("No WebSocket implementation found; pass options.webSocket");
+	/** Dial `url`, or wrap a socket you already have (see {@link WebSocketStream.adopt}). */
+	constructor(source: string | WebSocketLike, options: WebSocketStreamOptions = {}) {
+		let ws: WebSocketLike;
+		if (typeof source === "string") {
+			const Ctor = options.webSocket ?? (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket;
+			if (!Ctor) {
+				throw new Error("No WebSocket implementation found; pass options.webSocket");
+			}
+			ws = new Ctor(source, options.protocols);
+			this.url = source;
+		} else {
+			ws = source;
+			this.url = source.url ?? "";
 		}
-		const ws = new Ctor(url, options.protocols);
 		ws.binaryType = "arraybuffer";
 		this.#ws = ws;
 		this.#highWaterMark = Math.max(1, Math.floor(options.highWaterMark ?? DEFAULT_HIGH_WATER_MARK));
@@ -204,11 +214,40 @@ export class WebSocketStream implements WebSocketStreamLike {
 			closed.resolve({ closeCode: event.code ?? 1006, reason: event.reason ?? "" });
 		};
 
+		// An adopted socket may already have finished (or missed) its handshake, in
+		// which case `onopen`/`onclose` will never fire — settle from readyState.
+		if (ws.readyState !== CONNECTING) {
+			if (ws.readyState === OPEN) {
+				opened.resolve({ readable, writable, extensions: ws.extensions, protocol: ws.protocol });
+			} else {
+				opened.reject(new Error("WebSocket is already closed"));
+				try {
+					controller?.close();
+				} catch {}
+				closed.resolve({ closeCode: 1006, reason: "" });
+			}
+		}
+
 		const { signal } = options;
 		if (signal) {
 			if (signal.aborted) ws.close();
 			else signal.addEventListener("abort", () => ws.close(), { once: true });
 		}
+	}
+
+	/** Wrap a socket that already exists — typically one a server accepted from an
+	 *  HTTP upgrade (`Deno.upgradeWebSocket`, `ws`, ...), where there is no URL to
+	 *  dial and the handshake (including subprotocol selection) is already done.
+	 *
+	 *  Ownership transfers: this overwrites the socket's `onopen`/`onmessage`/
+	 *  `onerror`/`onclose` handlers, so adopt it before anything else reads from
+	 *  it — messages delivered before adoption are dropped by the platform, not
+	 *  buffered. A socket that is already open resolves {@link opened} without
+	 *  waiting for an `onopen` that has already fired (or was never going to).
+	 *
+	 *  `options.protocols` and `options.webSocket` are ignored; the socket exists. */
+	static adopt(ws: WebSocketLike, options: Pick<WebSocketStreamOptions, "highWaterMark" | "signal"> = {}) {
+		return new WebSocketStream(ws, options);
 	}
 
 	close(closeInfo: WebSocketStreamCloseInfo = {}): void {

--- a/rs/qmux/examples/interop-client.rs
+++ b/rs/qmux/examples/interop-client.rs
@@ -1,0 +1,123 @@
+//! WebSocket client used by the cross-language QMux smoke test.
+//!
+//! The mirror of `interop-server`: here the TypeScript side accepts the socket
+//! and this example dials it, so the roles that decide the stream-id space are
+//! swapped. Completing the scenario proves a `Session.accept` server agrees with
+//! an independent implementation about role assignment and the wire format.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context as _};
+use bytes::Bytes;
+use qmux::{Session, Version};
+use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
+
+const PROTOCOL: &str = "qmux-interop";
+const PAYLOAD_LEN: usize = 1_200_000;
+const CLIENT_SEED: usize = 17;
+const SERVER_SEED: usize = 29;
+const TIMEOUT: Duration = Duration::from_secs(15);
+
+fn parse_version(value: &str) -> anyhow::Result<Version> {
+    match value {
+        "qmux-00" => Ok(Version::QMux00),
+        "qmux-01" => Ok(Version::QMux01),
+        "qmux-02" => Ok(Version::QMux02),
+        _ => bail!("unsupported QMux version: {value}"),
+    }
+}
+
+fn payload(seed: usize) -> Vec<u8> {
+    (0..PAYLOAD_LEN)
+        .map(|index| ((index * 31 + seed) % 251) as u8)
+        .collect()
+}
+
+async fn run(session: Session, version: Version) -> anyhow::Result<()> {
+    if session.protocol() != Some(PROTOCOL) {
+        bail!("unexpected negotiated protocol: {:?}", session.protocol());
+    }
+
+    // Rust -> TypeScript, large enough to require both stream- and
+    // connection-level flow-control updates.
+    let mut send = tokio::time::timeout(TIMEOUT, session.open_uni())
+        .await
+        .context("timed out opening the client unidirectional stream")??;
+    tokio::time::timeout(TIMEOUT, send.write_all(&payload(CLIENT_SEED)))
+        .await
+        .context("timed out writing the client flow-control payload")??;
+    send.finish()?;
+
+    // TypeScript -> Rust. Server-initiated streams are the ids only a
+    // `Session.accept` session may mint; a client-role server would be rejected
+    // here rather than accepted.
+    let mut recv = tokio::time::timeout(TIMEOUT, session.accept_uni())
+        .await
+        .context("timed out accepting the server unidirectional stream")??;
+    let received = tokio::time::timeout(TIMEOUT, recv.read_all())
+        .await
+        .context("timed out reading the server flow-control payload")??;
+    if received.as_ref() != payload(SERVER_SEED) {
+        bail!("server flow-control payload did not match");
+    }
+
+    // Exercise both halves of one bidirectional stream and FIN propagation.
+    let (mut send, mut recv) = tokio::time::timeout(TIMEOUT, session.open_bi())
+        .await
+        .context("timed out opening the bidirectional stream")??;
+    let request = format!("ping:{}", version.alpn());
+    tokio::time::timeout(TIMEOUT, send.write_all(request.as_bytes()))
+        .await
+        .context("timed out writing the bidirectional request")??;
+    send.finish()?;
+    let response = tokio::time::timeout(TIMEOUT, recv.read_all())
+        .await
+        .context("timed out reading the bidirectional response")??;
+    if response.as_ref() != format!("pong:{}", version.alpn()).as_bytes() {
+        bail!("unexpected bidirectional response");
+    }
+
+    // DATAGRAM is available only on record-framed drafts (QMux01+).
+    if version.uses_records() {
+        session.send_datagram(Bytes::from_static(b"rust-datagram"))?;
+        let datagram = tokio::time::timeout(TIMEOUT, session.recv_datagram())
+            .await
+            .context("timed out receiving the TypeScript datagram")??;
+        if datagram.as_ref() != b"typescript-datagram" {
+            bail!("unexpected TypeScript datagram");
+        }
+    } else if session.max_datagram_size() != 0 {
+        bail!("QMux00 unexpectedly negotiated datagram support");
+    }
+
+    let closed = tokio::time::timeout(TIMEOUT, session.closed())
+        .await
+        .context("timed out waiting for the TypeScript server to close")?;
+    match closed {
+        qmux::Error::ConnectionClosed { code, reason }
+            if code.into_inner() == 42 && reason == "interop complete" => {}
+        other => bail!("unexpected session close: {other}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let url = args
+        .next()
+        .context("usage: interop-client <url> <qmux-00|qmux-01|qmux-02>")?;
+    let raw_version = args
+        .next()
+        .context("usage: interop-client <url> <qmux-00|qmux-01|qmux-02>")?;
+    let version = parse_version(&raw_version)?;
+
+    let session = qmux::ws::Client::new()
+        .with_protocol(PROTOCOL, &[version])
+        .require_protocol()
+        .connect(&url)
+        .await?;
+
+    run(session, version).await
+}


### PR DESCRIPTION
Closes #314.

`js/qmux`'s `Session` could only ever be a client. The protocol logic was already role-aware, but `#isServer` was never assigned and the socket was not injectable, so there was no way to build a server session from an accepted WebSocket — a JS accept server had no equivalent of the `ws://` fallback `moq-relay` serves alongside WebTransport.

## API

```ts
import Session, { selectSubprotocol } from "@moq/qmux"

Deno.serve((req) => {
	const protocol = selectSubprotocol(req.headers.get("sec-websocket-protocol"), {
		protocols: ["moq-lite-04"],
		versions: { "moq-lite-04": null },
	})
	if (!protocol) return new Response("no supported protocol", { status: 400 })

	const { socket, response } = Deno.upgradeWebSocket(req, { protocol })
	const session = Session.accept(socket)  // a WebTransport, server-side
	handle(session)
	return response
})
```

`Session.accept` mirrors the Rust crate's `qmux::ws::Server::accept`. `new Session(url)` keeps the `WebTransport` constructor signature, so `install()` is unaffected.

## Changes

- **`Session.accept(socket, options)`** takes a plain `WebSocket`, a `WebSocketStream`, or anything `WebSocketStreamLike` — so `Deno.upgradeWebSocket`, `ws`, and `Bun.serve` all work. The constructor now accepts a socket in place of a URL, which is what makes the role injectable.
- **`WebSocketStream.adopt()`** (`@moq/web-socket-stream`) wraps a socket that already exists. An accepted socket is typically already `OPEN`, so `onopen` has already fired and waiting for it would hang forever; `opened` now settles from `readyState`.
- **`selectSubprotocol()`** is the accept-side mirror of `resolveSubprotocols`. The host runs the handshake, so it — not the library — picks the subprotocol; this expands the same `protocols` + `versions` pair and returns the first wire form the client offered. Preference is ours, not the client's, matching `qmux::ws::Server`. It returns `undefined` on no match so the caller fails the upgrade: accepting with no subprotocol silently negotiates the legacy `webtransport` wire format and misreads every QMux frame.
- **`AcceptOptions.protocol`** stands in for hosts that don't report the negotiated subprotocol on the socket (Bun is one).

## Verification

New `interop-client` Rust example, the mirror of the existing `interop-server`: a real Rust client drives a JS `Session.accept` server across qmux-00/01/02 — 1.2 MB in each direction with flow-control replenishment, bidi streams, datagrams, and a clean close. It runs in CI via `just test`.

Reverting `#isServer = true` fails that test immediately with `Invalid stream ID direction`, along with four unit tests, so the coverage is anchored to the fix rather than passing incidentally. `just check` and `just test` are green.

## Notes

- **The `exports` half of #314 is not included.** `selectSubprotocol` ships from the main entry, which removes the reason to reach for `frame`/`credit`/`stream`/`varint`; those stay private, consistent with #313.
- **The reporter retracted the motivation** in a follow-up comment (the Deno bug they cited was closed as invalid) and offered to have the issue closed. This is built on the standalone merit — a JS accept server can now offer the same WebSocket fallback the relay does — not on the original diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
