### PR TITLE
feat(quiche)!: add mTLS client auth and TLS server name control

### DIFF
--- a/rs/web-transport-quiche/README.md
+++ b/rs/web-transport-quiche/README.md
@@ -11,7 +11,8 @@ This library builds on top of [tokio-quiche](https://docs.rs/tokio-quiche/latest
 
 [quiche-ez](ez) is a wrapper around `tokio-quiche` that provides an async API.
 It tries to cover as many warts as possible but it's still limited by the poor `tokio_quiche` API.
-For example, it's only possible to provide a single TLS certificate and it needs to be on disk.
+For example, `tokio_quiche` only accepts a single TLS certificate loaded from disk, so certificates
+are configured through a BoringSSL hook instead.
 
 If this library becomes popular, I can spin `quiche-ez` off into a separate crate that performs the Tokio networking itself.
 It should result in better performance too.

--- a/rs/web-transport-quiche/src/client.rs
+++ b/rs/web-transport-quiche/src/client.rs
@@ -89,6 +89,15 @@ impl<M: Metrics> ClientBuilder<M> {
         Self(self.0.with_root_certificates(roots))
     }
 
+    /// Use this name for SNI and certificate verification instead of the URL's host.
+    ///
+    /// The dial target is unchanged; only the name the server certificate must
+    /// match is. This is how you reach a host by IP, or through a tunnel, while
+    /// still verifying the certificate it was actually issued for.
+    pub fn with_server_name(self, name: impl Into<String>) -> Self {
+        Self(self.0.with_server_name(name))
+    }
+
     /// Accept the server certificate only if the SHA-256 of its DER encoding
     /// matches one of the provided hashes, bypassing CA verification.
     ///

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -24,6 +24,7 @@ pub struct ClientBuilder<M: Metrics = DefaultMetrics> {
     socket: Option<tokio::net::UdpSocket>,
     tls: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
     verify: ClientVerify,
+    server_name: Option<String>,
     metrics: M,
 }
 
@@ -45,6 +46,7 @@ impl<M: Metrics> ClientBuilder<M> {
             socket: None,
             tls: None,
             verify: ClientVerify::Default,
+            server_name: None,
         }
     }
 
@@ -61,6 +63,7 @@ impl<M: Metrics> ClientBuilder<M> {
             metrics: self.metrics,
             tls: self.tls,
             verify: self.verify,
+            server_name: self.server_name,
         })
     }
 
@@ -94,7 +97,19 @@ impl<M: Metrics> ClientBuilder<M> {
             metrics: self.metrics,
             socket: self.socket,
             verify: self.verify,
+            server_name: self.server_name,
         }
+    }
+
+    /// Use this name for SNI and certificate verification instead of the host
+    /// passed to [ClientBuilder::connect].
+    ///
+    /// The dial target is unchanged; only the name the server certificate must
+    /// match is. This is how you reach a host by IP, or through a tunnel, while
+    /// still verifying the certificate it was actually issued for.
+    pub fn with_server_name(mut self, name: impl Into<String>) -> Self {
+        self.server_name = Some(name.into());
+        self
     }
 
     /// Verify the server certificate against an explicit set of root
@@ -115,6 +130,10 @@ impl<M: Metrics> ClientBuilder<M> {
     }
 
     /// Connect to the QUIC server at the given host and port.
+    ///
+    /// `host` is the dial target: it's resolved via DNS and, unless
+    /// [ClientBuilder::with_server_name] overrides it, is also the name the
+    /// server's certificate must match.
     ///
     /// This takes ownership because the underlying quiche implementation doesn't support reusing the same socket.
     pub async fn connect(mut self, host: &str, port: u16) -> io::Result<Connecting> {
@@ -189,6 +208,9 @@ impl<M: Metrics> ClientBuilder<M> {
             (None, Hooks::default())
         };
 
+        // quiche uses this for both SNI and the certificate's hostname check.
+        let server_name = self.server_name.as_deref().unwrap_or(host);
+
         let params = tokio_quiche::ConnectionParams::new_client(self.settings, tls_cert, hooks);
 
         let accept_bi = flume::unbounded();
@@ -207,7 +229,7 @@ impl<M: Metrics> ClientBuilder<M> {
             dgram_max.clone(),
         );
 
-        let conn = tokio_quiche::quic::connect_with_config(socket, Some(host), &params, app)
+        let conn = tokio_quiche::quic::connect_with_config(socket, Some(server_name), &params, app)
             .await
             .map_err(|e| io::Error::other(e.to_string()))?;
 

--- a/rs/web-transport-quiche/src/ez/connection.rs
+++ b/rs/web-transport-quiche/src/ez/connection.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use rustls_pki_types::CertificateDer;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{
@@ -161,9 +162,16 @@ impl Drop for ConnectionClose {
 
 /// A QUIC connection that can create and accept streams.
 ///
-/// This is a handle to an established QUIC connection. It can be cloned to create
-/// multiple handles to the same connection. The connection will be closed when all
-/// handles are dropped.
+/// This is a handle to an *established* connection: it's only reachable through
+/// [Incoming::accept](super::Incoming::accept) or
+/// [Connecting::established](super::Connecting::established), both of which wait for
+/// the TLS handshake. So anything the handshake settles — [alpn](Connection::alpn),
+/// [server_name](Connection::server_name), [peer_certificates](Connection::peer_certificates) —
+/// is already known here, and a `None` means the value is genuinely absent rather
+/// than not yet available.
+///
+/// It can be cloned to create multiple handles to the same connection. The
+/// connection will be closed when all handles are dropped.
 #[derive(Clone)]
 pub struct Connection {
     inner: Arc<tokio_quiche::QuicConnection>,
@@ -294,8 +302,7 @@ impl Connection {
 
     /// Maximum size of a datagram that can be sent right now.
     ///
-    /// Returns `None` before the handshake completes or when datagrams are
-    /// disabled in the peer's transport parameters.
+    /// Returns `None` when datagrams are disabled in the peer's transport parameters.
     pub fn max_datagram_size(&self) -> Option<usize> {
         let v = self.dgram_max.load(Ordering::Relaxed);
         if v == 0 {
@@ -326,14 +333,31 @@ impl Connection {
         self.close.is_closed()
     }
 
-    /// Returns the negotiated ALPN protocol, if the handshake has completed.
+    /// Returns the negotiated ALPN protocol, or `None` if the peers negotiated none.
     pub fn alpn(&self) -> Option<Vec<u8>> {
         self.driver.lock().alpn().map(|a| a.to_vec())
     }
 
-    /// Returns the SNI server name from the TLS ClientHello, if the handshake has completed.
+    /// Returns the TLS server name, or `None` if the client sent no SNI.
+    ///
+    /// On a server this is the name the client asked for; on a client it's the name
+    /// it sent, which is the dial host unless [ClientBuilder::with_server_name](super::ClientBuilder::with_server_name)
+    /// overrode it.
     pub fn server_name(&self) -> Option<String> {
         self.driver.lock().server_name().map(|s| s.to_string())
+    }
+
+    /// Returns the peer's certificate chain, leaf first.
+    ///
+    /// The chain has already been verified according to the endpoint's
+    /// configuration: [ClientAuth](super::ClientAuth) on a server, or the
+    /// verification mode chosen on [ClientBuilder](super::ClientBuilder).
+    ///
+    /// A server returns `None` unless it requested a client certificate *and* the
+    /// client presented one, so this doubles as the "was this peer authenticated"
+    /// check under [ClientAuth::Optional](super::ClientAuth::Optional).
+    pub fn peer_certificates(&self) -> Option<Vec<CertificateDer<'static>>> {
+        self.driver.lock().peer_certificates().map(|c| c.to_vec())
     }
 
     /// Returns the most recent connection statistics snapshot.

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use rustls_pki_types::CertificateDer;
 use std::{
     collections::{hash_map, HashMap, HashSet},
     future::poll_fn,
@@ -39,11 +40,21 @@ pub(super) struct DriverState {
     close_requested: ConnectionClosed,
     closed: ConnectionClosed,
 
+    /// Whether the handshake has completed, and with it every value below.
+    ///
+    /// Tracked separately from those values because each is independently
+    /// optional: a connection can be established without, say, negotiating an
+    /// ALPN, so their absence can't stand in for "not established yet".
+    established: bool,
+
     /// The negotiated ALPN protocol, set after the handshake completes.
     alpn: Option<Vec<u8>>,
 
     /// The SNI server name from the TLS ClientHello, set after the handshake completes.
     server_name: Option<String>,
+
+    /// The peer's certificate chain, set after the handshake completes.
+    peer_certs: Option<Vec<CertificateDer<'static>>>,
 
     /// Wakers waiting for the handshake to complete.
     handshake_wakers: Vec<Waker>,
@@ -71,8 +82,10 @@ impl DriverState {
             closed: ConnectionClosed::default(),
             bi: DriverOpen::new(next_bi),
             uni: DriverOpen::new(next_uni),
+            established: false,
             alpn: None,
             server_name: None,
+            peer_certs: None,
             handshake_wakers: Vec::new(),
             stats: ConnectionStats::default(),
         }
@@ -121,16 +134,16 @@ impl DriverState {
         self.server_name.as_deref()
     }
 
-    /// Sets the SNI server name (captured from the TLS ClientHello).
-    pub fn set_server_name(&mut self, name: Option<String>) {
-        self.server_name = name;
+    /// Returns the peer's verified certificate chain, leaf first.
+    pub fn peer_certificates(&self) -> Option<&[CertificateDer<'static>]> {
+        self.peer_certs.as_deref()
     }
 
     /// Poll for handshake completion.
     /// Returns Ready once the handshake completes, or if the connection is closed.
     pub fn poll_handshake(&mut self, waker: &Waker) -> Poll<Result<(), ConnectionError>> {
         // Check if already established
-        if self.alpn.is_some() {
+        if self.established {
             return Poll::Ready(Ok(()));
         }
 
@@ -272,6 +285,21 @@ impl Driver {
         // Capture the negotiated ALPN protocol.
         let alpn = qconn.application_proto();
 
+        // SNI is only readable once BoringSSL has parsed the ClientHello, which
+        // doesn't happen until the handshake runs — before that quiche is still
+        // holding the Initial packet as unparsed bytes.
+        let server_name = qconn.server_name().map(|s| s.to_string());
+
+        // Copy the peer's chain out of quiche, which only lends it for as long as
+        // the connection is alive. It's already been verified by the handshake we
+        // just completed; on a server it's `None` unless client auth was requested.
+        let peer_certs = qconn.peer_cert_chain().map(|chain| {
+            chain
+                .into_iter()
+                .map(|der| CertificateDer::from(der.to_vec()))
+                .collect()
+        });
+
         // Publish the writable MTU once the handshake completes. The negotiated
         // value is fixed for the lifetime of the connection.
         self.dgram_max.store(
@@ -282,6 +310,11 @@ impl Driver {
         let wakers = {
             let mut state = self.state.lock();
             state.alpn = (!alpn.is_empty()).then(|| alpn.to_vec());
+            state.server_name = server_name;
+            state.peer_certs = peer_certs;
+            // Publish all of the above before marking the handshake complete: this
+            // is what `Connection`'s accessors promise are already populated.
+            state.established = true;
             state.complete_handshake()
         };
 
@@ -733,6 +766,23 @@ impl<T> DriverOpen<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn handshake_completes_without_an_alpn() {
+        // The established flag, not the ALPN, is what resolves the handshake: a
+        // connection that negotiates no ALPN must still hand back a Connection
+        // rather than wait forever.
+        let mut state = DriverState::new(false);
+        let waker = Waker::noop();
+
+        assert!(state.poll_handshake(waker).is_pending());
+
+        state.established = true;
+        let _ = state.complete_handshake();
+
+        assert!(state.alpn().is_none());
+        assert!(matches!(state.poll_handshake(waker), Poll::Ready(Ok(()))));
+    }
 
     #[test]
     fn closed_waits_for_driver_completion() {

--- a/rs/web-transport-quiche/src/ez/mod.rs
+++ b/rs/web-transport-quiche/src/ez/mod.rs
@@ -25,6 +25,6 @@ use driver::*;
 use lock::*;
 
 pub use rustls_pki_types::{CertificateDer, PrivateKeyDer};
-pub use tls::{CertResolver, CertifiedKey};
+pub use tls::{CertResolver, CertifiedKey, ClientAuth};
 pub use tokio_quiche::metrics::{DefaultMetrics, Metrics};
 pub use tokio_quiche::settings::QuicSettings as Settings;

--- a/rs/web-transport-quiche/src/ez/server.rs
+++ b/rs/web-transport-quiche/src/ez/server.rs
@@ -1,4 +1,3 @@
-use boring::ssl::NameType;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{io, marker::PhantomData};
@@ -15,7 +14,8 @@ use crate::ez::DriverState;
 
 use super::client::DGRAM_CHANNEL_CAPACITY;
 use super::{
-    CertResolver, Connection, ConnectionError, DefaultMetrics, Driver, Lock, Metrics, Settings,
+    CertResolver, ClientAuth, Connection, ConnectionError, DefaultMetrics, Driver, Lock, Metrics,
+    Settings,
 };
 
 /// Used with [ServerBuilder] to require specific parameters.
@@ -34,6 +34,7 @@ pub struct ServerBuilder<M: Metrics = DefaultMetrics, S = ServerInit> {
     metrics: M,
     state: S,
     alpn: Vec<Vec<u8>>,
+    client_auth: ClientAuth,
 }
 
 impl Default for ServerBuilder<DefaultMetrics> {
@@ -52,6 +53,7 @@ impl ServerBuilder<DefaultMetrics, ServerInit> {
             metrics: m,
             state: ServerInit {},
             alpn: Vec::new(),
+            client_auth: ClientAuth::None,
         }
     }
 }
@@ -63,6 +65,7 @@ impl<M: Metrics> ServerBuilder<M, ServerInit> {
             metrics: self.metrics,
             state: ServerWithListener { listeners: vec![] },
             alpn: self.alpn,
+            client_auth: self.client_auth,
         }
     }
 
@@ -90,6 +93,14 @@ impl<M: Metrics> ServerBuilder<M, ServerInit> {
     /// Use the provided [Settings] instead of the defaults.
     pub fn with_settings(mut self, settings: Settings) -> Self {
         self.settings = settings;
+        self
+    }
+
+    /// Authenticate clients with mTLS.
+    ///
+    /// Defaults to [ClientAuth::None].
+    pub fn with_client_auth(mut self, auth: ClientAuth) -> Self {
+        self.client_auth = auth;
         self
     }
 }
@@ -129,8 +140,19 @@ impl<M: Metrics> ServerBuilder<M, ServerWithListener> {
     }
 
     /// Use the provided [Settings] instead of the defaults.
+    ///
+    /// **NOTE**: [Settings::verify_peer] is ignored; use [ServerBuilder::with_client_auth]
+    /// to verify client certificates.
     pub fn with_settings(mut self, settings: Settings) -> Self {
         self.settings = settings;
+        self
+    }
+
+    /// Authenticate clients with mTLS.
+    ///
+    /// Defaults to [ClientAuth::None].
+    pub fn with_client_auth(mut self, auth: ClientAuth) -> Self {
+        self.client_auth = auth;
         self
     }
 
@@ -140,24 +162,45 @@ impl<M: Metrics> ServerBuilder<M, ServerWithListener> {
         chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
     ) -> io::Result<Server<M>> {
+        self.client_auth.validate()?;
+
         let alpn = std::mem::take(&mut self.alpn);
-        let hook = StaticCertHook { chain, key, alpn };
+        let client_auth = std::mem::take(&mut self.client_auth);
+        let hook = StaticCertHook {
+            chain,
+            key,
+            alpn,
+            client_auth,
+        };
 
         self.build_with_hook(Arc::new(hook))
     }
 
     /// Configure the server to use a dynamic certificate resolver for TLS.
     pub fn with_cert_resolver(mut self, resolver: Arc<dyn CertResolver>) -> io::Result<Server<M>> {
+        self.client_auth.validate()?;
+
         let alpn = std::mem::take(&mut self.alpn);
-        let hook = DynamicCertHook { resolver, alpn };
+        let client_auth = std::mem::take(&mut self.client_auth);
+        let hook = DynamicCertHook {
+            resolver,
+            alpn,
+            client_auth,
+        };
 
         self.build_with_hook(Arc::new(hook))
     }
 
     fn build_with_hook(
-        self,
+        mut self,
         hook: Arc<dyn tokio_quiche::quic::ConnectionHook + Send + Sync>,
     ) -> io::Result<Server<M>> {
+        // quiche applies `verify_peer` *after* the hook and would overwrite the
+        // verification mode installed there, downgrading a required client
+        // certificate to an optional one. On a server the same knob is expressed
+        // by [ClientAuth], which the hook has already applied.
+        self.settings.verify_peer = false;
+
         // ConnectionHook is only invoked when tls_cert is set, so we provide a dummy.
         let dummy_tls = TlsCertificatePaths {
             cert: "",
@@ -184,9 +227,17 @@ impl<M: Metrics> ServerBuilder<M, ServerWithListener> {
     }
 }
 
-/// A pre-accepted QUIC connection with the TLS handshake already complete.
+/// An incoming QUIC connection whose TLS handshake is still in flight.
 ///
-/// The peer address is available before calling [Incoming::accept].
+/// Only the addresses are known at this point, which is enough to [reject](Incoming::reject)
+/// a peer without paying for a handshake. Everything the handshake establishes —
+/// ALPN, SNI, peer certificates — lives on the [Connection] returned by
+/// [Incoming::accept], because none of it exists yet: the ClientHello is still an
+/// unparsed packet.
+///
+/// To choose a certificate or refuse a connection based on SNI, use
+/// [ServerBuilder::with_cert_resolver], which runs while the handshake is in
+/// progress — the last point where the server can still decide.
 pub struct Incoming {
     connection: Connection,
     driver: Lock<DriverState>,
@@ -201,18 +252,6 @@ impl Incoming {
     /// Returns the local socket address for this connection.
     pub fn local_addr(&self) -> SocketAddr {
         self.connection.local_addr()
-    }
-
-    /// Returns the negotiated ALPN protocol, if the handshake has completed.
-    pub fn alpn(&self) -> Option<Vec<u8>> {
-        self.driver.lock().alpn().map(|a| a.to_vec())
-    }
-
-    /// Returns the SNI server name from the TLS ClientHello.
-    ///
-    /// Available immediately, before [Incoming::accept] is called.
-    pub fn server_name(&self) -> Option<String> {
-        self.driver.lock().server_name().map(|s| s.to_string())
     }
 
     /// Reject the connection with an error code and reason.
@@ -275,13 +314,7 @@ impl<M: Metrics> Server<M> {
     ) -> io::Result<()> {
         let mut rx = socket.into_inner();
         while let Some(initial) = rx.recv().await {
-            let mut initial = initial?;
-
-            // Capture the SNI server name from the TLS ClientHello before starting the handshake.
-            let server_name = initial
-                .ssl_mut()
-                .servername(NameType::HOST_NAME)
-                .map(|s| s.to_string());
+            let initial = initial?;
 
             let accept_bi = flume::unbounded();
             let accept_uni = flume::unbounded();
@@ -290,7 +323,6 @@ impl<M: Metrics> Server<M> {
             let dgram_max = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
             let state = Lock::new(DriverState::new(true));
-            state.lock().set_server_name(server_name);
             let session = Driver::new(
                 state.clone(),
                 accept_bi.0,

--- a/rs/web-transport-quiche/src/ez/tls.rs
+++ b/rs/web-transport-quiche/src/ez/tls.rs
@@ -26,6 +26,72 @@ pub trait CertResolver: Send + Sync {
     fn resolve(&self, server_name: Option<&str>) -> Option<CertifiedKey>;
 }
 
+/// How a server authenticates clients (mTLS).
+///
+/// The chain a client presents is only validated against these roots; mapping it
+/// to an application identity is left to the caller, via
+/// [Connection::peer_certificates](super::Connection::peer_certificates).
+#[derive(Default)]
+pub enum ClientAuth {
+    /// Don't request a client certificate.
+    #[default]
+    None,
+
+    /// Request a client certificate and verify it against these roots.
+    ///
+    /// Clients that present no certificate are still accepted; a certificate
+    /// that doesn't chain to one of these roots fails the handshake.
+    Optional(Vec<CertificateDer<'static>>),
+
+    /// Require every client to present a certificate chaining to these roots.
+    Required(Vec<CertificateDer<'static>>),
+}
+
+impl ClientAuth {
+    /// Check this policy by applying it to a throwaway context.
+    ///
+    /// A [ConnectionHook] can only report failure by returning `None`, which
+    /// falls back to a context with no client authentication at all. Bad roots
+    /// have to fail here, where the error reaches the caller, rather than
+    /// downgrading the policy at handshake time.
+    pub(crate) fn validate(&self) -> io::Result<()> {
+        let mut probe = SslContextBuilder::new(SslMethod::tls()).map_err(io::Error::other)?;
+        apply_client_auth(&mut probe, self)
+    }
+}
+
+/// Request and verify client certificates according to `auth`.
+fn apply_client_auth(builder: &mut SslContextBuilder, auth: &ClientAuth) -> io::Result<()> {
+    let (roots, mode) = match auth {
+        ClientAuth::None => return Ok(()),
+        ClientAuth::Optional(roots) => (roots, SslVerifyMode::PEER),
+        ClientAuth::Required(roots) => (
+            roots,
+            SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT,
+        ),
+    };
+
+    if roots.is_empty() {
+        // An empty store rejects every chain, so this would silently refuse all
+        // (or, when optional, all certificate-bearing) clients.
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "client authentication requires at least one root certificate",
+        ));
+    }
+
+    let mut store = X509StoreBuilder::new().map_err(io::Error::other)?;
+    for der in roots {
+        let root = X509::from_der(der.as_ref()).map_err(io::Error::other)?;
+        store.add_cert(root).map_err(io::Error::other)?;
+    }
+
+    builder.set_cert_store_builder(store);
+    builder.set_verify(mode);
+
+    Ok(())
+}
+
 fn der_to_boring_key(key: &PrivateKeyDer) -> Result<PKey<Private>, boring::error::ErrorStack> {
     match key {
         PrivateKeyDer::Pkcs8(d) => PKey::private_key_from_der(d.secret_pkcs8_der()),
@@ -66,6 +132,7 @@ pub(crate) struct StaticCertHook {
     pub chain: Vec<CertificateDer<'static>>,
     pub key: PrivateKeyDer<'static>,
     pub alpn: Vec<Vec<u8>>,
+    pub client_auth: ClientAuth,
 }
 
 impl ConnectionHook for StaticCertHook {
@@ -75,6 +142,10 @@ impl ConnectionHook for StaticCertHook {
     ) -> Option<SslContextBuilder> {
         let mut builder = SslContextBuilder::new(SslMethod::tls())
             .inspect_err(|err| tracing::warn!(%err, "failed to create SSL context"))
+            .ok()?;
+
+        apply_client_auth(&mut builder, &self.client_auth)
+            .inspect_err(|err| tracing::warn!(%err, "failed to configure client authentication"))
             .ok()?;
 
         // Set the leaf certificate.
@@ -131,6 +202,7 @@ impl ConnectionHook for StaticCertHook {
 pub(crate) struct DynamicCertHook {
     pub resolver: Arc<dyn CertResolver>,
     pub alpn: Vec<Vec<u8>>,
+    pub client_auth: ClientAuth,
 }
 
 impl ConnectionHook for DynamicCertHook {
@@ -140,6 +212,10 @@ impl ConnectionHook for DynamicCertHook {
     ) -> Option<SslContextBuilder> {
         let mut builder = SslContextBuilder::new(SslMethod::tls())
             .inspect_err(|err| tracing::warn!(%err, "failed to create SSL context"))
+            .ok()?;
+
+        apply_client_auth(&mut builder, &self.client_auth)
+            .inspect_err(|err| tracing::warn!(%err, "failed to configure client authentication"))
             .ok()?;
 
         let resolver = self.resolver.clone();

--- a/rs/web-transport-quiche/src/lib.rs
+++ b/rs/web-transport-quiche/src/lib.rs
@@ -40,7 +40,7 @@ pub use recv::*;
 pub use send::*;
 pub use server::*;
 
-pub use ez::{CertResolver, CertificateDer, CertifiedKey, PrivateKeyDer, Settings};
+pub use ez::{CertResolver, CertificateDer, CertifiedKey, ClientAuth, PrivateKeyDer, Settings};
 
 pub use http;
 pub use web_transport_proto as proto;

--- a/rs/web-transport-quiche/src/server.rs
+++ b/rs/web-transport-quiche/src/server.rs
@@ -77,9 +77,16 @@ impl<M: ez::Metrics> ServerBuilder<M, ez::ServerInit> {
         ))
     }
 
-    /// Use the provided [Settings] instead of the defaults.
+    /// Use the provided [Settings](ez::Settings) instead of the defaults.
     pub fn with_settings(self, settings: ez::Settings) -> Self {
         Self(self.0.with_settings(settings))
+    }
+
+    /// Authenticate clients with mTLS.
+    ///
+    /// Defaults to [ez::ClientAuth::None].
+    pub fn with_client_auth(self, auth: ez::ClientAuth) -> Self {
+        Self(self.0.with_client_auth(auth))
     }
 }
 
@@ -99,9 +106,19 @@ impl<M: ez::Metrics> ServerBuilder<M, ez::ServerWithListener> {
         Ok(Self(self.0.with_bind(addrs)?))
     }
 
-    /// Use the provided [Settings] instead of the defaults.
+    /// Use the provided [Settings](ez::Settings) instead of the defaults.
+    ///
+    /// **NOTE**: [Settings::verify_peer](ez::Settings::verify_peer) is ignored; use
+    /// [ServerBuilder::with_client_auth] to verify client certificates.
     pub fn with_settings(self, settings: ez::Settings) -> Self {
         Self(self.0.with_settings(settings))
+    }
+
+    /// Authenticate clients with mTLS.
+    ///
+    /// Defaults to [ez::ClientAuth::None].
+    pub fn with_client_auth(self, auth: ez::ClientAuth) -> Self {
+        Self(self.0.with_client_auth(auth))
     }
 
     /// Configure the server to use a static certificate for TLS.

--- a/rs/web-transport-quiche/tests/client_auth.rs
+++ b/rs/web-transport-quiche/tests/client_auth.rs
@@ -1,0 +1,458 @@
+//! Client-certificate authentication (mTLS) and the peer chain it exposes.
+//!
+//! The security-critical assertions are the negative ones: a client chaining to
+//! an untrusted CA must *fail* the handshake, and a required certificate must
+//! actually be required rather than quietly optional.
+
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use url::Url;
+use web_transport_quiche::{ClientAuth, ClientBuilder, ServerBuilder, Settings};
+
+/// A CA plus a leaf signed by it, for the given purpose and names.
+struct Ca {
+    root: CertificateDer<'static>,
+    params: CertificateParams,
+    key: KeyPair,
+}
+
+impl Ca {
+    fn new(name: &str) -> Result<Self> {
+        let key = KeyPair::generate().context("ca key")?;
+        let mut params = CertificateParams::new(Vec::new()).context("ca params")?;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.distinguished_name.push(DnType::CommonName, name);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let cert = params.self_signed(&key).context("self-sign ca")?;
+
+        Ok(Self {
+            root: CertificateDer::from(cert.der().to_vec()),
+            params,
+            key,
+        })
+    }
+
+    /// Issue a leaf for the given SANs and extended key usage.
+    fn issue(
+        &self,
+        sans: Vec<String>,
+        common_name: &str,
+        usage: ExtendedKeyUsagePurpose,
+    ) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+        let key = KeyPair::generate().context("leaf key")?;
+        let mut params = CertificateParams::new(sans).context("leaf params")?;
+        params
+            .distinguished_name
+            .push(DnType::CommonName, common_name);
+        params.extended_key_usages = vec![usage];
+
+        let issuer = Issuer::from_params(&self.params, &self.key);
+        let cert = params.signed_by(&key, &issuer).context("sign leaf")?;
+
+        let chain = vec![CertificateDer::from(cert.der().to_vec())];
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(&key)));
+        Ok((chain, key))
+    }
+
+    fn server_cert(&self) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+        self.issue(
+            vec!["localhost".into(), "127.0.0.1".into()],
+            "localhost",
+            ExtendedKeyUsagePurpose::ServerAuth,
+        )
+    }
+
+    fn client_cert(
+        &self,
+        name: &str,
+    ) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+        self.issue(vec![name.into()], name, ExtendedKeyUsagePurpose::ClientAuth)
+    }
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+/// The peer chain the server saw for the one session it accepted, or `None` if
+/// the client presented no certificate.
+type PeerCerts = tokio::sync::oneshot::Receiver<Option<Vec<CertificateDer<'static>>>>;
+
+/// Bind a server that accepts a single session and reports the client's chain.
+async fn spawn_server(
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+    client_auth: ClientAuth,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>, PeerCerts)> {
+    // Bind to whatever `localhost` resolves to first, matching tests/verify.rs:
+    // the client connects to the same name, so both agree on the address family.
+    let bind = ("localhost", 0)
+        .to_socket_addrs()?
+        .next()
+        .context("localhost did not resolve")?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_client_auth(client_auth)
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(async move {
+        if let Some(request) = server.accept().await {
+            let certs = request.conn().peer_certificates();
+            let _ = tx.send(certs);
+
+            if let Ok(session) = request.ok().await {
+                let _ = session.closed().await;
+            }
+        }
+    });
+
+    Ok((addr, handle, rx))
+}
+
+fn url_for(addr: SocketAddr) -> Result<Url> {
+    Ok(Url::parse(&format!("https://localhost:{}/", addr.port()))?)
+}
+
+/// Loopback bind address matching the family of `addr`, for the client socket.
+fn loopback_for(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V4(_) => (Ipv4Addr::LOCALHOST, 0).into(),
+        SocketAddr::V6(_) => (Ipv6Addr::LOCALHOST, 0).into(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_accept() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+    let (client_chain, client_key) = ca.client_cert("client.example")?;
+    let client_leaf = client_chain[0].clone();
+
+    let (addr, server, peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Required(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca.root])
+        .with_single_cert(client_chain, client_key)
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed with a client cert from the trusted CA")?;
+
+    // The server must see the exact chain the client presented, leaf first —
+    // that's what an application maps to a peer identity.
+    let seen = peer_certs
+        .await?
+        .context("server saw no client certificate")?;
+    assert_eq!(seen, vec![client_leaf]);
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_untrusted_ca_reject() -> Result<()> {
+    init_tracing();
+
+    // The client's cert is signed by a CA the server doesn't trust.
+    let ca = Ca::new("web-transport test CA")?;
+    let other = Ca::new("web-transport other CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+    let (client_chain, client_key) = other.client_cert("client.example")?;
+
+    let (addr, server, _peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Required(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![ca.root])
+            .with_single_cert(client_chain, client_key)
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "handshake must fail when the client cert chains to an untrusted root"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_required_but_missing_reject() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+
+    let (addr, server, _peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Required(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    // No client certificate at all.
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![ca.root])
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "handshake must fail when a required client cert is missing"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_optional_and_missing_accept() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+
+    let (addr, server, peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Optional(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca.root])
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("optional client auth must accept a client without a certificate")?;
+
+    // An unauthenticated peer must be distinguishable from an authenticated one.
+    assert!(
+        peer_certs.await?.is_none(),
+        "server must report no client certificate"
+    );
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_optional_and_present_accept() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+    let (client_chain, client_key) = ca.client_cert("client.example")?;
+    let client_leaf = client_chain[0].clone();
+
+    let (addr, server, peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Optional(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca.root])
+        .with_single_cert(client_chain, client_key)
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed with a client cert from the trusted CA")?;
+
+    // Optional auth still has to surface the identity of a client that presented one.
+    let seen = peer_certs
+        .await?
+        .context("server saw no client certificate")?;
+    assert_eq!(seen, vec![client_leaf]);
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_optional_but_untrusted_reject() -> Result<()> {
+    init_tracing();
+
+    // Optional means "may omit", not "may present anything".
+    let ca = Ca::new("web-transport test CA")?;
+    let other = Ca::new("web-transport other CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+    let (client_chain, client_key) = other.client_cert("client.example")?;
+
+    let (addr, server, _peer_certs) = spawn_server(
+        server_chain,
+        server_key,
+        ClientAuth::Optional(vec![ca.root.clone()]),
+    )
+    .await?;
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![ca.root])
+            .with_single_cert(client_chain, client_key)
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "an untrusted client cert must fail even when client auth is optional"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_cert_required_survives_verify_peer_setting() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+
+    // quiche applies `verify_peer` after the TLS hook. If the server let it
+    // through it would replace the hook's verification mode, quietly turning a
+    // required client certificate into an optional one.
+    let mut settings = Settings::default();
+    settings.verify_peer = true;
+
+    let bind = ("localhost", 0)
+        .to_socket_addrs()?
+        .next()
+        .context("localhost did not resolve")?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_settings(settings)
+        .with_client_auth(ClientAuth::Required(vec![ca.root.clone()]))
+        .with_single_cert(server_chain, server_key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let handle = tokio::spawn(async move { server.accept().await.is_some() });
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    // No client certificate.
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![ca.root])
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "a required client cert must stay required regardless of Settings::verify_peer"
+    );
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn client_auth_without_roots_is_rejected() -> Result<()> {
+    init_tracing();
+
+    let ca = Ca::new("web-transport test CA")?;
+    let (server_chain, server_key) = ca.server_cert()?;
+
+    // An empty root store would reject every client; that's a config error, not
+    // a policy, so it must surface at build time rather than at handshake time.
+    let result = ServerBuilder::default()
+        .with_bind((Ipv6Addr::LOCALHOST, 0))?
+        .with_client_auth(ClientAuth::Required(Vec::new()))
+        .with_single_cert(server_chain, server_key);
+
+    assert!(
+        result.is_err(),
+        "client auth with no roots must fail to build"
+    );
+
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/server_name.rs
+++ b/rs/web-transport-quiche/tests/server_name.rs
@@ -1,0 +1,287 @@
+//! The TLS server name: what the server reports, and overriding it on the client
+//! independently of the dial target.
+//!
+//! The override tests use a certificate issued for a name that never resolves, so
+//! the only way the handshake can succeed is if the override reached both SNI and
+//! the hostname check — and the only way it can fail is if it didn't.
+
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use url::Url;
+use web_transport_quiche::{
+    ez::{CertResolver, CertifiedKey},
+    ClientBuilder, ServerBuilder,
+};
+
+/// A name the client can dial, because it resolves to loopback.
+const DIAL_NAME: &str = "localhost";
+
+/// A name the client cannot dial: it only ever reaches the wire as an override.
+const OVERRIDE_NAME: &str = "override.invalid";
+
+/// A CA plus a leaf issued for `sans`. Returns `(ca_root, chain, key)`.
+#[allow(clippy::type_complexity)]
+fn make_ca_chain(
+    sans: &[&str],
+) -> Result<(
+    CertificateDer<'static>,
+    Vec<CertificateDer<'static>>,
+    PrivateKeyDer<'static>,
+)> {
+    let ca_key = KeyPair::generate().context("ca key")?;
+    let mut ca_params = CertificateParams::new(Vec::new()).context("ca params")?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "web-transport test CA");
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_cert = ca_params.self_signed(&ca_key).context("self-sign ca")?;
+
+    let leaf_key = KeyPair::generate().context("leaf key")?;
+    let sans: Vec<String> = sans.iter().map(|s| s.to_string()).collect();
+    let mut leaf_params = CertificateParams::new(sans.clone()).context("leaf params")?;
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, sans.first().context("no SAN")?);
+    leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let ca_issuer = Issuer::from_params(&ca_params, &ca_key);
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &ca_issuer)
+        .context("sign leaf")?;
+
+    Ok((
+        CertificateDer::from(ca_cert.der().to_vec()),
+        vec![CertificateDer::from(leaf_cert.der().to_vec())],
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(&leaf_key))),
+    ))
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+/// The SNI the server reported for the one session it accepted.
+type ServerName = tokio::sync::oneshot::Receiver<Option<String>>;
+
+/// Bind a server that accepts a single session and reports the SNI it saw.
+async fn spawn_server(
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>, ServerName)> {
+    // Bind to whatever `localhost` resolves to first. The client connects to the
+    // same name, so both agree on the address family regardless of v4/v6 ordering.
+    let bind = (DIAL_NAME, 0)
+        .to_socket_addrs()?
+        .next()
+        .context("localhost did not resolve")?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(async move {
+        if let Some(request) = server.accept().await {
+            let _ = tx.send(request.conn().server_name());
+
+            if let Ok(session) = request.ok().await {
+                let _ = session.closed().await;
+            }
+        }
+    });
+
+    Ok((addr, handle, rx))
+}
+
+fn url_for(addr: SocketAddr) -> Result<Url> {
+    Ok(Url::parse(&format!(
+        "https://{DIAL_NAME}:{}/",
+        addr.port()
+    ))?)
+}
+
+/// Loopback bind address matching the family of `addr`, for the client socket.
+fn loopback_for(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V4(_) => (Ipv4Addr::LOCALHOST, 0).into(),
+        SocketAddr::V6(_) => (Ipv6Addr::LOCALHOST, 0).into(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_name_reported() -> Result<()> {
+    init_tracing();
+
+    let (ca_root, chain, key) = make_ca_chain(&[DIAL_NAME])?;
+    let (addr, server, server_name) = spawn_server(chain, key).await?;
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca_root])
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed")?;
+
+    assert_eq!(server_name.await?.as_deref(), Some(DIAL_NAME));
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_name_override_accept() -> Result<()> {
+    init_tracing();
+
+    let (ca_root, chain, key) = make_ca_chain(&[OVERRIDE_NAME])?;
+    let (addr, server, server_name) = spawn_server(chain, key).await?;
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca_root])
+        .with_server_name(OVERRIDE_NAME)
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should verify against the overridden name")?;
+
+    // The override must reach the wire as SNI, not just the local hostname check.
+    assert_eq!(server_name.await?.as_deref(), Some(OVERRIDE_NAME));
+
+    session.close(0, "bye");
+    session.closed().await;
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_name_default_reject() -> Result<()> {
+    init_tracing();
+
+    // Without the override the dial target is the name checked, and this
+    // certificate isn't valid for it. If this ever passes, the hostname check
+    // isn't happening at all and the test above proves nothing.
+    let (ca_root, chain, key) = make_ca_chain(&[OVERRIDE_NAME])?;
+    let (addr, server, _server_name) = spawn_server(chain, key).await?;
+
+    let url = url_for(addr)?;
+    let client_bind = loopback_for(addr);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async move {
+        ClientBuilder::default()
+            .with_bind(client_bind)?
+            .with_root_certificates(vec![ca_root])
+            .connect(url)
+            .await?
+            .established()
+            .await
+    })
+    .await
+    .context("handshake neither succeeded nor failed within the timeout")?;
+
+    assert!(
+        result.is_err(),
+        "handshake must fail when the certificate isn't valid for the dialed host"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+/// Serves one certificate and records the SNI it was asked to resolve.
+struct RecordingResolver {
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+    seen: Mutex<Vec<Option<String>>>,
+}
+
+impl CertResolver for RecordingResolver {
+    fn resolve(&self, server_name: Option<&str>) -> Option<CertifiedKey> {
+        self.seen
+            .lock()
+            .unwrap()
+            .push(server_name.map(str::to_string));
+
+        Some(CertifiedKey {
+            chain: self.chain.clone(),
+            key: self.key.clone_key(),
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_name_reaches_cert_resolver() -> Result<()> {
+    init_tracing();
+
+    // The resolver picks the certificate mid-handshake, so it's the one place the
+    // server sees SNI *before* deciding anything.
+    let (ca_root, chain, key) = make_ca_chain(&[DIAL_NAME])?;
+    let resolver = Arc::new(RecordingResolver {
+        chain,
+        key,
+        seen: Mutex::new(Vec::new()),
+    });
+
+    let bind = (DIAL_NAME, 0)
+        .to_socket_addrs()?
+        .next()
+        .context("localhost did not resolve")?;
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_cert_resolver(resolver.clone())?;
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let handle = tokio::spawn(async move {
+        if let Some(request) = server.accept().await {
+            if let Ok(session) = request.ok().await {
+                let _ = session.closed().await;
+            }
+        }
+    });
+
+    let session = ClientBuilder::default()
+        .with_bind(loopback_for(addr))?
+        .with_root_certificates(vec![ca_root])
+        .connect(url_for(addr)?)
+        .await?
+        .established()
+        .await
+        .context("handshake should succeed")?;
+
+    let seen = resolver.seen.lock().unwrap().clone();
+    assert_eq!(seen, vec![Some(DIAL_NAME.to_string())]);
+
+    session.close(0, "bye");
+    session.closed().await;
+    handle.abort();
+    Ok(())
+}


### PR DESCRIPTION
Upstream work for the TLS and certificates section of moq-dev/moq#2296. Those gaps split across two repos — this covers the parts that genuinely need new API here. Outbound client certs and the SNI cert resolver were already exposed (`ez::ClientBuilder::with_single_cert`, `ServerBuilder::with_cert_resolver`), so those items are pure `moq-native` wiring and aren't touched.

## Inbound mTLS + peer identity

`ServerBuilder::with_client_auth` takes a new `ClientAuth` policy — `None` (default), `Optional(roots)`, or `Required(roots)` — applied to both the static-cert and cert-resolver paths. The verified chain comes back via `Connection::peer_certificates()`, which is what `moq-native` needs for `Request::peer_identity` (reachable as `request.conn().peer_certificates()`).

Two decisions worth a reviewer's attention:

- **Roots are parsed at build time, not inside the hook.** A `ConnectionHook` can only report failure by returning `None`, and tokio-quiche then falls back to a context with *no* client auth — a silent security downgrade. Empty roots are rejected as a config error rather than fail-closed on every client.
- **The server now forces `Settings::verify_peer` off.** quiche applies that flag *after* the hook and would overwrite the verification mode, quietly turning `Required` into `Optional`. `ClientAuth` is the server-side expression of the same knob. Documented on `with_settings` and pinned by a test.

## Client hostname override

`ClientBuilder::with_server_name` decouples the TLS name from the dial target, on both the raw-QUIC and WebTransport builders. quiche's `set_host_name` drives SNI and the certificate hostname check together, so one setter covers `--client-tls-host-name`.

## Fix: `server_name()` always returned `None`

Pre-existing bug, found while testing the override. `ez::Server::run_socket` read SNI off the `SslRef` *before* `start()` — but at that point quiche is still holding the Initial packet as unparsed bytes in `params.initial_pkt`, so BoringSSL had never seen the ClientHello and `SSL_get_servername` returned NULL. The cert-resolver path was unaffected, since its callback runs mid-handshake.

It's now captured post-handshake via `qconn.server_name()`, alongside the peer chain.

**Behavior change:** clients now report the SNI they sent, where they previously reported `None` (only the server path ever set it). That follows from `SSL_get_servername`, but it's observable if anything relied on `None` to infer "this is the client side".

## Breaking: `Incoming::server_name` / `Incoming::alpn` removed

Both described values that only exist once the handshake completes, so they returned `None` where the type invited you to read them. They remain on `Connection`, which is only reachable through `Incoming::accept` or `Connecting::established` — so holding one already proves the handshake finished, and a `None` now means genuinely absent (no SNI sent, no ALPN negotiated) rather than not-yet-known. `with_cert_resolver` remains the way to act on SNI mid-handshake, the last point a server can still choose a certificate or refuse.

Safe for the known consumer: `moq-native`'s quiche backend already reads `peer_addr()` off `Incoming` and `alpn()` off `Connection` after `accept()`. Nothing in this repo used either method.

While documenting that invariant I found `poll_handshake` was keying off `alpn.is_some()` as its "established" signal, while `connected()` sets `alpn` to `None` when nothing is negotiated. It holds today only because `QuicSettings::alpn` defaults to `[b"h3"]`; a caller passing `Settings` with an empty `alpn` would have hung in `accept()` forever. Now an explicit `established` flag, so the guarantee doesn't rest on that coincidence.

## Tests

23 tests pass; `just check` and `just test` are green.

- `tests/client_auth.rs` — required/optional × present/absent/untrusted, the peer chain the server observes, empty-roots rejection, and the `verify_peer` downgrade guard. The load-bearing assertions are the negative ones: an untrusted chain must *fail* the handshake, and a required cert must stay required.
- `tests/server_name.rs` — SNI reporting, the override (accept + the reject that proves the check is real), and that SNI reaches a `CertResolver`. The two accessor tests fail without the fix (`left: None, right: Some("localhost")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)