### PR TITLE
refactor!: drop the synthesized CONNECT request and response from raw QUIC sessions

### DIFF
--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -105,7 +105,7 @@ impl Session {
     /// Returns the application protocol negotiated for this session.
     ///
     /// For an HTTP/3 session this is the subprotocol the server selected via
-    /// `WT-Available-Protocols`; for a raw QUIC session it is the negotiated ALPN.
+    /// `WT-Protocol`; for a raw QUIC session it is the negotiated ALPN.
     /// Returns `None` if neither was negotiated or the ALPN is not valid UTF-8.
     pub fn protocol(&self) -> Option<&str> {
         match self.h3.as_ref() {

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -102,6 +102,18 @@ impl Session {
         self.h3.as_ref().map(|s| &s.response)
     }
 
+    /// Returns the application protocol negotiated for this session.
+    ///
+    /// For an HTTP/3 session this is the subprotocol the server selected via
+    /// `WT-Available-Protocols`; for a raw QUIC session it is the negotiated ALPN.
+    /// Returns `None` if neither was negotiated or the ALPN is not valid UTF-8.
+    pub fn protocol(&self) -> Option<&str> {
+        match self.h3.as_ref() {
+            None => std::str::from_utf8(self.conn.alpn()).ok(),
+            Some(h3) => h3.response.protocol.as_deref(),
+        }
+    }
+
     /// Accept a new unidirectional stream. See [`iroh::endpoint::Connection::accept_uni`].
     pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
         if let Some(h3) = &self.h3 {
@@ -692,10 +704,7 @@ impl web_transport_trait::Session for Session {
     }
 
     fn protocol(&self) -> Option<&str> {
-        match self.h3.as_ref() {
-            None => std::str::from_utf8(self.conn.alpn()).ok(),
-            Some(h3) => h3.response.protocol.as_deref(),
-        }
+        Self::protocol(self)
     }
 
     fn stats(&self) -> impl web_transport_trait::Stats {

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -38,10 +38,14 @@ pub struct Session {
 }
 
 impl Session {
-    /// Create a new session from a raw QUIC connection and a URL.
+    /// Create a new session from a raw QUIC connection.
     ///
-    /// This is used to pretend like a QUIC connection is a WebTransport session.
-    /// It's a hack, but it makes it much easier to support WebTransport and raw QUIC simultaneously.
+    /// This is used to pretend like a QUIC connection is a WebTransport session,
+    /// making it easier to support WebTransport and raw QUIC simultaneously.
+    ///
+    /// There is no HTTP/3 exchange, so [`Self::request`] and [`Self::response`] both
+    /// return `None`. [`Self::protocol`] reports the ALPN negotiated by the QUIC
+    /// handshake instead.
     pub fn raw(conn: Connection) -> Self {
         Self { conn, h3: None }
     }

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -228,6 +228,7 @@ async fn quic_smoke() -> n0_error::Result<()> {
             println!("session established");
             assert_eq!(session.remote_id(), server_id);
             assert!(session.request().is_none());
+            assert_eq!(session.protocol(), Some(ALPN));
             let reason = session.closed().await;
             assert!(
                 matches!(reason, SessionError::ConnectionError(ConnectionError::ApplicationClosed(frame)) if frame.error_code.into_inner() == 23)
@@ -244,6 +245,7 @@ async fn quic_smoke() -> n0_error::Result<()> {
             assert_eq!(request.conn().remote_id(), client_id);
             let session = request.ok();
             assert!(session.request().is_none());
+            assert_eq!(session.protocol(), Some(ALPN));
             assert_eq!(session.conn().remote_id(), client_id);
             session.close(23, b"bye");
             server.close().await;

--- a/rs/web-transport-node/src/lib.rs
+++ b/rs/web-transport-node/src/lib.rs
@@ -285,7 +285,7 @@ impl NapiSession {
     /// The subprotocol selected by the server during WT-Available-Protocols negotiation.
     #[napi(getter)]
     pub fn protocol(&self) -> Option<String> {
-        self.inner.response().protocol.clone()
+        self.inner.protocol().map(str::to_string)
     }
 
     /// Accept an incoming unidirectional stream.

--- a/rs/web-transport-noq/examples/echo-client.rs
+++ b/rs/web-transport-noq/examples/echo-client.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("connected");
 
-    match (&args.protocol, &session.response().protocol) {
+    match (&args.protocol, session.protocol()) {
         (Some(_), Some(protocol)) => {
             tracing::info!(%protocol, "negotiated protocol");
         }

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -19,6 +19,32 @@ use crate::{
     ClientError, Connected, RecvStream, SendStream, SessionError, Settings, WebTransportError,
 };
 
+/// The ALPN the QUIC handshake negotiated, or `None` if there was none, the handshake
+/// has not completed, or it is not valid UTF-8.
+///
+/// Noq only exposes the ALPN via a downcast of the boxed handshake data, so the result
+/// is owned rather than borrowed from the connection.
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+fn negotiated_alpn(conn: &noq::Connection) -> Option<String> {
+    let data = conn.handshake_data()?;
+    let data = data.downcast::<noq::crypto::rustls::HandshakeData>().ok()?;
+
+    String::from_utf8(data.protocol?).ok()
+}
+
+/// `noq::crypto::rustls` only exists once a TLS backend is enabled, so there is no
+/// handshake data type to name here.
+///
+/// This crate's own builders are gated the same way, so normally there is no connection
+/// to read an ALPN from either. A caller that enables a provider on `noq` directly and
+/// brings its own endpoint can still establish one, and [`Session::protocol`] reports
+/// `None` for those raw sessions. Enable this crate's `aws-lc-rs` or `ring` feature to
+/// get the ALPN.
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+fn negotiated_alpn(_conn: &noq::Connection) -> Option<String> {
+    None
+}
+
 /// An established WebTransport session, acting like a full QUIC connection. See [`noq::Connection`].
 ///
 /// It is important to remember that WebTransport is layered on top of QUIC:
@@ -59,8 +85,20 @@ pub struct Session {
     // The request sent by the client, or None for a raw QUIC session.
     request: Option<ConnectRequest>,
 
-    // The response sent by the server.
-    response: ConnectResponse,
+    // The response sent by the server, or None for a raw QUIC session.
+    response: Option<ConnectResponse>,
+
+    // The ALPN negotiated by the QUIC handshake, for raw QUIC sessions. Noq only
+    // exposes it behind an allocating downcast, so `protocol()` has nothing in the
+    // connection to borrow from and needs somewhere to keep the result.
+    //
+    // Resolved on first read rather than at construction: `raw()` accepts any
+    // connection, including one whose handshake has not completed and so has no ALPN
+    // yet. Only a successful read is latched, so an early call cannot pin `None` for
+    // the life of the session. Shared across clones.
+    //
+    // Unused by HTTP/3 sessions, which read the subprotocol out of the response.
+    alpn: Arc<OnceLock<String>>,
 }
 
 impl Session {
@@ -96,7 +134,8 @@ impl Session {
             connect_send: Arc::new(Mutex::new(Some(connect.send))),
             error: error.clone(),
             request: Some(connect.request.clone()),
-            response: connect.response.clone(),
+            response: Some(connect.response.clone()),
+            alpn: Default::default(),
         };
 
         // Run a background task to read capsules from the CONNECT recv stream.
@@ -488,9 +527,11 @@ impl Session {
     /// This is used to pretend like a QUIC connection is a WebTransport session,
     /// making it easier to support WebTransport and raw QUIC simultaneously.
     ///
-    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
-    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
-    pub fn raw(conn: noq::Connection, response: impl Into<ConnectResponse>) -> Self {
+    /// There is no HTTP/3 exchange, so [`Self::request`] and [`Self::response`] both
+    /// return `None`. [`Self::protocol`] reports the ALPN negotiated by the QUIC
+    /// handshake, read from `conn` on demand — a connection that is still handshaking
+    /// (from `into_0rtt`, say) is fine, it just has no ALPN to report until it is done.
+    pub fn raw(conn: noq::Connection) -> Self {
         Self {
             conn,
             session_id: None,
@@ -502,7 +543,8 @@ impl Session {
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
             request: None,
-            response: response.into(),
+            response: None,
+            alpn: Default::default(),
         }
     }
 
@@ -512,8 +554,31 @@ impl Session {
         self.request.as_ref()
     }
 
-    pub fn response(&self) -> &ConnectResponse {
-        &self.response
+    /// Returns the [`ConnectResponse`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn response(&self) -> Option<&ConnectResponse> {
+        self.response.as_ref()
+    }
+
+    /// Returns the application protocol negotiated for this session.
+    ///
+    /// For an HTTP/3 session this is the subprotocol the server selected via
+    /// `WT-Available-Protocols`; for a raw QUIC session it is the negotiated ALPN.
+    /// `None` if neither was negotiated, the ALPN is not valid UTF-8, or the raw
+    /// connection is still handshaking.
+    pub fn protocol(&self) -> Option<&str> {
+        if let Some(response) = &self.response {
+            return response.protocol.as_deref();
+        }
+
+        if let Some(alpn) = self.alpn.get() {
+            return Some(alpn);
+        }
+
+        // Latch only a successful read, so a call made while the connection is still
+        // handshaking cannot pin `None` for the life of the session.
+        let alpn = negotiated_alpn(&self.conn)?;
+        Some(self.alpn.get_or_init(|| alpn))
     }
 
     /// Return connection-level statistics.
@@ -954,7 +1019,7 @@ impl web_transport_trait::Session for Session {
     }
 
     fn protocol(&self) -> Option<&str> {
-        self.response.protocol.as_deref()
+        Self::protocol(self)
     }
 
     #[allow(refining_impl_trait)]

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -56,8 +56,8 @@ pub struct Session {
     // Uses OnceLock for set-once, first-writer-wins semantics with lock-free reads.
     error: Arc<OnceLock<SessionError>>,
 
-    // The request sent by the client.
-    request: ConnectRequest,
+    // The request sent by the client, or None for a raw QUIC session.
+    request: Option<ConnectRequest>,
 
     // The response sent by the server.
     response: ConnectResponse,
@@ -95,7 +95,7 @@ impl Session {
             settings: Some(Arc::new(settings)),
             connect_send: Arc::new(Mutex::new(Some(connect.send))),
             error: error.clone(),
-            request: connect.request.clone(),
+            request: Some(connect.request.clone()),
             response: connect.response.clone(),
         };
 
@@ -483,15 +483,14 @@ impl Session {
         }
     }
 
-    /// Create a new session from a raw QUIC connection and a URL.
+    /// Create a new session from a raw QUIC connection.
     ///
-    /// This is used to pretend like a QUIC connection is a WebTransport session.
-    /// It's a hack, but it makes it much easier to support WebTransport and raw QUIC simultaneously.
-    pub fn raw(
-        conn: noq::Connection,
-        request: impl Into<ConnectRequest>,
-        response: impl Into<ConnectResponse>,
-    ) -> Self {
+    /// This is used to pretend like a QUIC connection is a WebTransport session,
+    /// making it easier to support WebTransport and raw QUIC simultaneously.
+    ///
+    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
+    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
+    pub fn raw(conn: noq::Connection, response: impl Into<ConnectResponse>) -> Self {
         Self {
             conn,
             session_id: None,
@@ -502,13 +501,15 @@ impl Session {
             settings: None,
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
-            request: request.into(),
+            request: None,
             response: response.into(),
         }
     }
 
-    pub fn request(&self) -> &ConnectRequest {
-        &self.request
+    /// Returns the [`ConnectRequest`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn request(&self) -> Option<&ConnectRequest> {
+        self.request.as_ref()
     }
 
     pub fn response(&self) -> &ConnectResponse {

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -13,7 +13,7 @@ use std::{
     future::Future,
     io::Cursor,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     task::{ready, Context, Poll, Waker},
 };
 
@@ -66,9 +66,21 @@ pub struct Connection {
     settings: Option<Arc<h3::Settings>>,
 
     // The request and response that were sent and received.
-    // The request is None for a raw QUIC session.
+    // Both are None for a raw QUIC session.
     request: Option<ConnectRequest>,
-    response: ConnectResponse,
+    response: Option<ConnectResponse>,
+
+    // The ALPN negotiated by the QUIC handshake, for raw QUIC sessions. Quiche only
+    // exposes it as an allocating `alpn()` call, so `protocol()` has nothing in the
+    // connection to borrow from and needs somewhere to keep the result.
+    //
+    // Resolved on first read rather than at construction: `raw()` accepts any
+    // connection, including one whose handshake has not completed and so has no ALPN
+    // yet. Only a successful read is latched, so an early call cannot pin `None` for
+    // the life of the session. Shared across clones.
+    //
+    // Unused by HTTP/3 sessions, which read the subprotocol out of the response.
+    alpn: Arc<OnceLock<String>>,
 
     // Opening a stream is two steps — take the stream, then write the WebTransport
     // header — so a `Pending` in the middle has to resume rather than start over.
@@ -160,7 +172,8 @@ impl Connection {
             header_bi,
             header_datagram,
             request: Some(connect.request.clone()),
-            response: connect.response.clone(),
+            response: Some(connect.response.clone()),
+            alpn: Default::default(),
             settings: Some(Arc::new(settings)),
             open_uni: OpenUni::Idle,
             open_bi: OpenBi::Idle,
@@ -382,10 +395,12 @@ impl Connection {
     /// This is used to pretend like a QUIC connection is a WebTransport session,
     /// making it easier to support WebTransport and raw QUIC simultaneously.
     ///
-    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
-    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
-    pub fn raw(conn: ez::Connection, response: impl Into<ConnectResponse>) -> Self {
+    /// There is no HTTP/3 exchange, so [`Self::request`] and [`Self::response`] both
+    /// return `None`. [`Self::protocol`] reports the ALPN negotiated by the QUIC
+    /// handshake, read from `conn` on demand.
+    pub fn raw(conn: ez::Connection) -> Self {
         let drop = Arc::new(ConnectionDrop { conn: conn.clone() });
+
         Self {
             conn,
             drop,
@@ -396,7 +411,8 @@ impl Connection {
             accept: None,
             settings: None,
             request: None,
-            response: response.into(),
+            response: None,
+            alpn: Default::default(),
             open_uni: OpenUni::Idle,
             open_bi: OpenBi::Idle,
             parked_accept_uni: Parked::default(),
@@ -414,8 +430,31 @@ impl Connection {
         self.request.as_ref()
     }
 
-    pub fn response(&self) -> &ConnectResponse {
-        &self.response
+    /// Returns the [`ConnectResponse`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn response(&self) -> Option<&ConnectResponse> {
+        self.response.as_ref()
+    }
+
+    /// Returns the application protocol negotiated for this session.
+    ///
+    /// For an HTTP/3 session this is the subprotocol the server selected via
+    /// `WT-Available-Protocols`; for a raw QUIC session it is the negotiated ALPN.
+    /// `None` if neither was negotiated, the ALPN is not valid UTF-8, or the raw
+    /// connection is still handshaking.
+    pub fn protocol(&self) -> Option<&str> {
+        if let Some(response) = &self.response {
+            return response.protocol.as_deref();
+        }
+
+        if let Some(alpn) = self.alpn.get() {
+            return Some(alpn);
+        }
+
+        // Latch only a successful read, so a call made while the connection is still
+        // handshaking cannot pin `None` for the life of the session.
+        let alpn = String::from_utf8(self.conn.alpn()?).ok()?;
+        Some(self.alpn.get_or_init(|| alpn))
     }
 
     /// Returns the most recent connection statistics snapshot.
@@ -492,7 +531,7 @@ impl web_transport_trait::Session for Connection {
     }
 
     fn protocol(&self) -> Option<&str> {
-        self.response().protocol.as_deref()
+        Self::protocol(self)
     }
 
     fn close(&self, code: u32, reason: &str) {
@@ -935,7 +974,7 @@ impl web_transport_trait::poll::Session for Connection {
     }
 
     fn protocol(&self) -> Option<&str> {
-        self.response.protocol.as_deref()
+        Self::protocol(self)
     }
 
     fn close(&mut self, code: u32, reason: &str) {

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -66,7 +66,8 @@ pub struct Connection {
     settings: Option<Arc<h3::Settings>>,
 
     // The request and response that were sent and received.
-    request: ConnectRequest,
+    // The request is None for a raw QUIC session.
+    request: Option<ConnectRequest>,
     response: ConnectResponse,
 
     // Opening a stream is two steps — take the stream, then write the WebTransport
@@ -158,7 +159,7 @@ impl Connection {
             header_uni,
             header_bi,
             header_datagram,
-            request: connect.request.clone(),
+            request: Some(connect.request.clone()),
             response: connect.response.clone(),
             settings: Some(Arc::new(settings)),
             open_uni: OpenUni::Idle,
@@ -171,10 +172,10 @@ impl Connection {
             parked_closed: Parked::default(),
         };
 
+        tracing::debug!(url = %connect.request.url, "WebTransport connection established");
+
         // Run a background task to check if the connect stream is closed.
         tokio::spawn(this.clone().run_closed(connect));
-
-        tracing::debug!(url = %this.request().url, "WebTransport connection established");
 
         this
     }
@@ -376,15 +377,14 @@ impl Connection {
         self.conn.closed().await.into()
     }
 
-    /// Create a new session from a raw QUIC connection and a URL.
+    /// Create a new session from a raw QUIC connection.
     ///
-    /// This is used to pretend like a QUIC connection is a WebTransport session.
-    /// It's a hack, but it makes it much easier to support WebTransport and raw QUIC simultaneously.
-    pub fn raw(
-        conn: ez::Connection,
-        request: impl Into<ConnectRequest>,
-        response: impl Into<ConnectResponse>,
-    ) -> Self {
+    /// This is used to pretend like a QUIC connection is a WebTransport session,
+    /// making it easier to support WebTransport and raw QUIC simultaneously.
+    ///
+    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
+    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
+    pub fn raw(conn: ez::Connection, response: impl Into<ConnectResponse>) -> Self {
         let drop = Arc::new(ConnectionDrop { conn: conn.clone() });
         Self {
             conn,
@@ -395,7 +395,7 @@ impl Connection {
             header_datagram: Default::default(),
             accept: None,
             settings: None,
-            request: request.into(),
+            request: None,
             response: response.into(),
             open_uni: OpenUni::Idle,
             open_bi: OpenBi::Idle,
@@ -408,8 +408,10 @@ impl Connection {
         }
     }
 
-    pub fn request(&self) -> &ConnectRequest {
-        &self.request
+    /// Returns the [`ConnectRequest`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn request(&self) -> Option<&ConnectRequest> {
+        self.request.as_ref()
     }
 
     pub fn response(&self) -> &ConnectResponse {

--- a/rs/web-transport-quinn/examples/echo-client.rs
+++ b/rs/web-transport-quinn/examples/echo-client.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("connected");
 
-    match (&args.protocol, &session.response().protocol) {
+    match (&args.protocol, session.protocol()) {
         (Some(_), Some(protocol)) => {
             tracing::info!(%protocol, "negotiated protocol");
         }

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -56,8 +56,8 @@ pub struct Session {
     // Uses OnceLock for set-once, first-writer-wins semantics with lock-free reads.
     error: Arc<OnceLock<SessionError>>,
 
-    // The request sent by the client.
-    request: ConnectRequest,
+    // The request sent by the client, or None for a raw QUIC session.
+    request: Option<ConnectRequest>,
 
     // The response sent by the server.
     response: ConnectResponse,
@@ -116,7 +116,7 @@ impl Session {
             settings: Some(Arc::new(settings)),
             connect_send: Arc::new(Mutex::new(Some(connect.send))),
             error: error.clone(),
-            request: connect.request.clone(),
+            request: Some(connect.request.clone()),
             response: connect.response.clone(),
             op_accept_uni: Default::default(),
             op_accept_bi: Default::default(),
@@ -499,15 +499,14 @@ impl Session {
         }
     }
 
-    /// Create a new session from a raw QUIC connection and a URL.
+    /// Create a new session from a raw QUIC connection.
     ///
-    /// This is used to pretend like a QUIC connection is a WebTransport session.
-    /// It's a hack, but it makes it much easier to support WebTransport and raw QUIC simultaneously.
-    pub fn raw(
-        conn: quinn::Connection,
-        request: impl Into<ConnectRequest>,
-        response: impl Into<ConnectResponse>,
-    ) -> Self {
+    /// This is used to pretend like a QUIC connection is a WebTransport session,
+    /// making it easier to support WebTransport and raw QUIC simultaneously.
+    ///
+    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
+    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
+    pub fn raw(conn: quinn::Connection, response: impl Into<ConnectResponse>) -> Self {
         Self {
             conn,
             session_id: None,
@@ -527,13 +526,15 @@ impl Session {
             settings: None,
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
-            request: request.into(),
+            request: None,
             response: response.into(),
         }
     }
 
-    pub fn request(&self) -> &ConnectRequest {
-        &self.request
+    /// Returns the [`ConnectRequest`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn request(&self) -> Option<&ConnectRequest> {
+        self.request.as_ref()
     }
 
     pub fn response(&self) -> &ConnectResponse {

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -19,6 +19,34 @@ use crate::{
     ClientError, Connected, RecvStream, SendStream, SessionError, Settings, WebTransportError,
 };
 
+/// The ALPN the QUIC handshake negotiated, or `None` if there was none, the handshake
+/// has not completed, or it is not valid UTF-8.
+///
+/// Quinn only exposes the ALPN via a downcast of the boxed handshake data, so the result
+/// is owned rather than borrowed from the connection.
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+fn negotiated_alpn(conn: &quinn::Connection) -> Option<String> {
+    let data = conn.handshake_data()?;
+    let data = data
+        .downcast::<quinn::crypto::rustls::HandshakeData>()
+        .ok()?;
+
+    String::from_utf8(data.protocol?).ok()
+}
+
+/// `quinn::crypto::rustls` only exists once a TLS backend is enabled, so there is no
+/// handshake data type to name here.
+///
+/// This crate's own builders are gated the same way, so normally there is no connection
+/// to read an ALPN from either. A caller that enables a provider on `quinn` directly and
+/// brings its own endpoint can still establish one, and [`Session::protocol`] reports
+/// `None` for those raw sessions. Enable this crate's `aws-lc-rs` or `ring` feature to
+/// get the ALPN.
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+fn negotiated_alpn(_conn: &quinn::Connection) -> Option<String> {
+    None
+}
+
 /// An established WebTransport session, acting like a full QUIC connection. See [`quinn::Connection`].
 ///
 /// It is important to remember that WebTransport is layered on top of QUIC:
@@ -59,8 +87,20 @@ pub struct Session {
     // The request sent by the client, or None for a raw QUIC session.
     request: Option<ConnectRequest>,
 
-    // The response sent by the server.
-    response: ConnectResponse,
+    // The response sent by the server, or None for a raw QUIC session.
+    response: Option<ConnectResponse>,
+
+    // The ALPN negotiated by the QUIC handshake, for raw QUIC sessions. Quinn only
+    // exposes it behind an allocating downcast, so `protocol()` has nothing in the
+    // connection to borrow from and needs somewhere to keep the result.
+    //
+    // Resolved on first read rather than at construction: `raw()` accepts any
+    // connection, including one from `into_0rtt()` whose handshake has not completed
+    // and so has no ALPN yet. Only a successful read is latched, so an early call
+    // cannot pin `None` for the life of the session. Shared across clones.
+    //
+    // Unused by HTTP/3 sessions, which read the subprotocol out of the response.
+    alpn: Arc<OnceLock<String>>,
 
     // Quinn exposes these only as futures, and those futures hold the `Notify`
     // registration that will wake us — rebuilding one per poll would drop the
@@ -117,7 +157,8 @@ impl Session {
             connect_send: Arc::new(Mutex::new(Some(connect.send))),
             error: error.clone(),
             request: Some(connect.request.clone()),
-            response: connect.response.clone(),
+            response: Some(connect.response.clone()),
+            alpn: Default::default(),
             op_accept_uni: Default::default(),
             op_accept_bi: Default::default(),
             op_open_uni: Default::default(),
@@ -504,9 +545,11 @@ impl Session {
     /// This is used to pretend like a QUIC connection is a WebTransport session,
     /// making it easier to support WebTransport and raw QUIC simultaneously.
     ///
-    /// There is no CONNECT request, so [`Self::request`] returns `None`. The response
-    /// is supplied by the caller to carry the negotiated ALPN via [`Self::protocol`].
-    pub fn raw(conn: quinn::Connection, response: impl Into<ConnectResponse>) -> Self {
+    /// There is no HTTP/3 exchange, so [`Self::request`] and [`Self::response`] both
+    /// return `None`. [`Self::protocol`] reports the ALPN negotiated by the QUIC
+    /// handshake, read from `conn` on demand — a connection that is still handshaking
+    /// (from `into_0rtt`, say) is fine, it just has no ALPN to report until it is done.
+    pub fn raw(conn: quinn::Connection) -> Self {
         Self {
             conn,
             session_id: None,
@@ -527,7 +570,8 @@ impl Session {
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
             request: None,
-            response: response.into(),
+            response: None,
+            alpn: Default::default(),
         }
     }
 
@@ -537,8 +581,31 @@ impl Session {
         self.request.as_ref()
     }
 
-    pub fn response(&self) -> &ConnectResponse {
-        &self.response
+    /// Returns the [`ConnectResponse`] if this session was established over HTTP/3,
+    /// or `None` for a raw QUIC session.
+    pub fn response(&self) -> Option<&ConnectResponse> {
+        self.response.as_ref()
+    }
+
+    /// Returns the application protocol negotiated for this session.
+    ///
+    /// For an HTTP/3 session this is the subprotocol the server selected via
+    /// `WT-Available-Protocols`; for a raw QUIC session it is the negotiated ALPN.
+    /// `None` if neither was negotiated, the ALPN is not valid UTF-8, or the raw
+    /// connection is still handshaking.
+    pub fn protocol(&self) -> Option<&str> {
+        if let Some(response) = &self.response {
+            return response.protocol.as_deref();
+        }
+
+        if let Some(alpn) = self.alpn.get() {
+            return Some(alpn);
+        }
+
+        // Latch only a successful read, so a call made while the connection is still
+        // handshaking cannot pin `None` for the life of the session.
+        let alpn = negotiated_alpn(&self.conn)?;
+        Some(self.alpn.get_or_init(|| alpn))
     }
 
     /// Return connection-level statistics.
@@ -969,7 +1036,7 @@ impl web_transport_trait::Session for Session {
     }
 
     fn protocol(&self) -> Option<&str> {
-        self.response.protocol.as_deref()
+        Self::protocol(self)
     }
 
     #[allow(refining_impl_trait)]
@@ -1187,7 +1254,7 @@ impl web_transport_trait::poll::Session for Session {
     }
 
     fn protocol(&self) -> Option<&str> {
-        self.response.protocol.as_deref()
+        Self::protocol(self)
     }
 
     fn close(&mut self, code: u32, reason: &str) {

--- a/rs/web-transport-quinn/tests/raw.rs
+++ b/rs/web-transport-quinn/tests/raw.rs
@@ -1,0 +1,155 @@
+//! Raw QUIC sessions: a QUIC connection using a non-HTTP/3 ALPN, wrapped in a
+//! [`Session`] so callers can treat WebTransport and raw QUIC uniformly.
+//!
+//! There is no CONNECT request on this path, so there is no request URL. The
+//! negotiated ALPN is carried by the response instead.
+
+// A crypto provider is needed to establish the connection, matching the gate on
+// the crate's own builders.
+#![cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+// The trait provides `protocol()`; imported anonymously to avoid clashing with
+// the concrete `Session`.
+use web_transport_quinn::generic::Session as _;
+use web_transport_quinn::{proto::ConnectResponse, Session};
+
+/// A raw QUIC ALPN, i.e. anything other than the `h3` used by WebTransport.
+const RAW_ALPN: &str = "moq-00";
+
+fn self_signed() -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into()]).context("rcgen")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
+
+    Ok((cert_der, key_der))
+}
+
+/// The provider is passed explicitly rather than relying on the process-level
+/// default, which rustls cannot determine when both backend features are enabled
+/// (as `--all-features` does).
+fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    #[cfg(feature = "aws-lc-rs")]
+    {
+        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+    }
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    {
+        Arc::new(rustls::crypto::ring::default_provider())
+    }
+}
+
+/// Bind a QUIC server and connect a client to it, both offering only `RAW_ALPN`.
+async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
+    let (cert, key) = self_signed()?;
+    let provider = crypto_provider();
+
+    let mut server_crypto = rustls::ServerConfig::builder_with_provider(provider.clone())
+        .with_protocol_versions(&[&rustls::version::TLS13])?
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.clone()], key)?;
+    server_crypto.alpn_protocols = vec![RAW_ALPN.as_bytes().to_vec()];
+
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)?,
+    ));
+
+    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let server = quinn::Endpoint::server(server_config, bind)?;
+    let server_addr = server.local_addr()?;
+
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(cert)?;
+
+    let mut client_crypto = rustls::ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![RAW_ALPN.as_bytes().to_vec()];
+
+    let client_config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)?,
+    ));
+
+    let mut client = quinn::Endpoint::client((Ipv4Addr::LOCALHOST, 0).into())?;
+    client.set_default_client_config(client_config);
+
+    let accept = tokio::spawn(async move {
+        let conn = server.accept().await.context("no connection")?.await?;
+        anyhow::Ok(conn)
+    });
+
+    let client_conn = client.connect(server_addr, "localhost")?.await?;
+    let server_conn = accept.await??;
+
+    Ok((client_conn, server_conn))
+}
+
+/// The ALPN the peers negotiated, as an accept path would read it.
+fn negotiated_alpn(conn: &quinn::Connection) -> Result<String> {
+    let data = conn
+        .handshake_data()
+        .context("no handshake data")?
+        .downcast::<quinn::crypto::rustls::HandshakeData>()
+        .ok()
+        .context("unexpected handshake data")?;
+
+    Ok(String::from_utf8(data.protocol.context("no ALPN")?)?)
+}
+
+/// A raw session has no CONNECT request, so it has no URL. Before this was an
+/// `Option`, callers had to synthesize a fake request to construct one.
+#[tokio::test]
+async fn raw_session_has_no_request() -> Result<()> {
+    let (client_conn, _server_conn) = connect_raw().await?;
+
+    let session = Session::raw(client_conn, ConnectResponse::OK);
+    assert!(session.request().is_none());
+
+    Ok(())
+}
+
+/// The response is what carries the negotiated ALPN on the raw path.
+#[tokio::test]
+async fn raw_session_reports_alpn_as_protocol() -> Result<()> {
+    let (client_conn, _server_conn) = connect_raw().await?;
+
+    let alpn = negotiated_alpn(&client_conn)?;
+    assert_eq!(alpn, RAW_ALPN);
+
+    let session = Session::raw(client_conn, ConnectResponse::OK.with_protocol(&alpn));
+    assert_eq!(session.protocol(), Some(RAW_ALPN));
+
+    Ok(())
+}
+
+/// A raw session must not write the WebTransport stream header, since the peer
+/// is reading plain QUIC.
+#[tokio::test]
+async fn raw_session_streams_omit_webtransport_header() -> Result<()> {
+    let (client_conn, server_conn) = connect_raw().await?;
+
+    let client = Session::raw(client_conn, ConnectResponse::OK);
+    let server = Session::raw(server_conn, ConnectResponse::OK);
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hello").await?;
+    send.finish()?;
+
+    let mut recv = server.accept_uni().await?;
+    let data = recv.read_to_end(1024).await?;
+    assert_eq!(&data, b"hello");
+
+    Ok(())
+}

--- a/rs/web-transport-quinn/tests/raw.rs
+++ b/rs/web-transport-quinn/tests/raw.rs
@@ -17,8 +17,7 @@ use std::{
 use anyhow::{Context, Result};
 use rcgen::{CertifiedKey, KeyPair};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-// The trait provides `protocol()`; imported anonymously to avoid clashing with
-// the concrete `Session`.
+// `Session::raw` and the inherent `protocol()` accessor are used directly.
 use web_transport_quinn::Session;
 
 /// A raw QUIC ALPN, i.e. anything other than the `h3` used by WebTransport.

--- a/rs/web-transport-quinn/tests/raw.rs
+++ b/rs/web-transport-quinn/tests/raw.rs
@@ -1,8 +1,8 @@
 //! Raw QUIC sessions: a QUIC connection using a non-HTTP/3 ALPN, wrapped in a
 //! [`Session`] so callers can treat WebTransport and raw QUIC uniformly.
 //!
-//! There is no CONNECT request on this path, so there is no request URL. The
-//! negotiated ALPN is carried by the response instead.
+//! There is no HTTP/3 exchange on this path, so there is neither a request URL nor
+//! a response. The session reports the negotiated ALPN as its protocol instead.
 
 // A crypto provider is needed to establish the connection, matching the gate on
 // the crate's own builders.
@@ -11,6 +11,7 @@
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -18,8 +19,7 @@ use rcgen::{CertifiedKey, KeyPair};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 // The trait provides `protocol()`; imported anonymously to avoid clashing with
 // the concrete `Session`.
-use web_transport_quinn::generic::Session as _;
-use web_transport_quinn::{proto::ConnectResponse, Session};
+use web_transport_quinn::Session;
 
 /// A raw QUIC ALPN, i.e. anything other than the `h3` used by WebTransport.
 const RAW_ALPN: &str = "moq-00";
@@ -50,8 +50,8 @@ fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     }
 }
 
-/// Bind a QUIC server and connect a client to it, both offering only `RAW_ALPN`.
-async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
+/// Bind a server endpoint and a client endpoint, both offering only `RAW_ALPN`.
+fn endpoints() -> Result<(quinn::Endpoint, quinn::Endpoint, SocketAddr)> {
     let (cert, key) = self_signed()?;
     let provider = crypto_provider();
 
@@ -60,6 +60,7 @@ async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
         .with_no_client_auth()
         .with_single_cert(vec![cert.clone()], key)?;
     server_crypto.alpn_protocols = vec![RAW_ALPN.as_bytes().to_vec()];
+    server_crypto.max_early_data_size = u32::MAX;
 
     let server_config = quinn::ServerConfig::with_crypto(Arc::new(
         quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)?,
@@ -77,6 +78,9 @@ async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
         .with_root_certificates(roots)
         .with_no_client_auth();
     client_crypto.alpn_protocols = vec![RAW_ALPN.as_bytes().to_vec()];
+    // Needed for the client-side 0-RTT test below; harmless elsewhere. The default
+    // `resumption` is an in-memory store, so one endpoint can resume its own ticket.
+    client_crypto.enable_early_data = true;
 
     let client_config = quinn::ClientConfig::new(Arc::new(
         quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)?,
@@ -84,6 +88,13 @@ async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
 
     let mut client = quinn::Endpoint::client((Ipv4Addr::LOCALHOST, 0).into())?;
     client.set_default_client_config(client_config);
+
+    Ok((server, client, server_addr))
+}
+
+/// Bind a QUIC server and connect a client to it, both fully handshaken.
+async fn connect_raw() -> Result<(quinn::Connection, quinn::Connection)> {
+    let (server, client, server_addr) = endpoints()?;
 
     let accept = tokio::spawn(async move {
         let conn = server.accept().await.context("no connection")?.await?;
@@ -114,22 +125,94 @@ fn negotiated_alpn(conn: &quinn::Connection) -> Result<String> {
 async fn raw_session_has_no_request() -> Result<()> {
     let (client_conn, _server_conn) = connect_raw().await?;
 
-    let session = Session::raw(client_conn, ConnectResponse::OK);
+    let session = Session::raw(client_conn);
     assert!(session.request().is_none());
+    assert!(session.response().is_none());
 
     Ok(())
 }
 
-/// The response is what carries the negotiated ALPN on the raw path.
+/// `protocol()` reports the ALPN the QUIC handshake negotiated, read off the
+/// connection rather than supplied by the caller.
 #[tokio::test]
 async fn raw_session_reports_alpn_as_protocol() -> Result<()> {
-    let (client_conn, _server_conn) = connect_raw().await?;
+    let (client_conn, server_conn) = connect_raw().await?;
 
-    let alpn = negotiated_alpn(&client_conn)?;
-    assert_eq!(alpn, RAW_ALPN);
+    // Independently confirm what was negotiated, so the assertion below is checking
+    // the session against the connection rather than against itself.
+    assert_eq!(negotiated_alpn(&client_conn)?, RAW_ALPN);
 
-    let session = Session::raw(client_conn, ConnectResponse::OK.with_protocol(&alpn));
-    assert_eq!(session.protocol(), Some(RAW_ALPN));
+    // Both directions: the server reads the ALPN from its own handshake data too.
+    assert_eq!(Session::raw(client_conn).protocol(), Some(RAW_ALPN));
+    assert_eq!(Session::raw(server_conn).protocol(), Some(RAW_ALPN));
+
+    Ok(())
+}
+
+/// Wrapping a connection that is still handshaking must not pin `protocol()` to
+/// `None` for the life of the session.
+///
+/// A resuming client gets its [`quinn::Connection`] from `into_0rtt` before the server
+/// has answered, so the ALPN genuinely is not negotiated yet. Reading `protocol()` in
+/// that window must not stop a later read from seeing the real value.
+#[tokio::test]
+async fn a_handshaking_session_reports_its_alpn_once_it_completes() -> Result<()> {
+    let (server, client, server_addr) = endpoints()?;
+
+    // Accept connections for the whole test; 0-RTT needs a prior session to resume.
+    let accepting = tokio::spawn(async move {
+        while let Some(incoming) = server.accept().await {
+            tokio::spawn(async move {
+                if let Ok(conn) = incoming.await {
+                    conn.closed().await;
+                }
+            });
+        }
+    });
+
+    // 0-RTT needs a ticket from an earlier session, and the ticket arrives after that
+    // handshake with no completion to await. Connect until one is available rather than
+    // sleeping on a guess: the first attempt is what produces the ticket, and a later
+    // one resumes it.
+    let mut zero_rtt = None;
+    for _ in 0..10 {
+        match client.connect(server_addr, "localhost")?.into_0rtt() {
+            Ok(resumed) => {
+                zero_rtt = Some(resumed);
+                break;
+            }
+            Err(connecting) => {
+                let conn = connecting.await?;
+                // The ticket arrives on this connection shortly after the handshake,
+                // with nothing to await on, so hold it open long enough to receive
+                // one. Retrying is what makes this robust — not the wait itself.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                conn.close(0u32.into(), b"");
+                conn.closed().await;
+            }
+        }
+    }
+
+    let (conn, accepted) = zero_rtt.context("0-RTT never became available")?;
+
+    let session = Session::raw(conn);
+
+    // The ALPN is not negotiated yet, so this read has nothing to report...
+    assert_eq!(
+        session.protocol(),
+        None,
+        "expected no ALPN before the handshake completed"
+    );
+
+    // ...and it must not have poisoned the answer for later reads.
+    assert!(accepted.await, "0-RTT was rejected by the server");
+    assert_eq!(
+        session.protocol(),
+        Some(RAW_ALPN),
+        "an early read pinned protocol() to None for the life of the session"
+    );
+
+    accepting.abort();
 
     Ok(())
 }
@@ -140,8 +223,8 @@ async fn raw_session_reports_alpn_as_protocol() -> Result<()> {
 async fn raw_session_streams_omit_webtransport_header() -> Result<()> {
     let (client_conn, server_conn) = connect_raw().await?;
 
-    let client = Session::raw(client_conn, ConnectResponse::OK);
-    let server = Session::raw(server_conn, ConnectResponse::OK);
+    let client = Session::raw(client_conn);
+    let server = Session::raw(server_conn);
 
     let mut send = client.open_uni().await?;
     send.write_all(b"hello").await?;

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -124,7 +124,8 @@ pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
     /// Return the application protocol negotiated for this session, if any.
     ///
     /// For WebTransport over HTTP/3 this is the selected WebTransport subprotocol;
-    /// for raw QUIC it is the negotiated ALPN.
+    /// for raw QUIC it is the negotiated ALPN. Returns `None` if neither was
+    /// negotiated or the ALPN is not valid UTF-8.
     fn protocol(&self) -> Option<&str> {
         None
     }

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -121,7 +121,10 @@ pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
     /// The maximum size of a datagram that can be sent.
     fn max_datagram_size(&self) -> usize;
 
-    /// Return the negotiated WebTransport subprotocol, if any.
+    /// Return the application protocol negotiated for this session, if any.
+    ///
+    /// For WebTransport over HTTP/3 this is the selected WebTransport subprotocol;
+    /// for raw QUIC it is the negotiated ALPN.
     fn protocol(&self) -> Option<&str> {
         None
     }

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -130,9 +130,9 @@ pub trait Session {
     ///
     /// For WebTransport over HTTP/3 this is the selected WebTransport subprotocol;
     /// for raw QUIC it is the negotiated ALPN. Return `None` if the transport does
-    /// not negotiate either. This is required rather than defaulted: a transport
-    /// that negotiates an application protocol and forgets to report it is a silent
-    /// bug, and the default hid that.
+    /// not negotiate either or the ALPN is not valid UTF-8. This is required rather
+    /// than defaulted: a transport that negotiates an application protocol and
+    /// forgets to report it is a silent bug, and the default hid that.
     fn protocol(&self) -> Option<&str>;
 
     /// Close the connection immediately with a code and reason.

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -126,11 +126,13 @@ pub trait Session {
     /// The maximum size of a datagram that can be sent.
     fn max_datagram_size(&self) -> usize;
 
-    /// Return the negotiated WebTransport subprotocol, if any.
+    /// Return the application protocol negotiated for this session, if any.
     ///
-    /// Return `None` if the transport does not negotiate one. This is required
-    /// rather than defaulted: a transport that negotiates a subprotocol and forgets
-    /// to report it is a silent bug, and the default hid that.
+    /// For WebTransport over HTTP/3 this is the selected WebTransport subprotocol;
+    /// for raw QUIC it is the negotiated ALPN. Return `None` if the transport does
+    /// not negotiate either. This is required rather than defaulted: a transport
+    /// that negotiates an application protocol and forgets to report it is a silent
+    /// bug, and the default hid that.
     fn protocol(&self) -> Option<&str>;
 
     /// Close the connection immediately with a code and reason.

--- a/rs/web-transport/src/quinn.rs
+++ b/rs/web-transport/src/quinn.rs
@@ -173,9 +173,10 @@ impl Session {
         self.inner.closed().await.into()
     }
 
-    /// Return the URL used to create the session.
-    pub fn url(&self) -> &Url {
-        &self.inner.request().url
+    /// Return the URL used to create the session, or `None` for a raw QUIC
+    /// session established without an HTTP/3 CONNECT request.
+    pub fn url(&self) -> Option<&Url> {
+        self.inner.request().map(|request| &request.url)
     }
 
     /// Return the application protocol used to create the session.

--- a/rs/web-transport/src/quinn.rs
+++ b/rs/web-transport/src/quinn.rs
@@ -180,8 +180,11 @@ impl Session {
     }
 
     /// Return the application protocol used to create the session.
+    ///
+    /// For a WebTransport session this is the negotiated subprotocol; for a raw QUIC
+    /// session it is the negotiated ALPN.
     pub fn protocol(&self) -> Option<&str> {
-        self.inner.response().protocol.as_deref()
+        self.inner.protocol()
     }
 }
 

--- a/rs/web-transport/src/wasm.rs
+++ b/rs/web-transport/src/wasm.rs
@@ -108,8 +108,11 @@ impl Session {
     }
 
     /// Return the URL used to create the session.
-    pub fn url(&self) -> &Url {
-        self.0.url()
+    ///
+    /// Always `Some` on this platform; the browser API has no raw QUIC session.
+    /// Matches the native signature so callers compile on both targets.
+    pub fn url(&self) -> Option<&Url> {
+        Some(self.0.url())
     }
 
     /// Return the application protocol used to create the session.


### PR DESCRIPTION
## What

Raw QUIC (a moq ALPN with no WebTransport CONNECT) has no HTTP/3 exchange, but `Session::raw()` required both a `ConnectRequest` and a `ConnectResponse`. Callers had to synthesize a request from the TLS SNI purely to satisfy the signature — and then discard it. Since SNI is optional (a client dialing a bare IP sends none, per RFC 6066), that synthesis also imposed a needless "SNI is required" constraint on the accept path.

Both halves are now gone, so the type tells the truth:

- `Session::raw(conn)` — takes the connection alone (quinn, noq, quiche)
- `Session::request() -> Option<&ConnectRequest>`
- `Session::response() -> Option<&ConnectResponse>`
- `web_transport::Session::url() -> Option<&Url>`

This is the shape `web-transport-iroh` already had; the other backends now match it.

## Why this shape

**The response went too, not just the request.** It was only there to carry the negotiated ALPN for `protocol()` — which is the same synthesized-HTTP/3-artifact problem the request had. The ALPN is a property of the connection, so each backend reads it from there instead: `handshake_data()` for quinn and noq, `ez::Connection::alpn()` for quiche. `protocol()` is now an inherent method, so the two trait impls and the `web-transport` router share one definition.

**`protocol()` resolves the ALPN lazily and never latches a negative.** `raw()` accepts any connection, including one from `into_0rtt()` whose handshake hasn't completed and so has no ALPN yet. Reading it at construction would pin `None` for the life of the session; reading on demand and caching only a successful result means an early call can't poison a later one.

**No `path()` or `host()` accessor.** Decomposing the URL was only ever needed to work around the synthesized authority. `host()` in particular would merge an unauthenticated `:authority` header with a cert-bound SNI behind one name, hiding which of the two a caller was trusting — the security property would depend on the transport.

**`ConnectRequest.url` is unchanged.** It's still needed to encode the `:scheme`, `:authority`, and `:path` pseudo-headers, and it's what downstream reads.

**Bindings untouched.** FFI, Node, and the browser have no raw QUIC support, so `url()` is always `Some` there. Making it nullable would have broken the Python/JS query-string coverage for no gain.

**wasm returns `Some` unconditionally** so the signature is identical across targets and cross-platform callers still compile.

## Known limitation

Extracting the ALPN needs `quinn::crypto::rustls`, which only exists when a TLS backend is enabled. Under `--no-default-features` (where this crate's own builders are gated out too) `protocol()` reports `None` for raw sessions even if a caller enabled a provider on `quinn` directly and brought its own endpoint. Enabling `aws-lc-rs` or `ring` on this crate fixes it. Documented at the fallback.

## Tests

`rs/web-transport-quinn/tests/raw.rs` covers raw sessions for the first time:

- `raw_session_has_no_request` — neither request nor response
- `raw_session_reports_alpn_as_protocol` — the ALPN comes off the connection, checked against an independent read of the handshake data, for both peers
- `a_handshaking_session_reports_its_alpn_once_it_completes` — a resuming client takes its connection from `into_0rtt()` before the server has answered; reading `protocol()` in that window must not stop a later read from seeing the real value
- `raw_session_streams_omit_webtransport_header` — streams round-trip without the WebTransport header

The last two are real behavior tests: each fails against a deliberately broken implementation (ALPN read stubbed out; negative result latched). Verified 12/12 clean runs, no flakiness.

## Verification

`just check` and `just test` pass (clippy `-D warnings` on native and wasm32, `cargo fmt --check`, the `cargo hack --feature-powerset` sweep, full test suite). Also checked under default, `--all-features`, `ring`-only, and `--no-default-features`.

## Follow-up

Unblocks deleting the `moqt://{sni}` synthesis in `moq-native`, where the raw arm collapses to `Self::Raw { connection }`. `Error::BuildUrl` dies with it, and `Error::MissingServerName` is already orphaned there.

## Breaking

`Session::raw()` no longer takes a `ConnectRequest` or `ConnectResponse`; `Session::request()`, `Session::response()`, and `web_transport::Session::url()` now return `Option`. Affects `web-transport`, `web-transport-quinn`, `web-transport-noq`, and `web-transport-quiche`. Both halves land in one release so callers absorb a single break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)
