### PR TITLE
chore(js): bump packages for release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "js/qmux": {
       "name": "@moq/qmux",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/web-socket-stream": "workspace:*",
       },
@@ -32,7 +32,7 @@
     },
     "js/web-socket-stream": {
       "name": "@moq/web-socket-stream",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.0",

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "QMux protocol (draft-ietf-quic-qmux-02) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/web-socket-stream/package.json
+++ b/js/web-socket-stream/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/web-socket-stream",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "A WebSocketStream polyfill: a plain WebSocket wrapped as { readable, writable } streams with backpressure",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- bump `@moq/qmux` from `0.3.0` to `0.3.1`
- bump `@moq/web-socket-stream` from `0.1.0` to `0.1.1`
- synchronize the Bun workspace lockfile metadata

## Why

The latest JavaScript changes add backward-compatible server-side APIs that have not yet been published. Patch releases match the project's pre-1.0 compatibility policy for additive APIs. The native `@moq/web-transport` package remains at `0.1.4` because its published contents have not changed since that release.

## Impact

Merging triggers the JavaScript release workflow. It publishes `@moq/web-socket-stream` first, then publishes `@moq/qmux` with a generated dependency on `@moq/web-socket-stream@^0.1.1`.

## Validation

- confirmed current npm versions are `@moq/qmux@0.3.0`, `@moq/web-socket-stream@0.1.0`, and `@moq/web-transport@0.1.4`
- `nix develop --command just check`
- package builds and `publint`
- 132 QMux unit tests
