### PR TITLE
Expose qlog configuration, and fix the quinn server's transport config

### DIFF
--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -18,6 +18,9 @@ all-features = true
 default = ["aws-lc-rs"]
 aws-lc-rs = ["noq/aws-lc-rs", "rustls/aws-lc-rs"]
 ring = ["noq/ring", "rustls/ring"]
+# Unlocks `noq::TransportConfig::qlog_*`, which this crate re-exports but cannot
+# enable on a caller's behalf.
+qlog = ["noq/qlog"]
 
 [dependencies]
 bytes = "1"

--- a/rs/web-transport-noq/tests/qlog.rs
+++ b/rs/web-transport-noq/tests/qlog.rs
@@ -4,8 +4,21 @@
 
 use web_transport_noq::noq;
 
+/// `TransportConfig`'s Debug reports whether a qlog factory is installed, which is the
+/// only observable state noq exposes for it.
+fn qlog_enabled(transport: &noq::TransportConfig) -> bool {
+    format!("{transport:?}").contains("qlog_factory: true")
+}
+
 #[test]
 fn transport_config_exposes_qlog() {
     let mut transport = noq::TransportConfig::default();
+    assert!(!qlog_enabled(&transport), "qlog should start disabled");
+
     transport.qlog_from_path(std::env::temp_dir(), "web-transport-noq");
+
+    assert!(
+        qlog_enabled(&transport),
+        "qlog_from_path did not install a factory"
+    );
 }

--- a/rs/web-transport-noq/tests/qlog.rs
+++ b/rs/web-transport-noq/tests/qlog.rs
@@ -1,0 +1,11 @@
+//! The `qlog` feature must keep `noq`'s qlog knobs reachable through our re-export.
+
+#![cfg(feature = "qlog")]
+
+use web_transport_noq::noq;
+
+#[test]
+fn transport_config_exposes_qlog() {
+    let mut transport = noq::TransportConfig::default();
+    transport.qlog_from_path(std::env::temp_dir(), "web-transport-noq");
+}

--- a/rs/web-transport-quiche/Cargo.toml
+++ b/rs/web-transport-quiche/Cargo.toml
@@ -14,6 +14,12 @@ categories = ["network-programming", "web-programming"]
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+# Honor `Settings::keylog_file` and `SSLKEYLOGFILE`. tokio-quiche gates the keylog
+# behind its own feature, so without this it warns and logs nothing. Off by default:
+# a keylog decrypts every connection the process makes.
+keylog = ["tokio-quiche/capture_keylogs"]
+
 [dependencies]
 boring = "4"
 bytes = "1"

--- a/rs/web-transport-quiche/src/ez/mod.rs
+++ b/rs/web-transport-quiche/src/ez/mod.rs
@@ -28,4 +28,6 @@ use lock::*;
 pub use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 pub use tls::{CertResolver, CertifiedKey, ClientAuth};
 pub use tokio_quiche::metrics::{DefaultMetrics, Metrics};
+/// Compression applied to the qlog traces written to [`Settings::qlog_dir`].
+pub use tokio_quiche::settings::QlogCompression;
 pub use tokio_quiche::settings::QuicSettings as Settings;

--- a/rs/web-transport-quiche/src/lib.rs
+++ b/rs/web-transport-quiche/src/lib.rs
@@ -40,7 +40,10 @@ pub use recv::*;
 pub use send::*;
 pub use server::*;
 
-pub use ez::{CertResolver, CertificateDer, CertifiedKey, ClientAuth, PrivateKeyDer, Settings};
+pub use ez::{
+    CertResolver, CertificateDer, CertifiedKey, ClientAuth, PrivateKeyDer, QlogCompression,
+    Settings,
+};
 
 pub use http;
 pub use web_transport_proto as proto;

--- a/rs/web-transport-quiche/tests/qlog.rs
+++ b/rs/web-transport-quiche/tests/qlog.rs
@@ -9,4 +9,5 @@ fn settings_expose_qlog() {
     settings.qlog_compression = QlogCompression::Gzip;
 
     assert_eq!(settings.qlog_dir.as_deref(), Some("/tmp/qlog"));
+    assert_eq!(settings.qlog_compression, QlogCompression::Gzip);
 }

--- a/rs/web-transport-quiche/tests/qlog.rs
+++ b/rs/web-transport-quiche/tests/qlog.rs
@@ -1,0 +1,12 @@
+//! `Settings` must keep tokio-quiche's qlog knobs reachable, compression included.
+
+use web_transport_quiche::{QlogCompression, Settings};
+
+#[test]
+fn settings_expose_qlog() {
+    let mut settings = Settings::default();
+    settings.qlog_dir = Some("/tmp/qlog".to_string());
+    settings.qlog_compression = QlogCompression::Gzip;
+
+    assert_eq!(settings.qlog_dir.as_deref(), Some("/tmp/qlog"));
+}

--- a/rs/web-transport-quinn/Cargo.toml
+++ b/rs/web-transport-quinn/Cargo.toml
@@ -18,6 +18,9 @@ all-features = true
 default = ["aws-lc-rs"]
 aws-lc-rs = ["quinn/rustls-aws-lc-rs", "rustls/aws-lc-rs"]
 ring = ["quinn/rustls-ring", "rustls/ring"]
+# Unlocks `quinn::TransportConfig::qlog_stream` and `quinn::QlogConfig`, which this
+# crate re-exports but cannot enable on a caller's behalf.
+qlog = ["quinn/qlog"]
 
 [dependencies]
 bytes = "1"

--- a/rs/web-transport-quinn/Cargo.toml
+++ b/rs/web-transport-quinn/Cargo.toml
@@ -53,6 +53,7 @@ web-transport-trait = { workspace = true }
 [dev-dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+rcgen = "0.14"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rs/web-transport-quinn/src/client.rs
+++ b/rs/web-transport-quinn/src/client.rs
@@ -26,14 +26,42 @@ pub enum CongestionControl {
 }
 
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+pub(crate) type ControllerFactory =
+    Arc<dyn quinn::congestion::ControllerFactory + Send + Sync + 'static>;
+
+/// Turn a [CongestionControl] choice into the factory quinn wants.
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+pub(crate) fn controller_factory(algorithm: CongestionControl) -> Option<ControllerFactory> {
+    match algorithm {
+        CongestionControl::LowLatency => Some(Arc::new(quinn::congestion::BbrConfig::default())),
+        // TODO BBR is also higher throughput in theory.
+        CongestionControl::Throughput => Some(Arc::new(quinn::congestion::CubicConfig::default())),
+        CongestionControl::Default => None,
+    }
+}
+
+/// The transport config shared by both builders, so the client and server can't
+/// drift on which knobs actually get applied.
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+pub(crate) fn transport_config(
+    congestion_controller: Option<&ControllerFactory>,
+) -> Arc<quinn::TransportConfig> {
+    let mut transport = quinn::TransportConfig::default();
+    if let Some(cc) = congestion_controller {
+        transport.congestion_controller_factory(cc.clone());
+    }
+
+    Arc::new(transport)
+}
+
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 /// Construct a WebTransport [Client] using sane defaults.
 ///
 /// This is optional; advanced users may use [Client::new] directly.
 #[derive(Clone)]
 pub struct ClientBuilder {
     provider: crypto::Provider,
-    congestion_controller:
-        Option<Arc<dyn quinn::congestion::ControllerFactory + Send + Sync + 'static>>,
+    congestion_controller: Option<ControllerFactory>,
 }
 
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
@@ -48,17 +76,7 @@ impl ClientBuilder {
 
     /// Enable the specified congestion controller.
     pub fn with_congestion_control(mut self, algorithm: CongestionControl) -> Self {
-        self.congestion_controller = match algorithm {
-            CongestionControl::LowLatency => {
-                Some(Arc::new(quinn::congestion::BbrConfig::default()))
-            }
-            // TODO BBR is also higher throughput in theory.
-            CongestionControl::Throughput => {
-                Some(Arc::new(quinn::congestion::CubicConfig::default()))
-            }
-            CongestionControl::Default => None,
-        };
-
+        self.congestion_controller = controller_factory(algorithm);
         self
     }
 
@@ -142,13 +160,7 @@ impl ClientBuilder {
 
         let client_config = QuicClientConfig::try_from(crypto).unwrap();
         let mut client_config = quinn::ClientConfig::new(Arc::new(client_config));
-
-        let mut transport = quinn::TransportConfig::default();
-        if let Some(cc) = &self.congestion_controller {
-            transport.congestion_controller_factory(cc.clone());
-        }
-
-        client_config.transport_config(transport.into());
+        client_config.transport_config(transport_config(self.congestion_controller.as_ref()));
 
         let client = quinn::Endpoint::client("[::]:0".parse().unwrap()).unwrap();
         Ok(Client {

--- a/rs/web-transport-quinn/src/server.rs
+++ b/rs/web-transport-quinn/src/server.rs
@@ -6,6 +6,8 @@ use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+use crate::client::{controller_factory, transport_config, ControllerFactory};
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 use crate::{crypto, CongestionControl};
 use crate::{
     proto::{ConnectRequest, ConnectResponse},
@@ -19,8 +21,7 @@ use crate::{
 pub struct ServerBuilder {
     provider: crypto::Provider,
     addr: std::net::SocketAddr,
-    congestion_controller:
-        Option<Arc<dyn quinn::congestion::ControllerFactory + Send + Sync + 'static>>,
+    congestion_controller: Option<ControllerFactory>,
 }
 
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
@@ -48,17 +49,7 @@ impl ServerBuilder {
 
     /// Enable the specified congestion controller.
     pub fn with_congestion_control(mut self, algorithm: CongestionControl) -> Self {
-        self.congestion_controller = match algorithm {
-            CongestionControl::LowLatency => {
-                Some(Arc::new(quinn::congestion::BbrConfig::default()))
-            }
-            // TODO BBR is also higher throughput in theory.
-            CongestionControl::Throughput => {
-                Some(Arc::new(quinn::congestion::CubicConfig::default()))
-            }
-            CongestionControl::Default => None,
-        };
-
+        self.congestion_controller = controller_factory(algorithm);
         self
     }
 
@@ -69,6 +60,23 @@ impl ServerBuilder {
         chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
     ) -> Result<Server, ServerError> {
+        let transport = transport_config(self.congestion_controller.as_ref());
+        let config = self.config(chain, key, transport)?;
+
+        let server = quinn::Endpoint::server(config, self.addr)
+            .map_err(|e| ServerError::IoError(e.into()))?;
+
+        Ok(Server::new(server))
+    }
+
+    /// Build the quinn config, taking the transport separately so the caller (and the
+    /// tests) can tell which one ends up attached.
+    fn config(
+        &self,
+        chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+        transport: Arc<quinn::TransportConfig>,
+    ) -> Result<quinn::ServerConfig, ServerError> {
         // Standard Quinn setup
         let mut config = rustls::ServerConfig::builder_with_provider(self.provider.clone())
             .with_protocol_versions(&[&rustls::version::TLS13])?
@@ -78,12 +86,10 @@ impl ServerBuilder {
         config.alpn_protocols = vec![crate::ALPN.as_bytes().to_vec()]; // this one is important
 
         let config: quinn::crypto::rustls::QuicServerConfig = config.try_into().unwrap();
-        let config = quinn::ServerConfig::with_crypto(Arc::new(config));
+        let mut config = quinn::ServerConfig::with_crypto(Arc::new(config));
+        config.transport_config(transport);
 
-        let server = quinn::Endpoint::server(config, self.addr)
-            .map_err(|e| ServerError::IoError(e.into()))?;
-
-        Ok(Server::new(server))
+        Ok(config)
     }
 }
 
@@ -203,5 +209,50 @@ impl core::ops::Deref for Request {
 
     fn deref(&self) -> &Self::Target {
         &self.connect
+    }
+}
+
+#[cfg(all(test, any(feature = "aws-lc-rs", feature = "ring")))]
+mod tests {
+    use super::*;
+    use rustls::pki_types::PrivatePkcs8KeyDer;
+
+    fn self_signed() -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+        let key = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let chain = vec![CertificateDer::from(key.cert.der().to_vec())];
+        let der = rcgen::KeyPair::serialize_der(&key.signing_key);
+
+        (chain, PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(der)))
+    }
+
+    /// `ServerBuilder::new` goes through [crypto::default_provider], which panics when
+    /// both backends are compiled in and no process-wide default is installed. Pick one
+    /// here rather than mutating global state from a test.
+    fn builder() -> ServerBuilder {
+        #[cfg(feature = "aws-lc-rs")]
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+        ServerBuilder {
+            provider,
+            addr: "[::]:0".parse().unwrap(),
+            congestion_controller: None,
+        }
+    }
+
+    /// quinn installs its own default transport config, so the builder's has to be
+    /// attached explicitly or every server knob (congestion control) silently no-ops.
+    #[test]
+    fn builder_transport_reaches_the_config() {
+        let (chain, key) = self_signed();
+
+        let builder = builder().with_congestion_control(CongestionControl::LowLatency);
+        assert!(builder.congestion_controller.is_some());
+
+        let transport = transport_config(builder.congestion_controller.as_ref());
+        let config = builder.config(chain, key, transport.clone()).unwrap();
+
+        assert!(Arc::ptr_eq(&config.transport, &transport));
     }
 }

--- a/rs/web-transport-quinn/tests/qlog.rs
+++ b/rs/web-transport-quinn/tests/qlog.rs
@@ -4,11 +4,23 @@
 
 use web_transport_quinn::quinn;
 
+/// `TransportConfig`'s Debug reports whether a qlog sink is installed, which is the
+/// only observable state quinn exposes for it.
+fn qlog_enabled(transport: &quinn::TransportConfig) -> bool {
+    format!("{transport:?}").contains("qlog_stream: true")
+}
+
 #[test]
 fn transport_config_exposes_qlog() {
+    let mut transport = quinn::TransportConfig::default();
+    assert!(!qlog_enabled(&transport), "qlog should start disabled");
+
     let mut config = quinn::QlogConfig::default();
     config.writer(Box::new(std::io::sink()));
-
-    let mut transport = quinn::TransportConfig::default();
     transport.qlog_stream(config.into_stream());
+
+    assert!(
+        qlog_enabled(&transport),
+        "qlog_stream did not install a sink"
+    );
 }

--- a/rs/web-transport-quinn/tests/qlog.rs
+++ b/rs/web-transport-quinn/tests/qlog.rs
@@ -1,0 +1,14 @@
+//! The `qlog` feature must keep `quinn`'s qlog knobs reachable through our re-export.
+
+#![cfg(feature = "qlog")]
+
+use web_transport_quinn::quinn;
+
+#[test]
+fn transport_config_exposes_qlog() {
+    let mut config = quinn::QlogConfig::default();
+    config.writer(Box::new(std::io::sink()));
+
+    let mut transport = quinn::TransportConfig::default();
+    transport.qlog_stream(config.into_stream());
+}


### PR DESCRIPTION
Makes qlog capture reachable through these wrappers, and fixes two knobs that were silently doing nothing.

Motivated by adding qlog support to `moq-native`, which needs to turn on qlog for whichever backend is selected. Only the `web-transport-noq` change is strictly required for that (see below); the rest came out of the same investigation.

## qlog

quinn and noq gate their qlog knobs (`TransportConfig::qlog_stream` / `qlog_from_path`, `QlogConfig`) behind a cargo feature on the backend crate. We re-export `quinn` and `noq`, but a consumer reaching those types *only* through the re-export has no way to enable the feature. Added a passthrough `qlog` feature to each, matching the `qlog = ["iroh/qlog"]` that `web-transport-iroh` already has.

quiche needed nothing on the plumbing: `Settings::qlog_dir` already flows into `quiche_conn.set_qlog` via tokio-quiche, whose `quiche` dep enables `qlog` and whose defaults include `qlog-gzip`/`qlog-zstd`. But `QlogCompression` was not re-exported, pinning consumers to uncompressed `.sqlog`. Re-exported alongside `Settings`.

Each crate gets a test that names the qlog API through the re-export, so a dependency bump that drops it fails the build rather than silently regressing.

## `ServerBuilder::with_congestion_control` was a no-op

`ServerBuilder` stored a controller factory that nothing ever read. `with_certificate` built its config with `quinn::ServerConfig::with_crypto`, which installs quinn's *own* default transport config, and never attached one of its own. Every server-side call was silently discarded; only the client honored the setting.

Rather than patch the one call site, both builders now share `client::transport_config`, so the two paths cannot drift on which knobs get applied again. That drift is what let this hide. `controller_factory` also replaces the `match` that was duplicated in each `with_congestion_control`.

The regression test drives the extracted private `ServerBuilder::config` and asserts the transport it was handed is the one on the resulting `quinn::ServerConfig`. Before the fix that is quinn's default instead, so it fails without the change (verified by reverting the one line).

## `Settings::keylog_file` was a no-op

Setting it (or `SSLKEYLOGFILE`, which tokio-quiche reads as a fallback) got you a log warning and no keys: tokio-quiche gates the keylog behind its own `capture_keylogs` feature, which we never enabled. Added a `keylog` feature that forwards it.

Off by default, unlike the qlog features, because a keylog decrypts every connection the process makes.

## Notes

- One pre-existing sharp edge surfaced while writing the test: `ServerBuilder::new()` / `ClientBuilder::new()` panic under `--all-features`, because `crypto::default_provider()` matches neither single-backend cfg arm when both `aws-lc-rs` and `ring` are on and no process-wide default is installed. Documented behavior, not introduced here, but it means the test builds its builder with an explicit provider rather than mutating process-global state.
- `just check` passes (it uses `--all-features`, so the new features and tests are compiled and clippy'd), and the full `cargo test --workspace --all-targets --all-features` suite is green.

(written by Opus 4.8)