### PR TITLE
feat(wasm): fail with a clear error when web_sys_unstable_apis is unset

### DIFF
--- a/rs/web-transport-wasm/Cargo.toml
+++ b/rs/web-transport-wasm/Cargo.toml
@@ -46,3 +46,6 @@ features = [
     "WritableStream",
     "WritableStreamDefaultWriter",
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }

--- a/rs/web-transport-wasm/README.md
+++ b/rs/web-transport-wasm/README.md
@@ -4,3 +4,19 @@
 
 # web-transport-wasm
 A wrapper around the WebTransport browser API.
+
+## Requirements
+
+`web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`, so this crate
+cannot compile without it. The flag can't be enabled by a dependency; it has to come from the final
+build. Add it to `.cargo/config.toml`:
+
+```toml
+[build]
+rustflags = ["--cfg=web_sys_unstable_apis"]
+```
+
+Or set `RUSTFLAGS="--cfg=web_sys_unstable_apis"` in the environment. `RUSTFLAGS` overrides
+`.cargo/config.toml` rather than adding to it, so use one or the other.
+
+Building without the flag fails with a `compile_error!` pointing back here.

--- a/rs/web-transport-wasm/src/lib.rs
+++ b/rs/web-transport-wasm/src/lib.rs
@@ -2,15 +2,48 @@
 //!
 //! This crate wraps the WebTransport API and provides ergonomic Rust bindings.
 //! Some liberties have been taken to make the API more Rust-like and closer to native.
+//!
+//! # Requirements
+//!
+//! `web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`,
+//! so this crate cannot compile without that flag. It cannot be enabled by a dependency;
+//! it has to be set by the final build, for example via `.cargo/config.toml`:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ["--cfg=web_sys_unstable_apis"]
+//! ```
 
+#[cfg(not(web_sys_unstable_apis))]
+compile_error!(
+    "web-transport-wasm requires `--cfg=web_sys_unstable_apis` because web-sys gates the \
+     WebTransport bindings behind it. This flag cannot be enabled by a dependency; add it to \
+     your own build, for example in `.cargo/config.toml`:\n\n\
+     \x20   [build]\n\
+     \x20   rustflags = [\"--cfg=web_sys_unstable_apis\"]\n\n\
+     or set `RUSTFLAGS=\"--cfg=web_sys_unstable_apis\"` in the environment. Note that RUSTFLAGS \
+     overrides `.cargo/config.toml`, so only one of the two takes effect."
+);
+
+// Gated so missing web-sys bindings don't bury the error above.
+#[cfg(web_sys_unstable_apis)]
 mod client;
+#[cfg(web_sys_unstable_apis)]
 mod error;
+#[cfg(web_sys_unstable_apis)]
 mod recv;
+#[cfg(web_sys_unstable_apis)]
 mod send;
+#[cfg(web_sys_unstable_apis)]
 mod session;
 
+#[cfg(web_sys_unstable_apis)]
 pub use client::*;
+#[cfg(web_sys_unstable_apis)]
 pub use error::*;
+#[cfg(web_sys_unstable_apis)]
 pub use recv::*;
+#[cfg(web_sys_unstable_apis)]
 pub use send::*;
+#[cfg(web_sys_unstable_apis)]
 pub use session::*;

--- a/rs/web-transport/README.md
+++ b/rs/web-transport/README.md
@@ -12,6 +12,9 @@ This crate provides a generic WebTransport implementation depending on the platf
 -   Native: [web-transport-quinn](../web-transport-quinn)
 -   WASM: [web-transport-wasm](../web-transport-wasm)
 
+WASM builds additionally require `--cfg=web_sys_unstable_apis`; see
+[web-transport-wasm](../web-transport-wasm/README.md#requirements).
+
 
 ## Why no trait?
 


### PR DESCRIPTION
Closes #335.

`web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`, and a dependency can't turn that on for its users. Without the flag, `web-transport-wasm` failed with a pile of `cannot find type \`WebTransport\` in \`web_sys\`` errors that never mentioned the actual cause.

- `compile_error!` in `web-transport-wasm` naming the flag and both ways to set it (`.cargo/config.toml` vs `RUSTFLAGS`, including that the latter overrides the former).
- Modules are gated behind the cfg so the missing bindings don't bury that message — the build now emits exactly one error.
- Documented the requirement in `rs/web-transport-wasm/README.md` and linked it from `rs/web-transport/README.md`.

Building without the flag now produces:

```
error: web-transport-wasm requires `--cfg=web_sys_unstable_apis` because web-sys gates the
       WebTransport bindings behind it. This flag cannot be enabled by a dependency; add it to
       your own build, for example in `.cargo/config.toml`:

           [build]
           rustflags = ["--cfg=web_sys_unstable_apis"]

       or set `RUSTFLAGS="--cfg=web_sys_unstable_apis"` in the environment. Note that RUSTFLAGS
       overrides `.cargo/config.toml`, so only one of the two takes effect.
  --> rs/web-transport-wasm/src/lib.rs:18:1
```

Verified both paths: `cargo check -p web-transport-wasm --target wasm32-unknown-unknown` passes with the flag, and `RUSTFLAGS="" cargo check -p web-transport --target wasm32-unknown-unknown` fails with only the message above. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)