### PR TITLE
ci: require the moq-bot App token in release-rs

### DIFF
--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -1,6 +1,7 @@
-# Uses APP_ID / APP_PRIVATE_KEY secrets so the auto-pushed web-transport-ffi-v* tag fires
-# the downstream release-py/release-kt/release-swift workflows. If the App credentials
-# aren't configured, fall back to GITHUB_TOKEN — but tags won't trigger workflows in that case.
+# Authenticates as the moq-bot GitHub App (APP_ID / APP_PRIVATE_KEY) so the release PR
+# and the auto-pushed web-transport-ffi-v* tag trigger workflows; GITHUB_TOKEN-authored
+# refs deliberately do not, which would leave the release PR unchecked and the downstream
+# release-py/release-kt/release-swift workflows unfired.
 name: release-rs
 
 permissions:
@@ -23,11 +24,9 @@ jobs:
     steps:
       # Generating a GitHub token, so that PRs and tags created by
       # the release-plz-action can trigger actions workflows.
-      # Optional: falls back to GITHUB_TOKEN if the App isn't configured.
       - name: Generate GitHub token
         uses: actions/create-github-app-token@v3
         id: generate-token
-        continue-on-error: true
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -36,7 +35,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -44,5 +43,5 @@ jobs:
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## What

`release-rs` now requires the moq-bot GitHub App token instead of silently degrading to `GITHUB_TOKEN`:

- dropped `continue-on-error: true` on the `create-github-app-token` step
- dropped the `|| secrets.GITHUB_TOKEN` fallback on both the checkout `token:` and release-plz's `GITHUB_TOKEN`
- rewrote the header comment to describe the current design

This matches [`moq-dev/moq`'s `release-rs.yml`](https://github.com/moq-dev/moq/blob/main/.github/workflows/release-rs.yml).

## Why

Refs created with `GITHUB_TOKEN` deliberately do not trigger workflows. For this repo that meant two things were quietly broken:

1. The release-plz PR opened with **no CI checks at all**.
2. The auto-pushed `web-transport-ffi-v*` tag never fired the downstream `release-py` / `release-kt` / `release-swift` workflows.

The workflow already tried to mint a moq-bot App token, but `APP_ID` / `APP_PRIVATE_KEY` were never configured on this repo — so with `continue-on-error` plus the fallback, every run took the `GITHUB_TOKEN` path and looked green while doing the wrong thing. Removing the fallback makes a missing/expired credential fail loudly.

## Reviewer notes

- **The credentials are already in place.** `APP_ID` and `APP_PRIVATE_KEY` are now set as **org-level** secrets on `moq-dev` with `ALL` repo visibility (previously they existed only as repo secrets on `moq-dev/moq`). The moq-bot App (id `1039466`) is installed org-wide — `repository_selection: all` — with `contents: write`, `pull_requests: write`, `actions: write`, which is exactly what release-plz needs. No install or permission change is required for this PR to work.
- **This cannot be tested before merge.** `release-rs` triggers only on `push` to `main` and has no `workflow_dispatch`. The first signal is the next push to `main`: the "Generate GitHub token" step should succeed, and the resulting release PR should be authored by **moq-bot** with CI running on it.
- **If it does fail**, the failure is loud and isolated — the release job errors at the token step and no release happens; nothing else in CI is affected. Reverting this commit restores the previous (silently degraded) behavior.
- No Rust or JS code is touched, so `just check` / `just test` are unaffected.

(written by Opus 4.8)