### PR TITLE
fix(qmux): only let a send restart the idle timer once per receive

### DIFF
--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -528,13 +528,44 @@ describe("Session integration (scripted peer)", () => {
 			for (let i = 0; i < 6; i++) {
 				await new Promise((resolve) => setTimeout(resolve, 45));
 				await writer.write(new Uint8Array([i]));
+				// The peer answers every other write, as a live peer responding to the
+				// keep-alive would. A send restarts the deadline only once per receive
+				// (RFC 9000 §10.1), so proof of life has to keep arriving.
+				if (i % 2 === 0) peer.send({ type: "ping_response", sequence: BigInt(i) });
 			}
 
-			// More than two idle windows elapsed without another inbound frame, but
-			// the successful STREAM writes above kept resetting the shared deadline.
+			// More than two idle windows elapsed with only occasional inbound frames,
+			// but the successful STREAM writes kept resetting the shared deadline.
 			expect(peer.has("connection_close")).toBe(false);
 			session.close();
 			expect(await session.closed).toEqual({ closeCode: 0, reason: "" });
+		});
+
+		test("a silent peer idle-closes even while our own writes land", async () => {
+			// The dead-peer case: nothing ever arrives again, but the socket still
+			// accepts everything we send. Our own keep-alive pings advance the send
+			// clock, so counting every send as activity left the deadline permanently
+			// in the future and the session never closed.
+			const { session, peer } = connect({ maxIdleTimeout: 120n });
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			const writable = await session.createUnidirectionalStream();
+			const writer = writable.getWriter();
+			const writes = (async () => {
+				try {
+					for (let i = 0; i < 12; i++) {
+						await new Promise((resolve) => setTimeout(resolve, 45));
+						await writer.write(new Uint8Array([i]));
+					}
+				} catch {
+					// The session closes out from under the writer; that's the point.
+				}
+			})();
+
+			const err = await expectSessionFailure(session);
+			expect(err.message).toContain("idle timeout");
+			await writes;
 		});
 
 		test("the standard reconnect idiom sees a drop", async () => {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -608,6 +608,11 @@ export default class Session implements WebTransport {
 	// QMux01 idle-timeout tracking (engaged once we've received the peer's params).
 	#lastRecvAt = Date.now();
 	#lastSendAt = Date.now();
+	// Deadline bookkeeping for #idleActivityAt: the newest receive observed, the
+	// send last allowed to restart the deadline, and whether a send may restart it.
+	#recvSeen = 0;
+	#sendResetAt = 0;
+	#sendCredit = true;
 	#nextPingSeq = 0;
 	// Highest sequence seen in a received QX_PING request (draft-02 requires them
 	// to strictly increase). Undefined until the first request arrives.
@@ -1007,13 +1012,39 @@ export default class Session implements WebTransport {
 		this.#idleTimer = setInterval(() => this.#idleTick(Number(timeoutMs)), tickMs);
 	}
 
+	/**
+	 * Newest activity that counts toward the idle deadline.
+	 *
+	 * A received frame always restarts the timer: it is the only direct proof the
+	 * peer is still there. A send restarts it too, but at most once per receive
+	 * (RFC 9000 §10.1). That proviso is what keeps the deadline reachable: our own
+	 * keep-alive pings advance `#lastSendAt`, so counting every send would let them
+	 * restart the very deadline they exist to test, and a peer that goes silent
+	 * while its socket still accepts our writes would never be reclaimed.
+	 *
+	 * Crediting the first send after each receive is what still lets a mostly
+	 * one-way sender stay open — its peer answers the keep-alive, and each answer
+	 * re-arms the credit.
+	 */
+	#idleActivityAt(): number {
+		if (this.#lastRecvAt > this.#recvSeen) {
+			this.#recvSeen = this.#lastRecvAt;
+			this.#sendCredit = true;
+		}
+		if (this.#sendCredit && this.#lastSendAt > this.#sendResetAt) {
+			this.#sendResetAt = this.#lastSendAt;
+			this.#sendCredit = false;
+		}
+		return Math.max(this.#recvSeen, this.#sendResetAt);
+	}
+
 	#idleTick(timeoutMs: number) {
 		if (this.#closed) {
 			if (this.#idleTimer) clearInterval(this.#idleTimer);
 			return;
 		}
 		const now = Date.now();
-		if (now - Math.max(this.#lastRecvAt, this.#lastSendAt) > timeoutMs) {
+		if (now - this.#idleActivityAt() > timeoutMs) {
 			// No frames have been sent or received within the negotiated limit. Abnormal:
 			// without a rejection this is indistinguishable from a graceful close(), which
 			// also settles with closeCode 0.

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -655,10 +655,10 @@ mod writer_final_size_tests {
 ///
 ///  - enqueues a `QX_PING` on the control lane once we've been silent on send for a
 ///    third of the idle window (the keep-alive cadence), and
-///  - closes the session once we've been silent on send and receive for a full
-///    idle window, deferred by at most one extra window while the reader or writer is
-///    backpressured — that's evidence the peer is alive and we simply can't get a
-///    keep-alive through (or aren't reading its replies).
+///  - closes the session once a full idle window passes with no activity that counts
+///    (see [`IdleActivity`]), deferred by at most one extra window while the reader or
+///    writer is backpressured — that's evidence the peer is alive and we simply can't
+///    get a keep-alive through (or aren't reading its replies).
 ///
 /// Only meaningful for the record-framed drafts (QMux01+) — the versions that
 /// negotiate an idle timeout — so it isn't spawned otherwise.
@@ -683,7 +683,65 @@ struct TimerState {
     pings_sent: Arc<AtomicU64>,
 }
 
+/// Decides which of the reader's and writer's clocks currently count as "activity"
+/// for the idle deadline.
+///
+/// A received frame always restarts the timer: it is the only direct proof the peer
+/// is still there. A send restarts it too, but at most once per receive (RFC 9000
+/// §10.1). That proviso is what keeps the deadline reachable: our own keep-alive
+/// pings advance `last_send_at`, so counting every send would let them restart the
+/// very deadline they exist to test, and a peer that goes silent while its socket
+/// still accepts our writes would never be reclaimed.
+///
+/// Crediting the first send after each receive is what still lets a mostly one-way
+/// sender stay open — its peer answers the keep-alive, and each answer re-arms the
+/// credit.
+struct IdleActivity {
+    /// Newest `last_recv_at` observed so far.
+    recv_seen: u64,
+    /// The send we last allowed to restart the deadline.
+    send_reset_at: u64,
+    /// Whether a send may restart the deadline (a receive has landed since the last
+    /// one that did).
+    send_credit: bool,
+}
+
+impl IdleActivity {
+    /// Start from the receive that established the session; the peer has just been
+    /// heard from, so a send may restart the deadline immediately.
+    fn new(recv_at: u64) -> Self {
+        Self {
+            recv_seen: recv_at,
+            send_reset_at: recv_at,
+            send_credit: true,
+        }
+    }
+
+    /// Fold in the latest clocks and return the millis of the newest activity that
+    /// counts toward the idle deadline.
+    fn observe(&mut self, recv_at: u64, send_at: u64) -> u64 {
+        if recv_at > self.recv_seen {
+            self.recv_seen = recv_at;
+            self.send_credit = true;
+        }
+        if self.send_credit && send_at > self.send_reset_at {
+            self.send_reset_at = send_at;
+            self.send_credit = false;
+        }
+        self.recv_seen.max(self.send_reset_at)
+    }
+}
+
 impl TimerState {
+    /// Read both clocks and fold them into `activity`, returning the millis of the
+    /// newest activity that counts toward the idle deadline.
+    fn observe_activity(&self, activity: &mut IdleActivity) -> u64 {
+        activity.observe(
+            self.last_recv_at.load(Ordering::Acquire),
+            self.last_send_at.load(Ordering::Acquire),
+        )
+    }
+
     async fn run(mut self) {
         let mut closed_rx = self.closed.subscribe();
 
@@ -718,14 +776,10 @@ impl TimerState {
         // `last_send_at` frozen) doesn't make us re-enqueue one on every wake-up.
         let mut last_ping_ms = self.last_send_at.load(Ordering::Acquire);
         let mut next_ping_seq: u64 = 0;
+        let mut activity = IdleActivity::new(self.last_recv_at.load(Ordering::Acquire));
 
         loop {
-            let last_activity = instant_at(
-                self.base,
-                self.last_recv_at
-                    .load(Ordering::Acquire)
-                    .max(self.last_send_at.load(Ordering::Acquire)),
-            );
+            let last_activity = instant_at(self.base, self.observe_activity(&mut activity));
             let ping_ref = instant_at(
                 self.base,
                 self.last_send_at.load(Ordering::Acquire).max(last_ping_ms),
@@ -768,14 +822,10 @@ impl TimerState {
                 last_ping_ms = millis_since(self.base, now);
             }
 
-            // Idle close: due once we've been silent on send and receive for a full
-            // window. Draft-02 section 7.1 resets the timer for either direction.
-            let last_activity = instant_at(
-                self.base,
-                self.last_recv_at
-                    .load(Ordering::Acquire)
-                    .max(self.last_send_at.load(Ordering::Acquire)),
-            );
+            // Idle close: due once a full window has passed with no qualifying
+            // activity. Re-read the clocks; the ping we may have just enqueued does
+            // not itself buy another window (see [`IdleActivity`]).
+            let last_activity = instant_at(self.base, self.observe_activity(&mut activity));
             if now < last_activity + idle {
                 deferred_since = None; // send or receive progressed — not idle
                 continue;
@@ -2523,23 +2573,60 @@ mod timer_tests {
         );
     }
 
-    /// Successful outbound frames reset the same idle deadline as inbound frames.
-    /// A one-way sender must remain open while its writes continue beyond a full
-    /// idle window, even when the peer sends nothing back.
+    /// Successful outbound frames reset the same idle deadline as inbound frames,
+    /// so a mostly one-way sender stays open across many idle windows while its
+    /// peer is still answering — here at a keep-alive-like cadence, far slower
+    /// than the writes.
     #[tokio::test]
     async fn send_progress_averts_idle_close() {
         let h = spawn_timer(100);
 
         let base = tokio::time::Instant::now();
-        for _ in 0..6 {
-            tokio::time::sleep(Duration::from_millis(50)).await;
+        for i in 0..12 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
             let elapsed = base.elapsed().as_millis() as u64;
             h.last_send_at.store(elapsed, Ordering::Release);
+            // The peer answers roughly every third write, as a live peer
+            // responding to QX_PING would.
+            if i % 3 == 0 {
+                h.last_recv_at.store(elapsed, Ordering::Release);
+            }
         }
         assert!(
             h.closed.borrow().is_none(),
-            "a session that keeps sending must not be idle-closed"
+            "a one-way sender whose peer still answers must not be idle-closed"
         );
+    }
+
+    /// A peer that has gone silent must be closed even while our own side keeps
+    /// sending successfully.
+    ///
+    /// Only a *received* frame proves the peer is alive. Our keep-alive pings (and
+    /// any application writes into a socket that still accepts them) advance
+    /// `last_send_at`, so letting every send reset the deadline lets us hold a dead
+    /// session open by talking to ourselves — the timeout can never fire.
+    #[tokio::test]
+    async fn idle_close_when_peer_silent_despite_our_sends() {
+        let h = spawn_timer(100);
+
+        // Our writes keep landing for well over two idle windows; the peer never
+        // says anything back.
+        let base = tokio::time::Instant::now();
+        let pump = tokio::spawn({
+            let last_send_at = h.last_send_at.clone();
+            async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    last_send_at.store(base.elapsed().as_millis() as u64, Ordering::Release);
+                }
+            }
+        });
+
+        let reason = tokio::time::timeout(Duration::from_millis(600), closed_reason(&h))
+            .await
+            .expect("a silent peer must idle-close even while we keep sending");
+        assert!(matches!(reason, Error::IdleTimeout), "got {reason:?}");
+        pump.abort();
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -827,7 +827,7 @@ impl TimerState {
             // not itself buy another window (see [`IdleActivity`]).
             let last_activity = instant_at(self.base, self.observe_activity(&mut activity));
             if now < last_activity + idle {
-                deferred_since = None; // send or receive progressed — not idle
+                deferred_since = None; // qualifying activity progressed — not idle
                 continue;
             }
 

--- a/rs/qmux/tests/qmux01.rs
+++ b/rs/qmux/tests/qmux01.rs
@@ -209,3 +209,77 @@ async fn qmux01_ping_keeps_idle_session_alive() {
 
     client.close(0, "done");
 }
+
+/// The other half of that contract: a peer that goes SILENT must be idle-closed,
+/// even while our own writes keep landing.
+///
+/// This is what a vanished host or a dropped network looks like on a stream
+/// transport (Unix socket, TCP, WebSocket): no close, no EOF, just nothing ever
+/// arriving again while the socket happily accepts everything we send. Our own
+/// keep-alive pings advance the send clock every idle/3, so counting every send as
+/// activity left the deadline permanently in the future and the session lived until
+/// the process died. Only a *received* frame proves the peer is still there.
+#[tokio::test]
+async fn qmux01_silent_peer_is_idle_closed() {
+    use qmux::transport::Stream;
+    use qmux::{Config, Error, Session};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let (client_io, proxy_client) = tokio::io::duplex(64 * 1024);
+    let (proxy_server, server_io) = tokio::io::duplex(64 * 1024);
+    let silenced = Arc::new(AtomicBool::new(false));
+
+    // Proxy the two sockets so one direction can be cut without closing either.
+    // Client→server always flows, so the client's writes keep succeeding and its
+    // pings still reach a peer that dutifully answers them. Server→client is drained
+    // but discarded once silenced, so the client hears nothing while its own send
+    // clock keeps advancing — the exact shape of the bug.
+    let (mut client_rx, mut client_tx) = tokio::io::split(proxy_client);
+    let (mut server_rx, mut server_tx) = tokio::io::split(proxy_server);
+    let upstream =
+        tokio::spawn(async move { tokio::io::copy(&mut client_rx, &mut server_tx).await });
+    let downstream = tokio::spawn({
+        let silenced = silenced.clone();
+        async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = match server_rx.read(&mut buf).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => n,
+                };
+                if silenced.load(Ordering::Relaxed) {
+                    continue;
+                }
+                if client_tx.write_all(&buf[..n]).await.is_err() {
+                    return;
+                }
+            }
+        }
+    });
+
+    let mut config = Config::new(Version::QMux01);
+    config.max_idle_timeout = 150;
+    let ta = Stream::new(client_io, config.version, config.max_record_size);
+    let tb = Stream::new(server_io, config.version, config.max_record_size);
+    let (client, server) = tokio::join!(
+        Session::connect(ta, config.clone()),
+        Session::accept(tb, config),
+    );
+    let client = client.unwrap();
+    let _server = server.unwrap();
+
+    silenced.store(true, Ordering::Relaxed);
+
+    // One idle window to notice, plus at most one more for the send credit.
+    let reason = tokio::time::timeout(Duration::from_secs(1), client.closed())
+        .await
+        .expect("a silent peer must idle-close, even while our own sends land");
+    assert!(matches!(reason, Error::IdleTimeout), "got {reason:?}");
+
+    upstream.abort();
+    downstream.abort();
+}


### PR DESCRIPTION
## Summary

- The idle deadline was `max(last_recv_at, last_send_at)` (#303), which made it unreachable. The keep-alive ping goes out every `idle/3` and advances `last_send_at`, so it restarted the very deadline it exists to test.
- Root cause of the visible damage: a peer that goes silent while its socket still accepts our writes (crashed host, dropped network, wedged process) was never reclaimed, and neither was anything the session owned. Downstream this showed up as a relay announcing a publisher's broadcasts for hours after it was gone, cluster-wide.
- Rather than reverting #303, this adopts the RFC 9000 §10.1 proviso: a receive always restarts the timer, and a send restarts it only if the peer has been heard from since the last send-driven restart. A mostly one-way sender still stays open — its peer answers the keep-alive and each answer re-arms the credit — but we can no longer hold a dead session open by talking to ourselves. Worst case a silent peer is reclaimed within two idle windows instead of never.
- Applied to Rust and JS, since `js/qmux` mirrors the same deadline.

This is the transport-layer half of moq-dev/moq#2471, which added `KeepAlive` to the relay's WebSocket upgrade. That knob only exists on the WebSocket transport; `uds` and `tcp` have nothing but this timer, so they were fully exposed.

## Public API changes

None. `IdleActivity` is private; `Config`, `KeepAlive`, and the `Session` surface are untouched. The behavior change is that a silent peer is now closed with `Error::IdleTimeout` where it previously hung.

## Test plan

Two tests changed rather than being added: `send_progress_averts_idle_close` (Rust) and `"outbound frame activity resets the idle timeout"` (JS) both asserted the old behavior using a peer that answered *nothing* — i.e. the dead-peer case this fixes. Both now model a peer that does answer, which is what a real one-way sender faces.

- New `session::timer_tests::idle_close_when_peer_silent_despite_our_sends`: drives `TimerState` with the send clock advancing and the receive clock frozen. Fails without the fix (`Elapsed`).
- New `qmux01_silent_peer_is_idle_closed`: full session over a proxied duplex pair; client→server keeps flowing (so its writes land and its pings are answered) while server→client is drained and discarded. Asserts `Error::IdleTimeout`. Fails without the fix (`Elapsed`).
- New JS `"a silent peer idle-closes even while our own writes land"`. Fails without the fix (5s timeout).
- `cargo test -p qmux`: 146 passed across lib + all integration targets, including `qmux01_ping_keeps_idle_session_alive` and `qmux02_ping_keeps_idle_session_alive` (the healthy-peer controls) and `idle_timeout_deferred_but_bounded_under_backpressure`.
- `bun test js/qmux/src/session.test.ts`: 55 passed.
- `cargo clippy -p qmux --all-targets --all-features` and `cargo fmt --check` clean; `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)