### PR TITLE
feat(qmux): carry stream reset codes in both directions

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -79,6 +79,29 @@ try {
 Don't reach for `closeCode` to tell the two apart — close codes are application-defined, so an app
 closing with `1006` is indistinguishable from a dropped socket. The settled state is the signal.
 
+### Stream reset codes
+
+A reset carries an application error code in both directions, like native WebTransport:
+
+```ts
+import { StreamError } from "@moq/qmux"
+
+// Send RESET_STREAM with code 26.
+await stream.writable.abort(new StreamError("RESET_STREAM", 26))
+
+// Receive one: the code is a field, not text buried in the message.
+try {
+	await reader.read()
+} catch (err) {
+	// err.source === "stream"
+	console.warn("reset by peer with code", err.streamErrorCode)
+}
+```
+
+The outgoing code comes off the reason passed to `abort()` / `cancel()`, so any `WebTransportError`
+(native or the exported `StreamError`) sends its `streamErrorCode` and anything else sends 0.
+`STOP_SENDING` works the same way, erroring the sender's writable with the code the peer chose.
+
 ### Polyfill
 
 Install as a global `WebTransport` polyfill:

--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -87,7 +87,7 @@ A reset carries an application error code in both directions, like native WebTra
 import { StreamError } from "@moq/qmux"
 
 // Send RESET_STREAM with code 26.
-await stream.writable.abort(new StreamError("RESET_STREAM", 26))
+await stream.writable.abort(new StreamError(26))
 
 // Receive one: the code is a field, not text buried in the message.
 try {

--- a/js/qmux/src/error.test.ts
+++ b/js/qmux/src/error.test.ts
@@ -1,12 +1,16 @@
 import { expect, test } from "bun:test";
-import { resetCode, SessionError, StreamError } from "./error.ts";
+import { resetCode, SessionError, StreamError, streamCode } from "./error.ts";
 
 test("StreamError is shaped like a stream-source WebTransportError", () => {
-	const err = new StreamError("RESET_STREAM", 26);
+	const err = new StreamError(26, "RESET_STREAM");
 	expect(err.name).toBe("WebTransportError");
 	expect(err.source).toBe("stream");
 	expect(err.streamErrorCode).toBe(26);
 	expect(err.message).toBe("RESET_STREAM: 26");
+});
+
+test("StreamError needs only a code, for sending one of your own", () => {
+	expect(new StreamError(26).message).toBe("stream reset: 26");
 });
 
 test("SessionError has no stream code", () => {
@@ -14,7 +18,7 @@ test("SessionError has no stream code", () => {
 });
 
 test("resetCode: reads the code off a WebTransportError-shaped reason", () => {
-	expect(resetCode(new StreamError("RESET_STREAM", 2))).toBe(2);
+	expect(resetCode(new StreamError(2, "RESET_STREAM"))).toBe(2);
 	expect(resetCode({ streamErrorCode: 31 })).toBe(31);
 });
 
@@ -29,4 +33,12 @@ test("resetCode: anything without a code resets with 0", () => {
 test("resetCode: wraps to unsigned 32-bit like the IDL type", () => {
 	expect(resetCode({ streamErrorCode: -1 })).toBe(0xffffffff);
 	expect(resetCode({ streamErrorCode: 2 ** 32 })).toBe(0);
+});
+
+test("streamCode: narrows a varint off the wire to an unsigned 32-bit code", () => {
+	expect(streamCode(26n)).toBe(26);
+	// A peer can encode a code far wider than the IDL type, and wider than Number holds
+	// exactly. Truncating keeps streamErrorCode a value the WebTransport API can represent.
+	expect(streamCode((1n << 62n) - 1n)).toBe(0xffffffff);
+	expect(streamCode(1n << 32n)).toBe(0);
 });

--- a/js/qmux/src/error.test.ts
+++ b/js/qmux/src/error.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { resetCode, SessionError, StreamError } from "./error.ts";
+
+test("StreamError is shaped like a stream-source WebTransportError", () => {
+	const err = new StreamError("RESET_STREAM", 26);
+	expect(err.name).toBe("WebTransportError");
+	expect(err.source).toBe("stream");
+	expect(err.streamErrorCode).toBe(26);
+	expect(err.message).toBe("RESET_STREAM: 26");
+});
+
+test("SessionError has no stream code", () => {
+	expect(new SessionError("idle timeout").streamErrorCode).toBeNull();
+});
+
+test("resetCode: reads the code off a WebTransportError-shaped reason", () => {
+	expect(resetCode(new StreamError("RESET_STREAM", 2))).toBe(2);
+	expect(resetCode({ streamErrorCode: 31 })).toBe(31);
+});
+
+test("resetCode: anything without a code resets with 0", () => {
+	expect(resetCode(new Error("cancel"))).toBe(0);
+	expect(resetCode(undefined)).toBe(0);
+	expect(resetCode("nope")).toBe(0);
+	expect(resetCode({ streamErrorCode: null })).toBe(0);
+	expect(resetCode({ streamErrorCode: Number.NaN })).toBe(0);
+});
+
+test("resetCode: wraps to unsigned 32-bit like the IDL type", () => {
+	expect(resetCode({ streamErrorCode: -1 })).toBe(0xffffffff);
+	expect(resetCode({ streamErrorCode: 2 ** 32 })).toBe(0);
+});

--- a/js/qmux/src/error.ts
+++ b/js/qmux/src/error.ts
@@ -19,19 +19,19 @@ export class SessionError extends Error implements Pick<WebTransportError, "sour
 	}
 }
 
-/** A stream reset by the peer, shaped like the `WebTransportError` the WebTransport spec
- *  requires a reset stream to error with.
+/** A stream reset, shaped like the `WebTransportError` the WebTransport spec requires a reset
+ *  stream to error with. Pass one to `abort()` / `cancel()` to send a code of your own.
  *
  *  Same reasoning as {@link SessionError}: mint our own rather than reach for a global the
- *  runnning environment does not have. The code the peer sent is the whole point of this
- *  error, so it goes in `streamErrorCode` where a consumer already looks for it, rather
+ *  running environment does not have. The code is the whole point of this error, so it leads
+ *  the constructor and goes in `streamErrorCode` where a consumer already looks for it, rather
  *  than being formatted into the message and lost.
  */
 export class StreamError extends Error implements Pick<WebTransportError, "source" | "streamErrorCode"> {
 	readonly source = "stream" as const;
 	readonly streamErrorCode: number;
 
-	constructor(message: string, code: number) {
+	constructor(code: number, message = "stream reset") {
 		super(`${message}: ${code}`);
 		this.name = "WebTransportError";
 		this.streamErrorCode = code;
@@ -49,8 +49,19 @@ export function resetCode(reason: unknown): number {
 	if (typeof reason !== "object" || reason === null) return 0;
 
 	const { streamErrorCode } = reason as { streamErrorCode?: unknown };
-	if (typeof streamErrorCode !== "number" || !Number.isFinite(streamErrorCode)) return 0;
+	if (typeof streamErrorCode !== "number") return 0;
 
-	// The IDL type is `unsigned long`, so wrap like the platform would.
+	// The IDL type is `unsigned long`, so wrap like the platform would. This also folds a
+	// fractional or non-finite value to an integer rather than putting it on the wire.
 	return streamErrorCode >>> 0;
+}
+
+/** Narrow a code off the wire to the `unsigned long` a `streamErrorCode` is.
+ *
+ *  A frame's code is a varint, so a peer can encode one far wider than the IDL type (and wider
+ *  than `Number` holds exactly). Truncating keeps `streamErrorCode` a value the WebTransport
+ *  API can actually represent, and matches what {@link resetCode} puts on the wire.
+ */
+export function streamCode(code: bigint): number {
+	return Number(BigInt.asUintN(32, code));
 }

--- a/js/qmux/src/error.ts
+++ b/js/qmux/src/error.ts
@@ -18,3 +18,39 @@ export class SessionError extends Error implements Pick<WebTransportError, "sour
 		this.name = "WebTransportError";
 	}
 }
+
+/** A stream reset by the peer, shaped like the `WebTransportError` the WebTransport spec
+ *  requires a reset stream to error with.
+ *
+ *  Same reasoning as {@link SessionError}: mint our own rather than reach for a global the
+ *  runnning environment does not have. The code the peer sent is the whole point of this
+ *  error, so it goes in `streamErrorCode` where a consumer already looks for it, rather
+ *  than being formatted into the message and lost.
+ */
+export class StreamError extends Error implements Pick<WebTransportError, "source" | "streamErrorCode"> {
+	readonly source = "stream" as const;
+	readonly streamErrorCode: number;
+
+	constructor(message: string, code: number) {
+		super(`${message}: ${code}`);
+		this.name = "WebTransportError";
+		this.streamErrorCode = code;
+	}
+}
+
+/** The application error code a reset `reason` carries onto the wire.
+ *
+ *  The WebTransport spec derives the RESET_STREAM / STOP_SENDING code from the reason passed
+ *  to `abort()` / `cancel()`: a `WebTransportError`'s `streamErrorCode`, or 0 for anything
+ *  else, including no reason at all. Matched by field rather than by class so both a native
+ *  `WebTransportError` and one of ours work.
+ */
+export function resetCode(reason: unknown): number {
+	if (typeof reason !== "object" || reason === null) return 0;
+
+	const { streamErrorCode } = reason as { streamErrorCode?: unknown };
+	if (typeof streamErrorCode !== "number" || !Number.isFinite(streamErrorCode)) return 0;
+
+	// The IDL type is `unsigned long`, so wrap like the platform would.
+	return streamErrorCode >>> 0;
+}

--- a/js/qmux/src/index.ts
+++ b/js/qmux/src/index.ts
@@ -1,7 +1,7 @@
 import type { Version } from "./session.ts";
 import Session from "./session.ts";
 
-export { SessionError } from "./error.ts";
+export { SessionError, StreamError } from "./error.ts";
 export type { AcceptOptions, Config, SessionOptions, Version } from "./session.ts";
 export { selectSubprotocol } from "./session.ts";
 

--- a/js/qmux/src/recv.ts
+++ b/js/qmux/src/recv.ts
@@ -26,14 +26,15 @@ export class RecvStream {
 	/**
 	 * @param onConsume Invoked with each chunk's byte length as it is delivered
 	 *   to the reader. Drives MAX_STREAM_DATA.
-	 * @param onCancel Invoked with the number of discarded buffered bytes when the
-	 *   application cancels the readable (→ STOP_SENDING).
+	 * @param onCancel Invoked with the number of discarded buffered bytes, and the reason the
+	 *   application passed to `cancel()`, when the application cancels the readable
+	 *   (→ STOP_SENDING, whose code comes from that reason).
 	 * @param onTerminal Invoked once when FIN, RESET_STREAM, or local cancellation
 	 *   makes the receive side terminal.
 	 */
 	constructor(
 		onConsume: (bytes: number) => void,
-		onCancel: (discarded: number) => void,
+		onCancel: (discarded: number, reason: unknown) => void,
 		onTerminal: () => void = () => {},
 	) {
 		this.#onTerminal = onTerminal;
@@ -61,9 +62,9 @@ export class RecvStream {
 					// an unaccepted stream's hidden ReadableStream queue.
 					onConsume(chunk.byteLength);
 				},
-				cancel: () => {
+				cancel: (reason: unknown) => {
 					this.#error ??= new Error("stream cancelled");
-					onCancel(this.#discard());
+					onCancel(this.#discard(), reason);
 					this.#notifyTerminal();
 					this.#signal();
 				},

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -286,7 +286,7 @@ describe("Session integration (scripted peer)", () => {
 		peer.send({ type: "transport_parameters", params: peerParams() });
 
 		const writable = await session.createUnidirectionalStream();
-		await writable.abort(new StreamError("RESET_STREAM", 26));
+		await writable.abort(new StreamError(26, "RESET_STREAM"));
 
 		await waitFor(() => peer.has("reset_stream"));
 		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
@@ -319,7 +319,7 @@ describe("Session integration (scripted peer)", () => {
 		const reader = session.incomingUnidirectionalStreams.getReader();
 		const incoming = await reader.read();
 		if (!incoming.value) throw new Error("expected an incoming stream");
-		await incoming.value.cancel(new StreamError("STOP_SENDING", 2));
+		await incoming.value.cancel(new StreamError(2, "STOP_SENDING"));
 
 		await waitFor(() => peer.has("stop_sending"));
 		const stop = peer.received().find((f) => f.type === "stop_sending") as Frame.StopSending;

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { WebSocketLike, WebSocketStreamLike } from "@moq/web-socket-stream";
-import { SessionError } from "./error.ts";
+import { SessionError, StreamError } from "./error.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_MAX_RECORD_SIZE, type TransportParams } from "./frame.ts";
 import Session, { type Config } from "./session.ts";
@@ -277,6 +277,104 @@ describe("Session integration (scripted peer)", () => {
 		await waitFor(() => peer.has("reset_stream"));
 		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
 		expect(reset.finalSize).toBe(3n);
+		session.close();
+	});
+
+	test("aborting with a WebTransportError sends its streamErrorCode", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.abort(new StreamError("RESET_STREAM", 26));
+
+		await waitFor(() => peer.has("reset_stream"));
+		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
+		expect(reset.code.value).toBe(26n);
+		session.close();
+	});
+
+	test("aborting with a plain error sends code 0", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.abort(new Error("cancel"));
+
+		await waitFor(() => peer.has("reset_stream"));
+		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
+		expect(reset.code.value).toBe(0n);
+		session.close();
+	});
+
+	test("cancelling with a WebTransportError sends its streamErrorCode as STOP_SENDING", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		peer.send({ type: "stream", id, data: new Uint8Array([1, 2, 3]), fin: false });
+
+		const reader = session.incomingUnidirectionalStreams.getReader();
+		const incoming = await reader.read();
+		if (!incoming.value) throw new Error("expected an incoming stream");
+		await incoming.value.cancel(new StreamError("STOP_SENDING", 2));
+
+		await waitFor(() => peer.has("stop_sending"));
+		const stop = peer.received().find((f) => f.type === "stop_sending") as Frame.StopSending;
+		expect(stop.code.value).toBe(2n);
+		session.close();
+	});
+
+	test("a received RESET_STREAM errors the readable with the peer's code", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		peer.send({ type: "stream", id, data: new Uint8Array([1, 2, 3]), fin: false });
+
+		const reader = session.incomingUnidirectionalStreams.getReader();
+		const incoming = await reader.read();
+		if (!incoming.value) throw new Error("expected an incoming stream");
+
+		// Drain what arrived before the reset, so the next read is the one that observes it.
+		const stream = incoming.value.getReader();
+		expect((await stream.read()).value).toEqual(new Uint8Array([1, 2, 3]));
+
+		peer.send({ type: "reset_stream", id, code: VarInt.from(31), finalSize: 3n });
+
+		// The code is the point: an application distinguishing "cancelled, move on" from
+		// "data is missing" reads it off the error rather than parsing the message.
+		const err = await stream.read().then(
+			() => undefined,
+			(e: unknown) => e,
+		);
+		expect(err).toBeInstanceOf(StreamError);
+		expect((err as StreamError).source).toBe("stream");
+		expect((err as StreamError).streamErrorCode).toBe(31);
+		session.close();
+	});
+
+	test("a received STOP_SENDING errors the writable with the peer's code", async () => {
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		const writer = writable.getWriter();
+		await writer.write(new Uint8Array([1, 2, 3]));
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, false);
+		peer.send({ type: "stop_sending", id, code: VarInt.from(2) });
+
+		const err = await writer.closed.then(
+			() => undefined,
+			(e: unknown) => e,
+		);
+		expect(err).toBeInstanceOf(StreamError);
+		expect((err as StreamError).streamErrorCode).toBe(2);
 		session.close();
 	});
 

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -5,7 +5,7 @@ import {
 	type WebSocketStreamLike,
 } from "@moq/web-socket-stream";
 import { Credit, replenishWindow } from "./credit.ts";
-import { SessionError } from "./error.ts";
+import { resetCode, SessionError, StreamError } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
@@ -1341,12 +1341,12 @@ export default class Session implements WebTransport {
 					this.#accountStreamConsumed(streamId, bytes);
 					this.#accountConnConsumed(bytes);
 				},
-				(discarded) => {
+				(discarded, reason) => {
 					this.#accountConnConsumed(discarded);
 					this.#sendPriorityFrame({
 						type: "stop_sending",
 						id: frame.id,
-						code: VarInt.from(0),
+						code: VarInt.from(resetCode(reason)),
 					});
 
 					this.#recvStreams.delete(streamId);
@@ -1377,7 +1377,7 @@ export default class Session implements WebTransport {
 						this.#sendPriorityFrame({
 							type: "reset_stream",
 							id: frame.id,
-							code: VarInt.from(0),
+							code: VarInt.from(resetCode(e)),
 							finalSize: this.#sendFinalSize(streamId),
 						});
 
@@ -1480,7 +1480,7 @@ export default class Session implements WebTransport {
 			return;
 		}
 
-		const discarded = recv.reset(new Error(`RESET_STREAM: ${frame.code.value}`));
+		const discarded = recv.reset(new StreamError("RESET_STREAM", Number(frame.code.value)));
 		this.#accountConnConsumed(resetGap + BigInt(discarded));
 		this.#recvStreams.delete(streamId);
 		this.#maybeDeleteStreamFlow(streamId);
@@ -1491,9 +1491,10 @@ export default class Session implements WebTransport {
 		const stream = this.#sendStreams.get(streamId);
 		if (!stream) return;
 
-		stream.error(new Error(`STOP_SENDING: ${frame.code.value}`));
+		const stopped = new StreamError("STOP_SENDING", Number(frame.code.value));
+		stream.error(stopped);
 		this.#sendStreams.delete(streamId);
-		this.#scheduler?.dropStream(streamId, new Error(`STOP_SENDING: ${frame.code.value}`));
+		this.#scheduler?.dropStream(streamId, stopped);
 
 		this.#sendPriorityFrame({
 			type: "reset_stream",
@@ -1685,7 +1686,7 @@ export default class Session implements WebTransport {
 				this.#sendPriorityFrame({
 					type: "reset_stream",
 					id: streamId,
-					code: VarInt.from(0),
+					code: VarInt.from(resetCode(e)),
 					finalSize: this.#sendFinalSize(streamIdVal),
 				});
 
@@ -1707,12 +1708,12 @@ export default class Session implements WebTransport {
 				this.#accountStreamConsumed(streamIdVal, bytes);
 				this.#accountConnConsumed(bytes);
 			},
-			(discarded) => {
+			(discarded, reason) => {
 				this.#accountConnConsumed(discarded);
 				this.#sendPriorityFrame({
 					type: "stop_sending",
 					id: streamId,
-					code: VarInt.from(0),
+					code: VarInt.from(resetCode(reason)),
 				});
 
 				this.#recvStreams.delete(streamIdVal);
@@ -1765,7 +1766,7 @@ export default class Session implements WebTransport {
 				session.#sendPriorityFrame({
 					type: "reset_stream",
 					id: streamId,
-					code: VarInt.from(0),
+					code: VarInt.from(resetCode(e)),
 					finalSize: session.#sendFinalSize(streamIdVal),
 				});
 

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -5,7 +5,7 @@ import {
 	type WebSocketStreamLike,
 } from "@moq/web-socket-stream";
 import { Credit, replenishWindow } from "./credit.ts";
-import { resetCode, SessionError, StreamError } from "./error.ts";
+import { resetCode, SessionError, StreamError, streamCode } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
 import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
@@ -1480,7 +1480,7 @@ export default class Session implements WebTransport {
 			return;
 		}
 
-		const discarded = recv.reset(new StreamError("RESET_STREAM", Number(frame.code.value)));
+		const discarded = recv.reset(new StreamError(streamCode(frame.code.value), "RESET_STREAM"));
 		this.#accountConnConsumed(resetGap + BigInt(discarded));
 		this.#recvStreams.delete(streamId);
 		this.#maybeDeleteStreamFlow(streamId);
@@ -1491,7 +1491,7 @@ export default class Session implements WebTransport {
 		const stream = this.#sendStreams.get(streamId);
 		if (!stream) return;
 
-		const stopped = new StreamError("STOP_SENDING", Number(frame.code.value));
+		const stopped = new StreamError(streamCode(frame.code.value), "STOP_SENDING");
 		stream.error(stopped);
 		this.#sendStreams.delete(streamId);
 		this.#scheduler?.dropStream(streamId, stopped);


### PR DESCRIPTION
## Summary

- A RESET_STREAM / STOP_SENDING code was dropped at both boundaries. Incoming resets errored the stream with a plain `Error` whose message was `RESET_STREAM: <code>`, so recovering the code meant regexing a string. Outgoing resets hardcoded `VarInt.from(0)` at all five send sites, ignoring the reason passed to `abort()` / `cancel()`.
- Both directions now follow the WebTransport contract. `StreamError` is a `WebTransportError`-shaped error (`name: "WebTransportError"`, `source: "stream"`, the peer's code in `streamErrorCode`), mirroring the existing `SessionError`. `resetCode()` reads the outgoing code back off the reason, so a native `WebTransportError` or a `StreamError` sends its `streamErrorCode` and anything else sends 0.
- Codes stay raw u32 on the wire, matching `rs/qmux` (`SendStream::reset(code)` sends the code unmapped, and `Error::{StreamReset,StreamStop}` surfaces it unmapped), so a JS peer and a Rust peer agree. An incoming code is a varint, so it is truncated to 32 bits (`streamCode`) rather than handed over as a `Number` too wide for the IDL type to represent, matching the checked conversion `rs/qmux` does.

This unblocks moq-dev/moq#2508: `@moq/net` can decode a peer's reset code portably only if the WebSocket fallback exposes it as a field rather than as text.

## Public API changes

- Added: `StreamError` (exported from `@moq/qmux`), constructed as `new StreamError(code, message?)` so sending a code of your own is just `new StreamError(26)`.
- Internal, not exported from the entrypoint: `resetCode()`, `streamCode()`. `RecvStream`'s `onCancel` callback gained a `reason` parameter; `recv.ts` is never re-exported.
- No breaking changes: an incoming reset still rejects with an `Error`, whose message keeps its `RESET_STREAM: <code>` shape, now with the code in a field. An `abort()` with no code still sends 0.

## Test plan

- `bun run check`, `bun test src`: 145 pass (session tests covering send and receive for both frame types, unit tests for `StreamError`, `resetCode` including the unsigned-32-bit wrap, and `streamCode` including a 62-bit varint off the wire).
- `bun run fix` / `bun run --filter '*' check` clean.
- Not run: `just check` / `just test` in full (Rust untouched; the working tree has unrelated in-progress `web-transport-quiche` changes).

(Written by Opus 5)