### PR TITLE
fix(qmux): size STREAM frames from the negotiated max_record_size

### DIFF
--- a/js/qmux/src/frame.test.ts
+++ b/js/qmux/src/frame.test.ts
@@ -339,3 +339,49 @@ describe("QMux02 (draft-02)", () => {
 		expect(decoded[1].type).toBe("stream");
 	});
 });
+
+describe("maxStreamPayload", () => {
+	const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+
+	/** The encoded frame fills `budget` as tightly as the varint widths allow:
+	 *  one byte more would overrun it. */
+	function assertTight(budget: bigint, streamId: Stream.Id, offset: bigint) {
+		const payload = Frame.maxStreamPayload("qmux-01", budget, streamId, offset);
+		const framed = (n: bigint) =>
+			BigInt(1 + streamId.value.size() + VarInt.from(offset).size() + VarInt.from(n).size()) + n;
+
+		expect(framed(payload) <= budget).toBe(true);
+		expect(framed(payload + 1n) > budget).toBe(true);
+	}
+
+	test("fills the budget at varint boundaries", () => {
+		// Where the length field changes width, subtracting the width of the space
+		// left (rather than of the payload) leaves bytes unused: at 16387 that is
+		// 16380, but 16382 fits — its own length still encodes in two bytes.
+		for (let budget = 60n; budget <= 70n; budget++) assertTight(budget, id, 0n);
+		for (let budget = 16380n; budget <= 16392n; budget++) assertTight(budget, id, 0n);
+		expect(Frame.maxStreamPayload("qmux-01", 16387n, id, 0n)).toBe(16382n);
+	});
+
+	test("accounts for wider header fields", () => {
+		const wide = Stream.Id.create(1n << 20n, Stream.Dir.Uni, true);
+		assertTight(Frame.DEFAULT_MAX_RECORD_SIZE, wide, 1n << 20n);
+		expect(Frame.maxStreamPayload("qmux-01", Frame.DEFAULT_MAX_RECORD_SIZE, wide, 1n << 20n)).toBeLessThan(
+			Frame.maxStreamPayload("qmux-01", Frame.DEFAULT_MAX_RECORD_SIZE, id, 0n),
+		);
+	});
+
+	test("handles the largest advertised max_record_size", () => {
+		// max_record_size is a varint, so a peer may advertise 2^62-1 — a value
+		// `number` cannot hold exactly.
+		assertTight(VarInt.MAX, id, 0n);
+	});
+
+	test("the legacy binding reserves no length field", () => {
+		// The payload runs to the end of the message, so only the type byte and the
+		// stream ID come out of the budget.
+		expect(Frame.maxStreamPayload("webtransport", BigInt(Frame.MAX_FRAME_SIZE), id, 0n)).toBe(
+			BigInt(Frame.MAX_FRAME_SIZE) - 2n,
+		);
+	});
+});

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -16,6 +16,14 @@ export type WireFormat = "webtransport" | "qmux-00" | "qmux-01" | "qmux-02";
  * only bounds draft-00 and the legacy WebTransport binding. */
 export const MAX_FRAME_SIZE = 16384;
 
+/** Send-only compatibility ceiling for STREAM payloads on the currently
+ * supported wire formats.
+ *
+ * Released peers historically enforce this value on receive. A future QMux wire
+ * version can remove the ceiling once it cannot negotiate with those peers.
+ * Never use this value to validate inbound frames. */
+export const MAX_FRAME_PAYLOAD = MAX_FRAME_SIZE - 32;
+
 /** Largest value each varint width encodes (RFC 9000 §16). */
 const VARINT_MAX = [63n, 16383n, 1073741823n, 4611686018427387903n];
 
@@ -45,7 +53,8 @@ function maxLengthPrefixedPayload(available: bigint): bigint {
  * the record-framed drafts, {@link MAX_FRAME_SIZE} otherwise — so the frame's own
  * header comes out of it: the type, the stream ID, and (QMux only) the offset and
  * the length varint. Header widths are the ones this frame actually encodes, not
- * a worst-case reservation, so a chunk fills the record the peer advertised.
+ * a worst-case reservation. The session applies any send-only compatibility
+ * ceiling after calculating this exact peer budget.
  *
  * `budget` and the result are `bigint`: `max_record_size` is a varint, so a peer
  * may advertise up to 2^62-1, which `number` cannot hold exactly. */

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -16,26 +16,51 @@ export type WireFormat = "webtransport" | "qmux-00" | "qmux-01" | "qmux-02";
  * only bounds draft-00 and the legacy WebTransport binding. */
 export const MAX_FRAME_SIZE = 16384;
 
+/** Largest value each varint width encodes (RFC 9000 §16). */
+const VARINT_MAX = [63n, 16383n, 1073741823n, 4611686018427387903n];
+
+/** Largest `n` with `n + varint(n).size() <= available`.
+ *
+ * The length varint's width depends on the payload it describes, so this is a
+ * fixed point rather than a subtraction: at `available = 16384`, reserving four
+ * bytes (the width of 16384 itself) yields 16380, but 16382 fits — its length
+ * still encodes in two. Solve it by asking, for each width, what the largest
+ * payload that width can describe *and* leave room for is, then take the best. */
+function maxLengthPrefixedPayload(available: bigint): bigint {
+	let best = 0n;
+	for (const max of VARINT_MAX) {
+		const width = BigInt(VarInt.from(max).size());
+		if (available < width) break;
+		const candidate = available - width < max ? available - width : max;
+		// Skip a candidate this width cannot describe: a narrower varint means a
+		// smaller width already covered it, exactly.
+		if (VarInt.from(candidate).size() === Number(width) && candidate > best) best = candidate;
+	}
+	return best;
+}
+
 /** Largest STREAM payload that keeps the encoded frame within `budget` bytes.
  *
  * The budget is what the peer accepts for one frame — its `max_record_size` on
  * the record-framed drafts, {@link MAX_FRAME_SIZE} otherwise — so the frame's own
  * header comes out of it: the type, the stream ID, and (QMux only) the offset and
  * the length varint. Header widths are the ones this frame actually encodes, not
- * a worst-case reservation, so a chunk fills the record the peer advertised. */
-export function maxStreamPayload(version: WireFormat, budget: number, id: Stream.Id, offset: bigint): number {
+ * a worst-case reservation, so a chunk fills the record the peer advertised.
+ *
+ * `budget` and the result are `bigint`: `max_record_size` is a varint, so a peer
+ * may advertise up to 2^62-1, which `number` cannot hold exactly. */
+export function maxStreamPayload(version: WireFormat, budget: bigint, id: Stream.Id, offset: bigint): bigint {
+	// The type is 0x0e/0x0f on QMux and 0x08/0x09 on the legacy binding: one byte
+	// either way.
+	const header = BigInt(1 + id.value.size());
 	if (version === "webtransport") {
-		// One type byte plus the stream ID; the payload runs to the end of the
-		// message, so there is no length varint to reserve.
-		return Math.max(budget - (1 + id.value.size()), 0);
+		// The payload runs to the end of the message, so there is no length varint
+		// to reserve.
+		return budget > header ? budget - header : 0n;
 	}
 
-	// The type is 0x0e/0x0f, always one byte.
-	const available = Math.max(budget - (1 + id.value.size() + VarInt.from(offset).size()), 0);
-	// The length varint describes the payload, so size it from `available`: that
-	// bounds every payload that can still fit, and a varint is monotonic in its
-	// value, so no larger payload could use a shorter one.
-	return Math.max(available - VarInt.from(available).size(), 0);
+	const fixed = header + BigInt(VarInt.from(offset).size());
+	return maxLengthPrefixedPayload(budget > fixed ? budget - fixed : 0n);
 }
 
 export interface Data {

--- a/js/qmux/src/frame.ts
+++ b/js/qmux/src/frame.ts
@@ -9,11 +9,34 @@ import { VarInt } from "./varint.ts";
  */
 export type WireFormat = "webtransport" | "qmux-00" | "qmux-01" | "qmux-02";
 
-/** Maximum size of a single QMux frame on the wire. */
+/** Maximum size of a single QMux frame on the wire.
+ *
+ * This is draft-00's `max_frame_size`, which bounds the whole frame. The
+ * record-framed drafts supersede it with the negotiated `max_record_size`, so it
+ * only bounds draft-00 and the legacy WebTransport binding. */
 export const MAX_FRAME_SIZE = 16384;
 
-/** Maximum payload per STREAM frame, accounting for four 8-byte header varints. */
-export const MAX_FRAME_PAYLOAD = MAX_FRAME_SIZE - 32;
+/** Largest STREAM payload that keeps the encoded frame within `budget` bytes.
+ *
+ * The budget is what the peer accepts for one frame — its `max_record_size` on
+ * the record-framed drafts, {@link MAX_FRAME_SIZE} otherwise — so the frame's own
+ * header comes out of it: the type, the stream ID, and (QMux only) the offset and
+ * the length varint. Header widths are the ones this frame actually encodes, not
+ * a worst-case reservation, so a chunk fills the record the peer advertised. */
+export function maxStreamPayload(version: WireFormat, budget: number, id: Stream.Id, offset: bigint): number {
+	if (version === "webtransport") {
+		// One type byte plus the stream ID; the payload runs to the end of the
+		// message, so there is no length varint to reserve.
+		return Math.max(budget - (1 + id.value.size()), 0);
+	}
+
+	// The type is 0x0e/0x0f, always one byte.
+	const available = Math.max(budget - (1 + id.value.size() + VarInt.from(offset).size()), 0);
+	// The length varint describes the payload, so size it from `available`: that
+	// bounds every payload that can still fit, and a varint is monotonic in its
+	// value, so no larger payload could use a shorter one.
+	return Math.max(available - VarInt.from(available).size(), 0);
+}
 
 export interface Data {
 	type: "stream";

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1382,3 +1382,117 @@ describe("Session.accept (server role)", () => {
 		session.close();
 	});
 });
+
+// STREAM frame sizing. What we accept is bounded by the `max_record_size` we
+// advertised (enforced on the record, not on the frame inside it), and what we
+// send is bounded by the peer's — measured per frame, not by a fixed reservation.
+describe("STREAM frame size", () => {
+	afterEach(() => {
+		if (ORIGINAL_WSS === undefined) {
+			delete (globalThis as { WebSocketStream?: unknown }).WebSocketStream;
+		} else {
+			(globalThis as { WebSocketStream?: unknown }).WebSocketStream = ORIGINAL_WSS;
+		}
+	});
+
+	/** Read one incoming uni stream to completion. */
+	async function readIncomingUni(session: Session): Promise<Uint8Array> {
+		const incoming = await session.incomingUnidirectionalStreams.getReader().read();
+		if (!incoming.value) throw new Error("expected an incoming stream");
+		const reader = incoming.value.getReader();
+		const chunks: Uint8Array[] = [];
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+		}
+		const out = new Uint8Array(chunks.reduce((n, c) => n + c.byteLength, 0));
+		let offset = 0;
+		for (const chunk of chunks) {
+			out.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+		return out;
+	}
+
+	test("a record-sized STREAM frame is delivered", async () => {
+		// A 5-byte STREAM header plus 16377 payload bytes is a record of exactly the
+		// max_record_size we advertised: refusing it refuses the very size the
+		// handshake invited. A peer chunking at any other header budget — an older
+		// release, a third-party stack — lands somewhere in this range too.
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, true);
+		const data = new Uint8Array(Number(DEFAULT_MAX_RECORD_SIZE) - 5).fill(0x5a);
+		const frame: Frame.Data = { type: "stream", id, offset: 0n, data, fin: true };
+		expect(Frame.encode(frame, "qmux-01").byteLength).toBe(Number(DEFAULT_MAX_RECORD_SIZE));
+		peer.send(frame);
+
+		expect(await readIncomingUni(session)).toEqual(data);
+		session.close();
+	});
+
+	test("the legacy binding delivers a full-size frame", async () => {
+		// No record layer here, so the message is the frame; these bytes are
+		// unchanged across every release of this package.
+		const { session, peer } = accept({ protocol: "webtransport" });
+		await session.ready;
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, false);
+		const data = new Uint8Array(Frame.MAX_FRAME_SIZE - 2).fill(0x5a);
+		peer.sendRaw(Frame.encode({ type: "stream", id, data, fin: true }, "webtransport"));
+
+		expect(await readIncomingUni(session)).toEqual(data);
+		session.close();
+	});
+
+	test("a record over max_record_size closes the session", async () => {
+		// The record is the limit a peer can actually derive from the handshake, so
+		// it is the one worth enforcing — and a record too large to parse is a
+		// connection-level violation.
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		peer.sendRaw(new Uint8Array(Number(DEFAULT_MAX_RECORD_SIZE) + 1));
+
+		const err = await expectSessionFailure(session);
+		expect((err.cause as Error).message).toContain("max_record_size");
+		expect(sentCloseCode(peer)).toBe(1002);
+	});
+
+	test("we fill the record the peer advertised", async () => {
+		// The frame we emit has to reach the peer's limit: a fixed header
+		// reservation would leave the tail of every record unused.
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams() });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array(Number(DEFAULT_MAX_RECORD_SIZE) * 2).fill(0x5a));
+
+		await waitFor(() => peer.has("stream"));
+		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
+		expect(records[0].byteLength).toBe(Number(DEFAULT_MAX_RECORD_SIZE));
+		session.close();
+	});
+
+	test("we fill a larger record when the peer advertises one", async () => {
+		// The budget is the peer's, not a constant of ours, so a peer that accepts
+		// more gets larger records — and one that accepts less is never overrun.
+		const maxRecordSize = 32_768n;
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams({ maxRecordSize }) });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array(Number(maxRecordSize) * 2).fill(0x5a));
+
+		await waitFor(() => peer.has("stream"));
+		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
+		expect(records[0].byteLength).toBe(Number(maxRecordSize));
+		session.close();
+	});
+});

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1384,8 +1384,8 @@ describe("Session.accept (server role)", () => {
 });
 
 // STREAM frame sizing. What we accept is bounded by the `max_record_size` we
-// advertised (enforced on the record, not on the frame inside it), and what we
-// send is bounded by the peer's — measured per frame, not by a fixed reservation.
+// advertised (enforced on the record, not on the frame inside it). What we send
+// also keeps the compatibility ceiling required by released receivers.
 describe("STREAM frame size", () => {
 	afterEach(() => {
 		if (ORIGINAL_WSS === undefined) {
@@ -1498,9 +1498,7 @@ describe("STREAM frame size", () => {
 		expect(sentCloseCode(peer)).toBe(1002);
 	});
 
-	test("we fill the record the peer advertised", async () => {
-		// The frame we emit has to reach the peer's limit: a fixed header
-		// reservation would leave the tail of every record unused.
+	test("we keep STREAM payloads within the released-receiver ceiling", async () => {
 		const { session, peer } = connect();
 		await session.ready;
 		peer.send({ type: "transport_parameters", params: peerParams() });
@@ -1509,25 +1507,8 @@ describe("STREAM frame size", () => {
 		await writable.getWriter().write(new Uint8Array(Number(DEFAULT_MAX_RECORD_SIZE) * 2).fill(0x5a));
 
 		await waitFor(() => peer.has("stream"));
-		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
-		expect(records[0].byteLength).toBe(Number(DEFAULT_MAX_RECORD_SIZE));
-		session.close();
-	});
-
-	test("we fill a record whose size straddles a varint boundary", async () => {
-		// The length field describing the payload is narrower than one describing
-		// the space left for it, and those two bytes are usable.
-		const maxRecordSize = 16_387n;
-		const { session, peer } = connect();
-		await session.ready;
-		peer.send({ type: "transport_parameters", params: peerParams({ maxRecordSize }) });
-
-		const writable = await session.createUnidirectionalStream();
-		await writable.getWriter().write(new Uint8Array(Number(maxRecordSize) * 2).fill(0x5a));
-
-		await waitFor(() => peer.has("stream"));
-		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
-		expect(records[0].byteLength).toBe(Number(maxRecordSize));
+		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data;
+		expect(stream.data.byteLength).toBe(Frame.MAX_FRAME_PAYLOAD);
 		session.close();
 	});
 
@@ -1548,9 +1529,7 @@ describe("STREAM frame size", () => {
 		session.close();
 	});
 
-	test("we fill a larger record when the peer advertises one", async () => {
-		// The budget is the peer's, not a constant of ours, so a peer that accepts
-		// more gets larger records — and one that accepts less is never overrun.
+	test("a larger peer record limit does not bypass the compatibility ceiling", async () => {
 		const maxRecordSize = 32_768n;
 		const { session, peer } = connect();
 		await session.ready;
@@ -1560,8 +1539,8 @@ describe("STREAM frame size", () => {
 		await writable.getWriter().write(new Uint8Array(Number(maxRecordSize) * 2).fill(0x5a));
 
 		await waitFor(() => peer.has("stream"));
-		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
-		expect(records[0].byteLength).toBe(Number(maxRecordSize));
+		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data;
+		expect(stream.data.byteLength).toBe(Frame.MAX_FRAME_PAYLOAD);
 		session.close();
 	});
 });

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1434,6 +1434,40 @@ describe("STREAM frame size", () => {
 		session.close();
 	});
 
+	test("qmux-00 delivers a frame of exactly max_frame_size", async () => {
+		// draft-00 §5.2 bounds the whole frame, header included, so a 16384-byte
+		// frame is legal — and the parameter may only ever be raised.
+		const { session, peer } = accept({ protocol: "qmux-00" });
+		await session.ready;
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, false);
+		const data = new Uint8Array(Frame.MAX_FRAME_SIZE - 5).fill(0x5a);
+		const frame = Frame.encode({ type: "stream", id, offset: 0n, data, fin: true }, "qmux-00");
+		expect(frame.byteLength).toBe(Frame.MAX_FRAME_SIZE);
+		peer.sendRaw(frame);
+
+		expect(await readIncomingUni(session)).toEqual(data);
+		session.close();
+	});
+
+	test("a qmux-00 frame over max_frame_size closes the session", async () => {
+		// One byte past the limit is a frame-size violation, which draft-00 §5.2
+		// requires closing the connection over.
+		const { session, peer } = accept({ protocol: "qmux-00" });
+		await session.ready;
+
+		const id = Stream.Id.create(0n, Stream.Dir.Uni, false);
+		const data = new Uint8Array(Frame.MAX_FRAME_SIZE - 4).fill(0x5a);
+		const frame = Frame.encode({ type: "stream", id, offset: 0n, data, fin: true }, "qmux-00");
+		expect(frame.byteLength).toBe(Frame.MAX_FRAME_SIZE + 1);
+		peer.sendRaw(frame);
+
+		const err = await expectSessionFailure(session);
+		expect((err.cause as Error).message).toContain("max_frame_size");
+		await waitFor(() => sentCloseCode(peer) !== undefined);
+		expect(sentCloseCode(peer)).toBe(1002);
+	});
+
 	test("the legacy binding delivers a full-size frame", async () => {
 		// No record layer here, so the message is the frame; these bytes are
 		// unchanged across every release of this package.
@@ -1460,6 +1494,7 @@ describe("STREAM frame size", () => {
 
 		const err = await expectSessionFailure(session);
 		expect((err.cause as Error).message).toContain("max_record_size");
+		await waitFor(() => sentCloseCode(peer) !== undefined);
 		expect(sentCloseCode(peer)).toBe(1002);
 	});
 
@@ -1476,6 +1511,40 @@ describe("STREAM frame size", () => {
 		await waitFor(() => peer.has("stream"));
 		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
 		expect(records[0].byteLength).toBe(Number(DEFAULT_MAX_RECORD_SIZE));
+		session.close();
+	});
+
+	test("we fill a record whose size straddles a varint boundary", async () => {
+		// The length field describing the payload is narrower than one describing
+		// the space left for it, and those two bytes are usable.
+		const maxRecordSize = 16_387n;
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams({ maxRecordSize }) });
+
+		const writable = await session.createUnidirectionalStream();
+		await writable.getWriter().write(new Uint8Array(Number(maxRecordSize) * 2).fill(0x5a));
+
+		await waitFor(() => peer.has("stream"));
+		const records = peer.sent.filter((bytes) => Frame.decodeRecord(bytes).some((f) => f.type === "stream"));
+		expect(records[0].byteLength).toBe(Number(maxRecordSize));
+		session.close();
+	});
+
+	test("a peer advertising the largest max_record_size can still be written to", async () => {
+		// max_record_size is a varint, so 2^62-1 is legal — and is not a value
+		// `number` holds exactly, so the budget has to stay a bigint.
+		const { session, peer } = connect();
+		await session.ready;
+		peer.send({ type: "transport_parameters", params: peerParams({ maxRecordSize: VarInt.MAX }) });
+
+		const writable = await session.createUnidirectionalStream();
+		const data = new Uint8Array(1024).fill(0x5a);
+		await writable.getWriter().write(data);
+
+		await waitFor(() => peer.has("stream"));
+		const stream = peer.received().find((f) => f.type === "stream") as Frame.Data;
+		expect(stream.data).toEqual(data);
 		session.close();
 	});
 

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -840,6 +840,14 @@ export default class Session implements WebTransport {
 					this.#recvFrame(frame);
 				}
 			} else {
+				// draft-00 §5.2: `max_frame_size` bounds the whole frame, header
+				// included, and may only be raised from its initial value — which we
+				// never do, so the initial value is what a peer may send. Each message
+				// is one frame here. The legacy binding predates the parameter and
+				// negotiates nothing, so nothing bounds it.
+				if (this.#version === "qmux-00" && data.byteLength > Frame.MAX_FRAME_SIZE) {
+					throw new Error(`frame exceeds max_frame_size (${data.byteLength} > ${Frame.MAX_FRAME_SIZE})`);
+				}
 				const frame = Frame.decode(data, this.#version);
 				if (frame !== null) {
 					this.#recvFrame(frame);
@@ -1519,18 +1527,22 @@ export default class Session implements WebTransport {
 	 * TRANSPORT_PARAMETERS arrive, so we never send something it would reject).
 	 * draft-00 and the legacy binding have no record layer and negotiate nothing,
 	 * so draft-00's whole-frame `max_frame_size` stands in. */
-	#sendFrameBudget(): number {
-		if (!usesRecords(this.#version)) return Frame.MAX_FRAME_SIZE;
-		return Number(this.#paramsReceived ? this.#peerParams.maxRecordSize : Frame.DEFAULT_MAX_RECORD_SIZE);
+	#sendFrameBudget(): bigint {
+		if (!usesRecords(this.#version)) return BigInt(Frame.MAX_FRAME_SIZE);
+		return this.#paramsReceived ? this.#peerParams.maxRecordSize : Frame.DEFAULT_MAX_RECORD_SIZE;
 	}
 
-	/** The largest payload one STREAM frame at `offset` can carry to the peer. */
-	#maxStreamPayload(id: Stream.Id, offset: bigint): number {
+	/** The largest payload one STREAM frame at `offset` can carry to the peer.
+	 *
+	 * A `bigint`: the peer's `max_record_size` is a varint, so it can exceed what
+	 * `number` holds exactly. Callers clamp it to the bytes they actually have
+	 * before converting. */
+	#maxStreamPayload(id: Stream.Id, offset: bigint): bigint {
 		const max = Frame.maxStreamPayload(this.#version, this.#sendFrameBudget(), id, offset);
 		// Unreachable with a conforming peer: max_record_size is validated against
 		// the draft-01 minimum on arrival. Guard anyway — a zero budget would make
 		// the chunking loops below spin forever instead of failing.
-		if (max === 0) throw new Error("peer frame limit leaves no room for stream data");
+		if (max === 0n) throw new Error("peer frame limit leaves no room for stream data");
 		return max;
 	}
 
@@ -1560,10 +1572,11 @@ export default class Session implements WebTransport {
 		if (!flow) throw new Error(`missing flow state for stream ${streamId}`);
 
 		for (let offset = 0; offset < data.byteLength; ) {
-			const remaining = data.byteLength - offset;
+			const remaining = BigInt(data.byteLength - offset);
 			// Fill the frame the peer accepts, less this frame's own header. The
 			// offset varint grows as the stream advances, so size it per frame.
-			const chunkMax = Math.min(remaining, this.#maxStreamPayload(id, flow.sendOffset));
+			const payloadMax = this.#maxStreamPayload(id, flow.sendOffset);
+			const chunkMax = Number(payloadMax < remaining ? payloadMax : remaining);
 
 			// Claim flow control credit (stream + connection)
 			const allowed = await this.#claimSendCredit(streamId, BigInt(chunkMax));
@@ -1601,8 +1614,9 @@ export default class Session implements WebTransport {
 			await this.#sendStreamDataWithFlowControl(id, streamId, data);
 		} else {
 			// The legacy binding carries no offset field, so every frame's header —
-			// and therefore its payload budget — is the same size.
-			const chunkMax = this.#maxStreamPayload(id, 0n);
+			// and therefore its payload budget — is the same size. The budget is
+			// MAX_FRAME_SIZE there, so it always fits in a number.
+			const chunkMax = Number(this.#maxStreamPayload(id, 0n));
 			for (let offset = 0; offset < data.byteLength; offset += chunkMax) {
 				const end = Math.min(offset + chunkMax, data.byteLength);
 				const chunk = data.subarray(offset, end);

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -8,7 +8,7 @@ import { Credit, replenishWindow } from "./credit.ts";
 import { resetCode, SessionError, StreamError, streamCode } from "./error.ts";
 import type { TransportParams, WireFormat } from "./frame.ts";
 import * as Frame from "./frame.ts";
-import { DEFAULT_TRANSPORT_PARAMS, isQmux, MAX_FRAME_PAYLOAD, usesRecords } from "./frame.ts";
+import { DEFAULT_TRANSPORT_PARAMS, isQmux, usesRecords } from "./frame.ts";
 import { RecvStream } from "./recv.ts";
 import { DEFAULT_SEND_ORDER, SendScheduler, type SendSink, WritableStreamSink } from "./scheduler.ts";
 import * as Stream from "./stream.ts";
@@ -1250,12 +1250,6 @@ export default class Session implements WebTransport {
 		// #sendDatagram/#sendPriorityFrame post-close guards.
 		if (this.#closed) return;
 
-		if (frame.data.byteLength > MAX_FRAME_PAYLOAD) {
-			this.#sendConnectionClose(1002, "frame too large");
-			this.#abort(1002, "frame too large");
-			return;
-		}
-
 		const streamId = frame.id.value.value;
 
 		if (!frame.id.canRecv(this.#isServer)) {
@@ -1271,6 +1265,7 @@ export default class Session implements WebTransport {
 		) {
 			return;
 		}
+
 		if (!recv) {
 			// We created the stream, we can skip it.
 			if (frame.id.serverInitiated === this.#isServer) {
@@ -1517,6 +1512,28 @@ export default class Session implements WebTransport {
 		this.#sendPriorityFrame({ type: "transport_parameters", params: this.#ourParams });
 	}
 
+	/** The largest STREAM frame the peer accepts, in bytes.
+	 *
+	 * Record-framed drafts negotiate it: a frame rides in one record, so the
+	 * peer's `max_record_size` is the limit (the draft-01 default until its
+	 * TRANSPORT_PARAMETERS arrive, so we never send something it would reject).
+	 * draft-00 and the legacy binding have no record layer and negotiate nothing,
+	 * so draft-00's whole-frame `max_frame_size` stands in. */
+	#sendFrameBudget(): number {
+		if (!usesRecords(this.#version)) return Frame.MAX_FRAME_SIZE;
+		return Number(this.#paramsReceived ? this.#peerParams.maxRecordSize : Frame.DEFAULT_MAX_RECORD_SIZE);
+	}
+
+	/** The largest payload one STREAM frame at `offset` can carry to the peer. */
+	#maxStreamPayload(id: Stream.Id, offset: bigint): number {
+		const max = Frame.maxStreamPayload(this.#version, this.#sendFrameBudget(), id, offset);
+		// Unreachable with a conforming peer: max_record_size is validated against
+		// the draft-01 minimum on arrival. Guard anyway — a zero budget would make
+		// the chunking loops below spin forever instead of failing.
+		if (max === 0) throw new Error("peer frame limit leaves no room for stream data");
+		return max;
+	}
+
 	/** Validate an encoded record against the peer's max_record_size (QMux01+). */
 	#validateRecordSize(bytes: Uint8Array) {
 		if (usesRecords(this.#version)) {
@@ -1544,16 +1561,9 @@ export default class Session implements WebTransport {
 
 		for (let offset = 0; offset < data.byteLength; ) {
 			const remaining = data.byteLength - offset;
-			// Cap by both the static frame-payload ceiling and the peer's record limit
-			// (record-framed QMux only — once params are received). Leave 32 bytes of
-			// headroom for the STREAM frame header (type, stream ID, offset, and length).
-			let chunkMax = Math.min(remaining, MAX_FRAME_PAYLOAD);
-			if (usesRecords(this.#version) && this.#paramsReceived) {
-				const peerLimit = Number(this.#peerParams.maxRecordSize) - 32;
-				if (peerLimit > 0) {
-					chunkMax = Math.min(chunkMax, peerLimit);
-				}
-			}
+			// Fill the frame the peer accepts, less this frame's own header. The
+			// offset varint grows as the stream advances, so size it per frame.
+			const chunkMax = Math.min(remaining, this.#maxStreamPayload(id, flow.sendOffset));
 
 			// Claim flow control credit (stream + connection)
 			const allowed = await this.#claimSendCredit(streamId, BigInt(chunkMax));
@@ -1590,8 +1600,11 @@ export default class Session implements WebTransport {
 		if (isQmux(this.#version)) {
 			await this.#sendStreamDataWithFlowControl(id, streamId, data);
 		} else {
-			for (let offset = 0; offset < data.byteLength; offset += MAX_FRAME_PAYLOAD) {
-				const end = Math.min(offset + MAX_FRAME_PAYLOAD, data.byteLength);
+			// The legacy binding carries no offset field, so every frame's header —
+			// and therefore its payload budget — is the same size.
+			const chunkMax = this.#maxStreamPayload(id, 0n);
+			for (let offset = 0; offset < data.byteLength; offset += chunkMax) {
+				const end = Math.min(offset + chunkMax, data.byteLength);
 				const chunk = data.subarray(offset, end);
 				await this.#enqueueStreamFrame(streamId, { type: "stream", id, data: chunk, fin: false });
 			}

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1532,13 +1532,16 @@ export default class Session implements WebTransport {
 		return this.#paramsReceived ? this.#peerParams.maxRecordSize : Frame.DEFAULT_MAX_RECORD_SIZE;
 	}
 
-	/** The largest payload one STREAM frame at `offset` can carry to the peer.
+	/** The largest payload we may send in one STREAM frame at `offset`.
 	 *
-	 * A `bigint`: the peer's `max_record_size` is a varint, so it can exceed what
-	 * `number` holds exactly. Callers clamp it to the bytes they actually have
-	 * before converting. */
+	 * This respects the peer's frame budget and the send-only compatibility
+	 * ceiling for released receivers. A `bigint`: the peer's `max_record_size` is
+	 * a varint, so it can exceed what `number` holds exactly. Callers clamp it to
+	 * the bytes they actually have before converting. */
 	#maxStreamPayload(id: Stream.Id, offset: bigint): bigint {
-		const max = Frame.maxStreamPayload(this.#version, this.#sendFrameBudget(), id, offset);
+		const peerMax = Frame.maxStreamPayload(this.#version, this.#sendFrameBudget(), id, offset);
+		const compatibilityMax = BigInt(Frame.MAX_FRAME_PAYLOAD);
+		const max = peerMax < compatibilityMax ? peerMax : compatibilityMax;
 		// Unreachable with a conforming peer: max_record_size is validated against
 		// the draft-01 minimum on arrival. Guard anyway — a zero budget would make
 		// the chunking loops below spin forever instead of failing.
@@ -1573,8 +1576,8 @@ export default class Session implements WebTransport {
 
 		for (let offset = 0; offset < data.byteLength; ) {
 			const remaining = BigInt(data.byteLength - offset);
-			// Fill the frame the peer accepts, less this frame's own header. The
-			// offset varint grows as the stream advances, so size it per frame.
+			// Size from the peer's frame budget and this frame's actual header, then
+			// apply the compatibility ceiling for released receivers.
 			const payloadMax = this.#maxStreamPayload(id, flow.sendOffset);
 			const chunkMax = Number(payloadMax < remaining ? payloadMax : remaining);
 

--- a/rs/qmux/src/proto/mod.rs
+++ b/rs/qmux/src/proto/mod.rs
@@ -4,6 +4,8 @@ mod frame;
 mod params;
 mod version;
 
+use crate::StreamId;
+
 #[cfg(test)]
 mod wire_format_tests;
 
@@ -15,13 +17,35 @@ pub use version::*;
 pub use params::DEFAULT_MAX_RECORD_SIZE;
 
 /// Maximum size of a single QMux frame on the wire (type + fields + payload).
-/// For draft-00, this is the maximum frame size.
-/// For draft-01, this is superseded by max_record_size.
+///
+/// This is draft-00's `max_frame_size`, which bounds the whole frame. The
+/// record-framed drafts supersede it with the negotiated `max_record_size`, so it
+/// only bounds draft-00 and the legacy WebTransport binding.
 pub const MAX_FRAME_SIZE: usize = 16384;
 
-/// Maximum payload size for a STREAM frame, accounting for frame overhead.
-/// Overhead: frame type, stream ID, offset, and length (up to 8 bytes each).
-pub const MAX_FRAME_PAYLOAD: usize = MAX_FRAME_SIZE - 32;
+/// Largest STREAM payload that keeps the encoded frame within `budget` bytes.
+///
+/// The budget is what the peer accepts for one frame — its `max_record_size` on
+/// the record-framed drafts, [`MAX_FRAME_SIZE`] otherwise — so the frame's own
+/// header comes out of it: the type, the stream ID, and (QMux only) the offset and
+/// the length varint. Header widths are the ones this frame actually encodes, not
+/// a worst-case reservation, so a chunk fills the record the peer advertised.
+pub fn max_stream_payload(version: Version, budget: u64, id: StreamId, offset: u64) -> u64 {
+    // The type is 0x0e/0x0f on QMux and 0x08/0x09 on the legacy binding: one byte
+    // either way.
+    let header = 1 + varint_size(id.into_inner());
+    if !version.is_qmux() {
+        // The payload runs to the end of the message, so there is no length varint
+        // to reserve.
+        return budget.saturating_sub(header);
+    }
+
+    let available = budget.saturating_sub(header + varint_size(offset));
+    // The length varint describes the payload, so size it from `available`: that
+    // bounds every payload that can still fit, and a varint is monotonic in its
+    // value, so no larger payload could use a shorter one.
+    available.saturating_sub(varint_size(available))
+}
 
 /// Number of bytes a QUIC varint occupies when encoding `v`.
 pub(crate) const fn varint_size(v: u64) -> u64 {

--- a/rs/qmux/src/proto/mod.rs
+++ b/rs/qmux/src/proto/mod.rs
@@ -23,13 +23,22 @@ pub use params::DEFAULT_MAX_RECORD_SIZE;
 /// only bounds draft-00 and the legacy WebTransport binding.
 pub const MAX_FRAME_SIZE: usize = 16384;
 
+/// Send-only compatibility ceiling for STREAM payloads on the currently
+/// supported wire formats.
+///
+/// Released peers historically enforce this value on receive. A future QMux wire
+/// version can remove the ceiling once it cannot negotiate with those peers.
+/// Never use this value to validate inbound frames.
+pub const MAX_FRAME_PAYLOAD: usize = MAX_FRAME_SIZE - 32;
+
 /// Largest STREAM payload that keeps the encoded frame within `budget` bytes.
 ///
 /// The budget is what the peer accepts for one frame — its `max_record_size` on
 /// the record-framed drafts, [`MAX_FRAME_SIZE`] otherwise — so the frame's own
 /// header comes out of it: the type, the stream ID, and (QMux only) the offset and
 /// the length varint. Header widths are the ones this frame actually encodes, not
-/// a worst-case reservation, so a chunk fills the record the peer advertised.
+/// a worst-case reservation. The session applies any send-only compatibility
+/// ceiling after calculating this exact peer budget.
 pub fn max_stream_payload(version: Version, budget: u64, id: StreamId, offset: u64) -> u64 {
     // The type is 0x0e/0x0f on QMux and 0x08/0x09 on the legacy binding: one byte
     // either way.

--- a/rs/qmux/src/proto/mod.rs
+++ b/rs/qmux/src/proto/mod.rs
@@ -40,11 +40,34 @@ pub fn max_stream_payload(version: Version, budget: u64, id: StreamId, offset: u
         return budget.saturating_sub(header);
     }
 
-    let available = budget.saturating_sub(header + varint_size(offset));
-    // The length varint describes the payload, so size it from `available`: that
-    // bounds every payload that can still fit, and a varint is monotonic in its
-    // value, so no larger payload could use a shorter one.
-    available.saturating_sub(varint_size(available))
+    max_length_prefixed_payload(budget.saturating_sub(header + varint_size(offset)))
+}
+
+/// Largest `n` with `n + varint_size(n) <= available`.
+///
+/// The length varint's width depends on the payload it describes, so this is a
+/// fixed point rather than a subtraction: at `available == 16384`, reserving four
+/// bytes (the width of 16384 itself) yields 16380, but 16382 fits — its length
+/// still encodes in two. Solve it by asking, for each width, what the largest
+/// payload that width can describe *and* leave room for is, then take the best.
+fn max_length_prefixed_payload(available: u64) -> u64 {
+    /// Largest value each varint width encodes (RFC 9000 §16).
+    const VARINT_MAX: [u64; 4] = [63, 16383, (1 << 30) - 1, (1 << 62) - 1];
+
+    let mut best = 0;
+    for max in VARINT_MAX {
+        let width = varint_size(max);
+        if available < width {
+            break;
+        }
+        let candidate = (available - width).min(max);
+        // Skip a candidate this width cannot describe: a narrower varint means a
+        // smaller width already covered it, exactly.
+        if varint_size(candidate) == width && candidate > best {
+            best = candidate;
+        }
+    }
+    best
 }
 
 /// Number of bytes a QUIC varint occupies when encoding `v`.
@@ -57,5 +80,75 @@ pub(crate) const fn varint_size(v: u64) -> u64 {
         4
     } else {
         8
+    }
+}
+
+#[cfg(test)]
+mod max_stream_payload_tests {
+    use super::*;
+    use crate::{StreamDir, StreamId};
+    use web_transport_proto::VarInt;
+
+    /// The encoded frame must fill `budget` as tightly as the varint widths allow:
+    /// one byte more would overrun it, and the payload we return must be the
+    /// largest one that doesn't.
+    fn assert_tight(budget: u64, id: StreamId, offset: u64) {
+        let payload = max_stream_payload(Version::QMux01, budget, id, offset);
+        let framed =
+            |n: u64| 1 + varint_size(id.into_inner()) + varint_size(offset) + varint_size(n) + n;
+
+        assert!(
+            framed(payload) <= budget,
+            "budget {budget}: payload {payload} encodes to {}",
+            framed(payload)
+        );
+        assert!(
+            framed(payload + 1) > budget,
+            "budget {budget}: payload {} also fits, so {payload} under-fills",
+            payload + 1
+        );
+    }
+
+    /// Around each varint boundary the length field changes width, which is where
+    /// subtracting the width of `available` (rather than of the payload) leaves
+    /// bytes on the table: at a 16387 budget it yields 16380, but 16382 fits.
+    #[test]
+    fn fills_the_budget_at_varint_boundaries() {
+        let id = StreamId::new(0, StreamDir::Uni, true);
+        for budget in (60..=70).chain(16_380..=16_392) {
+            assert_tight(budget, id, 0);
+        }
+        assert_eq!(max_stream_payload(Version::QMux01, 16_387, id, 0), 16_382);
+    }
+
+    /// A wider stream ID or offset takes its bytes out of the same budget.
+    #[test]
+    fn accounts_for_wider_header_fields() {
+        let id = StreamId::new(0, StreamDir::Uni, true);
+        let wide = StreamId::new(1 << 20, StreamDir::Uni, true);
+        assert_tight(DEFAULT_MAX_RECORD_SIZE, wide, 1 << 20);
+        assert!(
+            max_stream_payload(Version::QMux01, DEFAULT_MAX_RECORD_SIZE, wide, 1 << 20)
+                < max_stream_payload(Version::QMux01, DEFAULT_MAX_RECORD_SIZE, id, 0)
+        );
+    }
+
+    /// `max_record_size` is a varint, so a peer may advertise up to 2^62-1. The
+    /// payload has to stay inside the budget without overflowing.
+    #[test]
+    fn handles_the_largest_advertised_record_size() {
+        let id = StreamId::new(0, StreamDir::Uni, true);
+        assert_tight(VarInt::MAX.into_inner(), id, 0);
+    }
+
+    /// The legacy binding has no length field: the payload runs to the end of the
+    /// message, so only the type and stream ID come out of the budget.
+    #[test]
+    fn legacy_binding_reserves_no_length() {
+        let id = StreamId::new(0, StreamDir::Uni, true);
+        assert_eq!(
+            max_stream_payload(Version::WebTransport, MAX_FRAME_SIZE as u64, id, 0),
+            MAX_FRAME_SIZE as u64 - 2
+        );
     }
 }

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -11,8 +11,9 @@ use crate::credit::Credit;
 use crate::sched::PriorityQueue;
 use crate::transport::{Reader, Transport, Writer};
 use crate::{
-    proto::varint_size, ApplicationClose, ConnectionClose, Error, Frame, ResetStream, StopSending,
-    Stream, StreamDir, StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD,
+    proto::{max_stream_payload, varint_size},
+    ApplicationClose, ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir,
+    StreamId, TransportParams, Version, MAX_FRAME_SIZE,
 };
 use bytes::{Buf, BufMut, Bytes};
 use tokio::sync::{mpsc, watch};
@@ -127,6 +128,11 @@ pub struct Session {
     // Resolved from the peer's transport parameters before the session is handed
     // to the caller (0 = the peer doesn't accept datagrams).
     datagram_max_size: Arc<AtomicUsize>,
+
+    // The peer's `max_record_size`, shared with the reader and writer tasks and
+    // handed to every `SendStream` we open so it can size its frames. Seeded with
+    // the draft-01 default until the peer's parameters arrive.
+    record_limit: Arc<AtomicU64>,
 
     // Closes the connection when the last `Session` clone drops. Never read.
     _guard: Arc<SessionGuard>,
@@ -618,6 +624,10 @@ mod writer_final_size_tests {
         let conn_credit = Credit::new(3);
         let mut send = SendStream {
             id,
+            version: crate::Version::QMux01,
+            record_limit: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+                crate::proto::DEFAULT_MAX_RECORD_SIZE,
+            )),
             outbound,
             outbound_priority: priority,
             inbound_stopped: stopped_rx,
@@ -916,10 +926,6 @@ impl<R: Reader> SessionState<R> {
                 self.recv_transport_parameters(params)?;
             }
             Frame::Stream(stream) => {
-                if stream.data.len() > MAX_FRAME_PAYLOAD {
-                    return Err(Error::FrameTooLarge);
-                }
-
                 if !stream.id.can_recv(self.is_server) {
                     return Err(Error::InvalidStreamId);
                 }
@@ -1077,6 +1083,8 @@ impl<R: Reader> SessionState<R> {
 
                         let send_frontend = SendStream {
                             id: stream.id,
+                            version: self.config.version,
+                            record_limit: self.record_limit.clone(),
                             outbound: self.outbound.clone(),
                             outbound_priority: self.control.clone(),
                             inbound_stopped: rx,
@@ -1775,6 +1783,7 @@ impl Session {
             conn_recv_credit,
             recv_datagram: Arc::new(tokio::sync::Mutex::new(recv_datagram_rx)),
             datagram_max_size,
+            record_limit,
             outbound_datagram: outbound_datagram_tx,
             _guard: guard,
         }
@@ -1825,6 +1834,8 @@ impl generic::Session for Session {
         };
         let send_frontend = SendStream {
             id,
+            version: self.config.version,
+            record_limit: self.record_limit.clone(),
             outbound: self.outbound.clone(),
             outbound_priority: self.outbound_priority.clone(),
             inbound_stopped: rx,
@@ -1880,6 +1891,8 @@ impl generic::Session for Session {
         };
         let send_frontend = SendStream {
             id,
+            version: self.config.version,
+            record_limit: self.record_limit.clone(),
             outbound: self.outbound.clone(),
             outbound_priority: self.outbound_priority.clone(),
             inbound_stopped: rx,
@@ -2031,6 +2044,12 @@ struct SendState {
 /// The send half of a multiplexed stream.
 pub struct SendStream {
     id: StreamId,
+    version: Version,
+
+    /// The peer's `max_record_size`, shared with the writer task: seeded with the
+    /// draft-01 default and raised once the peer's transport parameters arrive.
+    /// Unused on the wire formats that have no record layer.
+    record_limit: Arc<AtomicU64>,
 
     outbound: PriorityQueue,                         // STREAM
     outbound_priority: mpsc::UnboundedSender<Frame>, // RESET_STREAM
@@ -2049,6 +2068,20 @@ pub struct SendStream {
 }
 
 impl SendStream {
+    /// The largest STREAM frame the peer accepts, in bytes.
+    ///
+    /// Record-framed drafts negotiate it: a frame rides in one record, so the
+    /// peer's `max_record_size` is the limit. draft-00 and the legacy binding have
+    /// no record layer and negotiate nothing, so draft-00's whole-frame
+    /// `max_frame_size` stands in.
+    fn frame_budget(&self) -> u64 {
+        if self.version.uses_records() {
+            self.record_limit.load(Ordering::Acquire)
+        } else {
+            MAX_FRAME_SIZE as u64
+        }
+    }
+
     fn recv_stop(&mut self, code: VarInt) -> Error {
         if let Some(error) = &self.closed {
             return error.clone();
@@ -2169,7 +2202,16 @@ impl generic::SendStream for SendStream {
         let mut total = 0;
 
         while buf.has_remaining() {
-            let chunk_len = buf.chunk().len().min(MAX_FRAME_PAYLOAD) as u64;
+            // Fill the frame the peer accepts, less this frame's own header. The
+            // offset varint grows as the stream advances, so size it per frame.
+            let max_payload =
+                max_stream_payload(self.version, self.frame_budget(), self.id, self.offset);
+            if max_payload == 0 {
+                // Unreachable with a conforming peer: max_record_size is validated
+                // against the draft-01 minimum on arrival. Fail rather than loop.
+                return Err(Error::FrameTooLarge);
+            }
+            let chunk_len = (buf.chunk().len() as u64).min(max_payload);
 
             // Wait for queue capacity and flow-control credit *before* taking any
             // bytes out of `buf`. Callers race this future against other work (moq
@@ -2707,6 +2749,10 @@ mod send_offset_tests {
         let (_stop_tx, stop_rx) = mpsc::unbounded_channel();
         let mut send = SendStream {
             id,
+            version: crate::Version::QMux01,
+            record_limit: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+                crate::proto::DEFAULT_MAX_RECORD_SIZE,
+            )),
             outbound: outbound.clone(),
             outbound_priority: control,
             inbound_stopped: stop_rx,
@@ -2767,6 +2813,10 @@ mod write_cancel_tests {
         let (_stop_tx, stop_rx) = mpsc::unbounded_channel();
         SendStream {
             id: StreamId::new(0, StreamDir::Uni, false),
+            version: crate::Version::QMux01,
+            record_limit: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+                crate::proto::DEFAULT_MAX_RECORD_SIZE,
+            )),
             outbound,
             outbound_priority: control,
             inbound_stopped: stop_rx,
@@ -3234,6 +3284,237 @@ mod recv_open_tests {
             .expect("connection closed after legacy reset")
             .expect("accept_uni failed");
         assert_eq!(next.read_all().await.unwrap().as_ref(), b"ok");
+    }
+}
+
+// STREAM frame sizing. What we accept is bounded by the `max_record_size` we
+// advertised (enforced on the record, not on the frame inside it), and what we
+// send is bounded by the peer's — measured per frame, not by a fixed reservation.
+#[cfg(test)]
+mod stream_payload_tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use tokio::sync::mpsc;
+    use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
+
+    use super::{Reader, Session, Transport, Writer};
+    use crate::proto::{Frame, Stream, DEFAULT_MAX_RECORD_SIZE};
+    use crate::{Config, Error, StreamDir, StreamId, Version};
+
+    /// A scripted transport that also keeps every record the session wrote, so a
+    /// test can measure the frames it emitted.
+    struct ScriptedTransport {
+        incoming: mpsc::UnboundedReceiver<Bytes>,
+        outgoing: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    struct ScriptedWriter {
+        outgoing: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    struct ScriptedReader {
+        incoming: mpsc::UnboundedReceiver<Bytes>,
+    }
+
+    impl Transport for ScriptedTransport {
+        type Writer = ScriptedWriter;
+        type Reader = ScriptedReader;
+
+        fn split(self) -> (ScriptedWriter, ScriptedReader) {
+            (
+                ScriptedWriter {
+                    outgoing: self.outgoing,
+                },
+                ScriptedReader {
+                    incoming: self.incoming,
+                },
+            )
+        }
+    }
+
+    impl Writer for ScriptedWriter {
+        async fn send(&mut self, data: Bytes) -> Result<(), Error> {
+            self.outgoing.lock().unwrap().push(data);
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    impl Reader for ScriptedReader {
+        async fn recv(&mut self) -> Result<Bytes, Error> {
+            match self.incoming.recv().await {
+                Some(bytes) => Ok(bytes),
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    struct Peer {
+        inbound: mpsc::UnboundedSender<Bytes>,
+        outbound: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl Peer {
+        /// Announce the peer's transport parameters, which is what publishes its
+        /// `max_record_size` (and the credit our sends need).
+        fn params(&self, max_record_size: u64) {
+            let mut params = Config::new(Version::QMux01).to_transport_params();
+            params.max_record_size = max_record_size;
+            self.inbound
+                .send(
+                    Frame::TransportParameters(params)
+                        .encode(Version::QMux01)
+                        .unwrap(),
+                )
+                .unwrap();
+        }
+
+        /// Every record carrying a STREAM frame, in send order.
+        fn stream_records(&self) -> Vec<Bytes> {
+            self.outbound
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|record| {
+                    Frame::decode_record((*record).clone())
+                        .map(|frames| frames.iter().any(|f| matches!(f, Frame::Stream(_))))
+                        .unwrap_or(false)
+                })
+                .cloned()
+                .collect()
+        }
+    }
+
+    /// A client session fed by a scripted peer.
+    fn scripted_session(version: Version) -> (Session, Peer) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let outbound = Arc::new(Mutex::new(Vec::new()));
+        let session = Session::new(
+            ScriptedTransport {
+                incoming: rx,
+                outgoing: outbound.clone(),
+            },
+            false,
+            Config::new(version),
+        );
+        (
+            session,
+            Peer {
+                inbound: tx,
+                outbound,
+            },
+        )
+    }
+
+    /// A STREAM frame on a server-initiated uni stream (peer-initiated, since the
+    /// session under test is the client).
+    fn uni_stream(version: Version, index: u64, data: Vec<u8>, fin: bool) -> Bytes {
+        Frame::Stream(Stream {
+            id: StreamId::new(index, StreamDir::Uni, true),
+            offset: 0,
+            data: Bytes::from(data),
+            fin,
+        })
+        .encode(version)
+        .unwrap()
+    }
+
+    async fn read_uni(session: &Session) -> Vec<u8> {
+        let mut recv = tokio::time::timeout(Duration::from_secs(1), session.accept_uni())
+            .await
+            .expect("accept_uni timed out")
+            .expect("accept_uni failed");
+        recv.read_all().await.unwrap().to_vec()
+    }
+
+    /// Wait for the session to write `count` records carrying stream data.
+    async fn wait_for_stream_records(peer: &Peer, count: usize) -> Vec<Bytes> {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let records = peer.stream_records();
+                if records.len() >= count {
+                    return records;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the session did not write the expected stream records")
+    }
+
+    /// A record of exactly the `max_record_size` we advertised: a 5-byte STREAM
+    /// header plus 16377 payload bytes. Refusing this refuses the very size the
+    /// handshake invited — and a peer chunking at any other header budget (an
+    /// older release, a third-party stack) lands in this range too.
+    #[tokio::test]
+    async fn record_sized_stream_frame_is_delivered() {
+        let (session, peer) = scripted_session(Version::QMux01);
+
+        let payload = vec![0x5a; DEFAULT_MAX_RECORD_SIZE as usize - 5];
+        let frame = uni_stream(Version::QMux01, 0, payload.clone(), true);
+        assert_eq!(frame.len(), DEFAULT_MAX_RECORD_SIZE as usize);
+        peer.inbound.send(frame).unwrap();
+
+        assert_eq!(read_uni(&session).await, payload);
+    }
+
+    /// draft-00 has no record layer, so the whole frame is bounded by
+    /// `max_frame_size` — nothing narrower is derivable from the wire.
+    #[tokio::test]
+    async fn qmux00_full_size_frame_is_delivered() {
+        let (session, peer) = scripted_session(Version::QMux00);
+
+        let payload = vec![0x5a; crate::MAX_FRAME_SIZE - 5];
+        peer.inbound
+            .send(uni_stream(Version::QMux00, 0, payload.clone(), true))
+            .unwrap();
+
+        assert_eq!(read_uni(&session).await, payload);
+    }
+
+    /// The frames we emit have to reach the peer's limit: a fixed header
+    /// reservation would leave the tail of every record unused.
+    #[tokio::test]
+    async fn we_fill_the_record_the_peer_advertised() {
+        let (session, peer) = scripted_session(Version::QMux01);
+        peer.params(DEFAULT_MAX_RECORD_SIZE);
+
+        let mut send = tokio::time::timeout(Duration::from_secs(1), session.open_uni())
+            .await
+            .expect("open_uni timed out")
+            .expect("open_uni failed");
+        send.write(&vec![0x5a; DEFAULT_MAX_RECORD_SIZE as usize * 2])
+            .await
+            .unwrap();
+
+        let records = wait_for_stream_records(&peer, 1).await;
+        assert_eq!(records[0].len(), DEFAULT_MAX_RECORD_SIZE as usize);
+    }
+
+    /// The budget is the peer's, not a constant of ours, so a peer that accepts
+    /// more gets larger records.
+    #[tokio::test]
+    async fn we_fill_a_larger_record_when_the_peer_advertises_one() {
+        const MAX_RECORD_SIZE: u64 = 32_768;
+
+        let (session, peer) = scripted_session(Version::QMux01);
+        peer.params(MAX_RECORD_SIZE);
+
+        let mut send = tokio::time::timeout(Duration::from_secs(1), session.open_uni())
+            .await
+            .expect("open_uni timed out")
+            .expect("open_uni failed");
+        send.write(&vec![0x5a; MAX_RECORD_SIZE as usize * 2])
+            .await
+            .unwrap();
+
+        let records = wait_for_stream_records(&peer, 1).await;
+        assert_eq!(records[0].len(), MAX_RECORD_SIZE as usize);
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -13,7 +13,7 @@ use crate::transport::{Reader, Transport, Writer};
 use crate::{
     proto::{max_stream_payload, varint_size},
     ApplicationClose, ConnectionClose, Error, Frame, ResetStream, StopSending, Stream, StreamDir,
-    StreamId, TransportParams, Version, MAX_FRAME_SIZE,
+    StreamId, TransportParams, Version, MAX_FRAME_PAYLOAD, MAX_FRAME_SIZE,
 };
 use bytes::{Buf, BufMut, Bytes};
 use tokio::sync::{mpsc, watch};
@@ -2212,10 +2212,11 @@ impl generic::SendStream for SendStream {
         let mut total = 0;
 
         while buf.has_remaining() {
-            // Fill the frame the peer accepts, less this frame's own header. The
-            // offset varint grows as the stream advances, so size it per frame.
+            // Size from the peer's frame budget and this frame's actual header,
+            // then apply the compatibility ceiling for released receivers.
             let max_payload =
-                max_stream_payload(self.version, self.frame_budget(), self.id, self.offset);
+                max_stream_payload(self.version, self.frame_budget(), self.id, self.offset)
+                    .min(MAX_FRAME_PAYLOAD as u64);
             if max_payload == 0 {
                 // Unreachable with a conforming peer: max_record_size is validated
                 // against the draft-01 minimum on arrival. Fail rather than loop.
@@ -3298,8 +3299,8 @@ mod recv_open_tests {
 }
 
 // STREAM frame sizing. What we accept is bounded by the `max_record_size` we
-// advertised (enforced on the record, not on the frame inside it), and what we
-// send is bounded by the peer's — measured per frame, not by a fixed reservation.
+// advertised (enforced on the record, not on the frame inside it). What we send
+// also keeps the compatibility ceiling required by released receivers.
 #[cfg(test)]
 mod stream_payload_tests {
     use std::sync::{Arc, Mutex};
@@ -3311,7 +3312,7 @@ mod stream_payload_tests {
 
     use super::{Reader, Session, Transport, Writer};
     use crate::proto::{Frame, Stream, DEFAULT_MAX_RECORD_SIZE};
-    use crate::{Config, Error, StreamDir, StreamId, Version};
+    use crate::{Config, Error, StreamDir, StreamId, Version, MAX_FRAME_PAYLOAD};
 
     /// A scripted transport that also keeps every record the session wrote, so a
     /// test can measure the frames it emitted.
@@ -3457,6 +3458,17 @@ mod stream_payload_tests {
         .expect("the session did not write the expected stream records")
     }
 
+    fn stream_payload_len(record: &Bytes) -> usize {
+        Frame::decode_record(record.clone())
+            .unwrap()
+            .into_iter()
+            .find_map(|frame| match frame {
+                Frame::Stream(stream) => Some(stream.data.len()),
+                _ => None,
+            })
+            .expect("record did not contain a STREAM frame")
+    }
+
     /// A record of exactly the `max_record_size` we advertised: a 5-byte STREAM
     /// header plus 16377 payload bytes. Refusing this refuses the very size the
     /// handshake invited — and a peer chunking at any other header budget (an
@@ -3508,10 +3520,10 @@ mod stream_payload_tests {
         assert!(matches!(err, Error::FrameTooLarge), "got {err:?}");
     }
 
-    /// The frames we emit have to reach the peer's limit: a fixed header
-    /// reservation would leave the tail of every record unused.
+    /// Released receivers enforce the historical payload ceiling even though the
+    /// record they advertise can hold a slightly larger STREAM frame.
     #[tokio::test]
-    async fn we_fill_the_record_the_peer_advertised() {
+    async fn stream_payloads_stay_within_the_released_receiver_ceiling() {
         let (session, peer) = scripted_session(Version::QMux01);
         peer.params(DEFAULT_MAX_RECORD_SIZE);
 
@@ -3524,35 +3536,12 @@ mod stream_payload_tests {
             .unwrap();
 
         let records = wait_for_stream_records(&peer, 1).await;
-        assert_eq!(records[0].len(), DEFAULT_MAX_RECORD_SIZE as usize);
+        assert_eq!(stream_payload_len(&records[0]), MAX_FRAME_PAYLOAD);
     }
 
-    /// A budget that straddles a varint boundary still has to be filled exactly:
-    /// the length field describing the payload is narrower than one describing the
-    /// space left for it, and those two bytes are usable.
+    /// A larger peer record limit does not bypass the compatibility ceiling.
     #[tokio::test]
-    async fn we_fill_a_record_across_a_varint_boundary() {
-        const MAX_RECORD_SIZE: u64 = 16_387;
-
-        let (session, peer) = scripted_session(Version::QMux01);
-        peer.params(MAX_RECORD_SIZE);
-
-        let mut send = tokio::time::timeout(Duration::from_secs(1), session.open_uni())
-            .await
-            .expect("open_uni timed out")
-            .expect("open_uni failed");
-        send.write(&vec![0x5a; MAX_RECORD_SIZE as usize * 2])
-            .await
-            .unwrap();
-
-        let records = wait_for_stream_records(&peer, 1).await;
-        assert_eq!(records[0].len(), MAX_RECORD_SIZE as usize);
-    }
-
-    /// The budget is the peer's, not a constant of ours, so a peer that accepts
-    /// more gets larger records.
-    #[tokio::test]
-    async fn we_fill_a_larger_record_when_the_peer_advertises_one() {
+    async fn larger_record_limit_keeps_the_compatibility_ceiling() {
         const MAX_RECORD_SIZE: u64 = 32_768;
 
         let (session, peer) = scripted_session(Version::QMux01);
@@ -3567,7 +3556,7 @@ mod stream_payload_tests {
             .unwrap();
 
         let records = wait_for_stream_records(&peer, 1).await;
-        assert_eq!(records[0].len(), MAX_RECORD_SIZE as usize);
+        assert_eq!(stream_payload_len(&records[0]), MAX_FRAME_PAYLOAD);
     }
 }
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -890,8 +890,18 @@ impl<R: Reader> SessionState<R> {
                         for frame in Frame::decode_record(data)? {
                             self.recv_frame(frame).await?;
                         }
-                    } else if let Some(frame) = Frame::decode(data, self.config.version)? {
-                        self.recv_frame(frame).await?;
+                    } else {
+                        // draft-00 §5.2: `max_frame_size` bounds the whole frame,
+                        // header included, and may only be raised from its initial
+                        // value — which we never do, so the initial value is what a
+                        // peer may send. Each message is one frame here. The legacy
+                        // binding predates the parameter and bounds nothing.
+                        if self.config.version == Version::QMux00 && data.len() > MAX_FRAME_SIZE {
+                            return Err(Error::FrameTooLarge);
+                        }
+                        if let Some(frame) = Frame::decode(data, self.config.version)? {
+                            self.recv_frame(frame).await?;
+                        }
                     }
                 }
                 _ = async { closed.wait_for(|err| err.is_some()).await.ok(); } => {
@@ -3463,18 +3473,39 @@ mod stream_payload_tests {
         assert_eq!(read_uni(&session).await, payload);
     }
 
-    /// draft-00 has no record layer, so the whole frame is bounded by
-    /// `max_frame_size` — nothing narrower is derivable from the wire.
+    /// draft-00 §5.2 bounds the whole frame at `max_frame_size`, so a frame of
+    /// exactly that size — header included — is legal and must be delivered.
     #[tokio::test]
-    async fn qmux00_full_size_frame_is_delivered() {
+    async fn qmux00_max_size_frame_is_delivered() {
         let (session, peer) = scripted_session(Version::QMux00);
 
         let payload = vec![0x5a; crate::MAX_FRAME_SIZE - 5];
-        peer.inbound
-            .send(uni_stream(Version::QMux00, 0, payload.clone(), true))
-            .unwrap();
+        let frame = uni_stream(Version::QMux00, 0, payload.clone(), true);
+        assert_eq!(frame.len(), crate::MAX_FRAME_SIZE);
+        peer.inbound.send(frame).unwrap();
 
         assert_eq!(read_uni(&session).await, payload);
+    }
+
+    /// One byte past it is a frame-size violation, which draft-00 §5.2 requires
+    /// closing the connection over.
+    #[tokio::test]
+    async fn qmux00_oversized_frame_closes_the_session() {
+        let (session, peer) = scripted_session(Version::QMux00);
+
+        let frame = uni_stream(
+            Version::QMux00,
+            0,
+            vec![0x5a; crate::MAX_FRAME_SIZE - 4],
+            true,
+        );
+        assert_eq!(frame.len(), crate::MAX_FRAME_SIZE + 1);
+        peer.inbound.send(frame).unwrap();
+
+        let err = tokio::time::timeout(Duration::from_secs(1), session.closed())
+            .await
+            .expect("the session stayed open on an oversized frame");
+        assert!(matches!(err, Error::FrameTooLarge), "got {err:?}");
     }
 
     /// The frames we emit have to reach the peer's limit: a fixed header
@@ -3494,6 +3525,28 @@ mod stream_payload_tests {
 
         let records = wait_for_stream_records(&peer, 1).await;
         assert_eq!(records[0].len(), DEFAULT_MAX_RECORD_SIZE as usize);
+    }
+
+    /// A budget that straddles a varint boundary still has to be filled exactly:
+    /// the length field describing the payload is narrower than one describing the
+    /// space left for it, and those two bytes are usable.
+    #[tokio::test]
+    async fn we_fill_a_record_across_a_varint_boundary() {
+        const MAX_RECORD_SIZE: u64 = 16_387;
+
+        let (session, peer) = scripted_session(Version::QMux01);
+        peer.params(MAX_RECORD_SIZE);
+
+        let mut send = tokio::time::timeout(Duration::from_secs(1), session.open_uni())
+            .await
+            .expect("open_uni timed out")
+            .expect("open_uni failed");
+        send.write(&vec![0x5a; MAX_RECORD_SIZE as usize * 2])
+            .await
+            .unwrap();
+
+        let records = wait_for_stream_records(&peer, 1).await;
+        assert_eq!(records[0].len(), MAX_RECORD_SIZE as usize);
     }
 
     /// The budget is the peer's, not a constant of ours, so a peer that accepts

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -70,7 +70,7 @@ mod stream_transport {
     use web_transport_proto::VarInt;
 
     use super::{Reader, Transport, Writer};
-    use crate::{Error, Version, MAX_FRAME_PAYLOAD, MAX_FRAME_SIZE};
+    use crate::{Error, Version, MAX_FRAME_SIZE};
 
     /// Bound on queued frames waiting for the session to drain them. Bytes the
     /// session hasn't picked up yet are also buffered in the OS receive window
@@ -317,7 +317,12 @@ mod stream_transport {
 
             if has_len {
                 let len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
-                if len > MAX_FRAME_PAYLOAD {
+                // draft-00 bounds the whole frame by `max_frame_size`, so bound the
+                // payload by the same value rather than by our send-side header
+                // budget: a peer cannot derive that budget from anything on the
+                // wire. A byte stream cannot resynchronize past a bogus length, so
+                // this one stays fatal.
+                if len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);
                 }
                 read_bytes(reader, len, &mut buf).await?;

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -317,12 +317,11 @@ mod stream_transport {
 
             if has_len {
                 let len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
-                // draft-00 bounds the whole frame by `max_frame_size`, so bound the
-                // payload by the same value rather than by our send-side header
-                // budget: a peer cannot derive that budget from anything on the
-                // wire. A byte stream cannot resynchronize past a bogus length, so
-                // this one stays fatal.
-                if len > MAX_FRAME_SIZE {
+                // draft-00 §5.2: `max_frame_size` bounds the whole frame, so the
+                // header bytes read so far count against it. A byte stream cannot
+                // resynchronize past an oversized frame, so this stays fatal — as
+                // the draft requires (FRAME_ENCODING_ERROR).
+                if buf.len() + len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);
                 }
                 read_bytes(reader, len, &mut buf).await?;
@@ -355,7 +354,7 @@ mod stream_transport {
                     read_varint_into(reader, &mut buf).await?; // frame_type
                 }
                 let reason_len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
-                if reason_len > MAX_FRAME_SIZE {
+                if buf.len() + reason_len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);
                 }
                 read_bytes(reader, reason_len, &mut buf).await?;
@@ -391,7 +390,7 @@ mod stream_transport {
             // DATAGRAM with length
             0x31 => {
                 let len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
-                if len > MAX_FRAME_SIZE {
+                if buf.len() + len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);
                 }
                 read_bytes(reader, len, &mut buf).await?;
@@ -399,7 +398,7 @@ mod stream_transport {
             // QX_TRANSPORT_PARAMETERS
             0x3f5153300d0a0d0a => {
                 let len = read_varint_into(reader, &mut buf).await?.into_inner() as usize;
-                if len > MAX_FRAME_SIZE {
+                if buf.len() + len > MAX_FRAME_SIZE {
                     return Err(Error::FrameTooLarge);
                 }
                 read_bytes(reader, len, &mut buf).await?;
@@ -534,6 +533,43 @@ mod stream_transport {
             let err = transport.recv().await.expect_err("FrameTooLarge expected");
             assert!(matches!(err, Error::FrameTooLarge), "got {err:?}");
         }
+
+        /// draft-00 §5.2 bounds the whole frame at `max_frame_size`, header
+        /// included: a frame of exactly that size parses, and one byte more is a
+        /// frame-size violation rather than something to read into memory.
+        #[tokio::test]
+        async fn recv_qmux00_bounds_the_whole_frame() {
+            use crate::proto::{Frame, Stream as StreamFrame};
+            use crate::{StreamDir, StreamId};
+
+            let frame = |payload: usize| {
+                Frame::Stream(StreamFrame {
+                    id: StreamId::new(0, StreamDir::Uni, true),
+                    offset: 0,
+                    data: vec![0x5a; payload].into(),
+                    fin: false,
+                })
+                .encode(Version::QMux00)
+                .unwrap()
+            };
+
+            let at_limit = frame(MAX_FRAME_SIZE - 5);
+            assert_eq!(at_limit.len(), MAX_FRAME_SIZE);
+            let over_limit = frame(MAX_FRAME_SIZE - 4);
+            assert_eq!(over_limit.len(), MAX_FRAME_SIZE + 1);
+
+            let (client, mut server) = tokio::io::duplex(64 * 1024);
+            let (_writer, mut transport) = Stream::new(client, Version::QMux00, 0).split();
+
+            server.write_all(&at_limit).await.unwrap();
+            server.flush().await.unwrap();
+            assert_eq!(transport.recv().await.unwrap(), at_limit);
+
+            server.write_all(&over_limit).await.unwrap();
+            server.flush().await.unwrap();
+            let err = transport.recv().await.expect_err("FrameTooLarge expected");
+            assert!(matches!(err, Error::FrameTooLarge), "got {err:?}");
+        }
     }
 }
 
@@ -588,7 +624,7 @@ mod ws_transport {
 
     use super::{Reader, Transport, Writer};
     use crate::ws::KeepAlive;
-    use crate::{Error, Version};
+    use crate::{Error, Version, MAX_FRAME_SIZE};
 
     type Message = tungstenite::Message;
 
@@ -619,17 +655,27 @@ mod ws_transport {
     pub(crate) struct WsTransport<T> {
         ws: T,
         keep_alive: Option<KeepAlive>,
-        record_limit: Option<usize>,
+        /// Largest inbound message we accept, or `None` when nothing bounds it.
+        recv_limit: Option<usize>,
     }
 
     impl<T> WsTransport<T> {
         pub fn new(ws: T, version: Version, max_record_size: u64) -> Self {
+            // A message is a record on the record-framed drafts, bounded by the
+            // `max_record_size` we advertised; on draft-00 it is a single frame,
+            // bounded by `max_frame_size` (§5.2), which we never advertise above
+            // its initial value. The legacy binding negotiates neither.
+            let recv_limit = if version.uses_records() {
+                Some(usize::try_from(max_record_size).unwrap_or(usize::MAX))
+            } else if version.is_qmux() {
+                Some(MAX_FRAME_SIZE)
+            } else {
+                None
+            };
             Self {
                 ws,
                 keep_alive: None,
-                record_limit: version
-                    .uses_records()
-                    .then(|| usize::try_from(max_record_size).unwrap_or(usize::MAX)),
+                recv_limit,
             }
         }
 
@@ -722,7 +768,7 @@ mod ws_transport {
                 None => (None, None),
             };
             let (tx, rx) = mpsc::channel(WS_RECV_CHANNEL_CAPACITY);
-            let pump = tokio::spawn(ws_pump(stream, deadline, self.record_limit, tx));
+            let pump = tokio::spawn(ws_pump(stream, deadline, self.recv_limit, tx));
             (WsWriter { sink, ping }, WsReader { rx, pump })
         }
     }
@@ -788,7 +834,7 @@ mod ws_transport {
     async fn ws_pump<S>(
         mut stream: S,
         mut deadline: Option<DeadlineState>,
-        record_limit: Option<usize>,
+        recv_limit: Option<usize>,
         tx: mpsc::Sender<Result<Bytes, Error>>,
     ) where
         S: futures::Stream<Item = Result<Message, tungstenite::Error>> + Unpin + Send + 'static,
@@ -835,7 +881,7 @@ mod ws_transport {
 
             match message {
                 Message::Binary(data) => {
-                    if record_limit.is_some_and(|limit| data.len() > limit) {
+                    if recv_limit.is_some_and(|limit| data.len() > limit) {
                         // Release the oversized allocation before waiting for room to
                         // report the terminal error. In particular, never let it enter
                         // the bounded record queue while the session is backpressured.


### PR DESCRIPTION
Fixes #347.

## The defect

`MAX_FRAME_PAYLOAD` (`MAX_FRAME_SIZE - 32` = 16352) was a worst-case header reservation incorrectly used as the inbound accept boundary. Any STREAM frame with a larger payload killed the session with `CONNECTION_CLOSE(1002, "frame too large")`, even when the enclosing record fit the `max_record_size` advertised by the receiver. The check also applied to qmux-00 and the legacy `webtransport` binding, so changing a sender's header reservation silently changed which wire bytes a receiver accepted.

## The fix

**Receive.** Record-framed drafts enforce the limit the peer can derive from the handshake: `max_record_size` on the record itself. The per-frame payload check is removed. draft-00 enforces its whole-frame `max_frame_size`, including the header, in the JavaScript session, Rust session, Rust byte-stream reader, and Rust WebSocket transport. The legacy binding negotiates no receive limit and remains unbounded.

**Send.** Both implementations calculate the largest legal STREAM payload from the peer's negotiated record budget and the frame's actual type, stream ID, offset, and length-varint widths. The result is then capped by the restored send-only `MAX_FRAME_PAYLOAD` compatibility ceiling for every currently supported wire format. Released receivers still enforce that historical 16352-byte payload limit, so sending larger frames under the existing ALPN versions would recreate the version-skew failure in reverse. A future distinct QMux wire version can remove the ceiling once it cannot negotiate with those receivers.

The compatibility constant is never used for inbound validation.

## Tests

- JavaScript and Rust deliver a STREAM frame that fills the advertised `max_record_size`.
- JavaScript and Rust enforce draft-00's 16384-byte whole-frame boundary.
- Oversized records still close the session.
- Exact frame-budget helpers cover varint boundaries, wide stream IDs and offsets, and the largest legal `max_record_size`.
- Outbound STREAM payloads remain capped at 16352 bytes at the default and at larger peer record limits.

Verified with:

- `cargo test -p qmux --all-features`
- `cargo clippy -p qmux --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `bun run --cwd js/qmux check`
- `bun run --cwd js/qmux test`
- Biome checks on the changed TypeScript files
