### PR TITLE
Fix write_chunk truncation and lost accept wakers in iroh and quiche

### DIFF
--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -5,7 +5,7 @@ use std::{
     ops::Deref,
     pin::Pin,
     sync::{Arc, Mutex},
-    task::{Context, Poll, ready},
+    task::{Context, Poll, Waker},
 };
 
 use bytes::{Bytes, BytesMut};
@@ -362,6 +362,14 @@ struct H3SessionAccept {
     // Keep track of work being done to read/write the WebTransport stream header.
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
+
+    // Wakers from concurrent callers of accept_bi / accept_uni.
+    // When one caller gets a stream, all others are woken so they can retry.
+    // Every clone polls this one struct, which would otherwise keep only the most
+    // recent waker, so a second accepter would register through a waker the first
+    // had already replaced and never wake.
+    bi_wakers: Vec<Waker>,
+    uni_wakers: Vec<Waker>,
 }
 
 impl H3SessionAccept {
@@ -386,6 +394,9 @@ impl H3SessionAccept {
 
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
+
+            bi_wakers: Vec::new(),
+            uni_wakers: Vec::new(),
         }
     }
 
@@ -400,7 +411,15 @@ impl H3SessionAccept {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next(cx) {
                 // Start decoding the header and add the future to the list of pending streams.
-                let recv = res?;
+                let recv = match res {
+                    Ok(recv) => recv,
+                    Err(e) => {
+                        for waker in self.uni_wakers.drain(..) {
+                            waker.wake();
+                        }
+                        return Poll::Ready(Err(e.into()));
+                    }
+                };
                 let pending = Self::decode_uni(recv, self.session_id);
                 self.pending_uni.push(Box::pin(pending));
 
@@ -408,20 +427,28 @@ impl H3SessionAccept {
             }
 
             // Poll the list of pending streams.
-            let (typ, recv) = match ready!(self.pending_uni.poll_next(cx)) {
-                Some(Ok(res)) => res,
-                Some(Err(err)) => {
+            let (typ, recv) = match self.pending_uni.poll_next(cx) {
+                Poll::Ready(Some(Ok(res))) => res,
+                Poll::Ready(Some(Err(err))) => {
                     // Ignore the error, the stream was probably reset early.
                     tracing::warn!("failed to decode unidirectional stream: {err:?}");
                     continue;
                 }
-                None => return Poll::Pending,
+                Poll::Ready(None) | Poll::Pending => {
+                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                        self.uni_wakers.push(cx.waker().clone());
+                    }
+                    return Poll::Pending;
+                }
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
+                    for waker in self.uni_wakers.drain(..) {
+                        waker.wake();
+                    }
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -471,7 +498,15 @@ impl H3SessionAccept {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next(cx) {
                 // Start decoding the header and add the future to the list of pending streams.
-                let (send, recv) = res?;
+                let (send, recv) = match res {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        for waker in self.bi_wakers.drain(..) {
+                            waker.wake();
+                        }
+                        return Poll::Ready(Err(e.into()));
+                    }
+                };
                 let pending = Self::decode_bi(send, recv, self.session_id);
                 self.pending_bi.push(Box::pin(pending));
 
@@ -479,20 +514,28 @@ impl H3SessionAccept {
             }
 
             // Poll the list of pending streams.
-            let res = match ready!(self.pending_bi.poll_next(cx)) {
-                Some(Ok(res)) => res,
-                Some(Err(err)) => {
+            let res = match self.pending_bi.poll_next(cx) {
+                Poll::Ready(Some(Ok(res))) => res,
+                Poll::Ready(Some(Err(err))) => {
                     // Ignore the error, the stream was probably reset early.
                     tracing::warn!("failed to decode bidirectional stream: {err:?}");
                     continue;
                 }
-                None => return Poll::Pending,
+                Poll::Ready(None) | Poll::Pending => {
+                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                        self.bi_wakers.push(cx.waker().clone());
+                    }
+                    return Poll::Pending;
+                }
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
+                for waker in self.bi_wakers.drain(..) {
+                    waker.wake();
+                }
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -1,4 +1,12 @@
-use std::time::Duration;
+use std::{
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Wake, Waker},
+    time::Duration,
+};
 
 use iroh::{
     Endpoint,
@@ -10,6 +18,28 @@ use tracing::Instrument;
 use url::Url;
 
 use crate::{ALPN_H3, Client, H3Request, QuicRequest, SessionError};
+
+/// A waker that records whether it was ever woken.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl FlagWaker {
+    fn woken(&self) -> bool {
+        self.woken.load(Ordering::SeqCst)
+    }
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
 
 #[tokio::test]
 #[traced_test]
@@ -73,6 +103,92 @@ async fn h3_smoke() -> n0_error::Result<()> {
         }
         .instrument(tracing::error_span!("server")),
     );
+
+    timeout(Duration::from_secs(10), client_task)
+        .await
+        .expect("client task timed out")
+        .unwrap();
+    timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server task timed out")
+        .unwrap();
+
+    Ok(())
+}
+
+/// Every clone of a session polls one shared `H3SessionAccept`, which used to keep
+/// only the most recent waker: a second accepter registered through a waker the
+/// first had already replaced, so the first never woke again.
+///
+/// Register an accepter, let a second one resolve, and assert the first was woken so
+/// it can retry. Deterministic — the client is held back by a channel until the
+/// first accepter is registered, so there is no race to lose and no sleep to tune.
+#[tokio::test]
+#[traced_test]
+async fn concurrent_accept_wakes_every_accepter() -> n0_error::Result<()> {
+    let client = Endpoint::bind(presets::Minimal).await.unwrap();
+    let client = Client::new(client);
+
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![ALPN_H3.as_bytes().to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    let server_id = server.id();
+    let server_addr = server.addr();
+
+    let url: Url = format!("https://{}/foo", server_id).parse().unwrap();
+
+    // Held until the first accepter has registered its waker.
+    let (registered_tx, registered_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let client_task = tokio::task::spawn({
+        let url = url.clone();
+        async move {
+            let session = client.connect_h3(server_addr, url).await.unwrap();
+
+            registered_rx.await.unwrap();
+
+            let mut stream = session.open_uni().await.unwrap();
+            stream.write_all(b"hi").await.unwrap();
+            stream.finish().unwrap();
+
+            session.closed().await;
+            client.close().await;
+        }
+    });
+
+    let server_task = tokio::task::spawn(async move {
+        let conn = server.accept().await.unwrap().await.unwrap();
+        let session = H3Request::accept(conn).await.unwrap().ok().await.unwrap();
+
+        // The first accepter registers, then parks. No stream can have arrived yet:
+        // the client is still waiting on the channel.
+        let flag = Arc::new(FlagWaker::default());
+        let waker = Waker::from(flag.clone());
+        let mut first = std::pin::pin!(session.accept_uni());
+        assert!(
+            first
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending(),
+            "no stream should be available yet"
+        );
+
+        registered_tx.send(()).unwrap();
+
+        // The second accepter registers over the top of the first and resolves.
+        let mut stream = session.accept_uni().await.unwrap();
+        assert_eq!(stream.read_to_end(2).await.unwrap(), b"hi");
+
+        assert!(
+            flag.woken(),
+            "the first accepter's waker was dropped, so it would never retry"
+        );
+
+        session.close(0, b"bye");
+        server.close().await;
+    });
 
     timeout(Duration::from_secs(10), client_task)
         .await

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -262,3 +262,71 @@ async fn quic_smoke() -> n0_error::Result<()> {
 
     Ok(())
 }
+
+/// The user-visible form of the same bug, matching the original reproducer that
+/// diagnosed it for quinn: two independent tasks each awaiting `accept_uni`, and two
+/// streams to serve them. Without the waker list, whichever task registered first is
+/// never woken again and hangs forever.
+#[tokio::test]
+#[traced_test]
+async fn two_tasks_can_accept_concurrently() -> n0_error::Result<()> {
+    let client = Endpoint::bind(presets::Minimal).await.unwrap();
+    let client = Client::new(client);
+
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![ALPN_H3.as_bytes().to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    let server_id = server.id();
+    let server_addr = server.addr();
+
+    let url: Url = format!("https://{}/foo", server_id).parse().unwrap();
+
+    let client_task = tokio::task::spawn({
+        let url = url.clone();
+        async move {
+            let session = client.connect_h3(server_addr, url).await.unwrap();
+            for _ in 0..2 {
+                let mut stream = session.open_uni().await.unwrap();
+                stream.write_all(b"hi").await.unwrap();
+                stream.finish().unwrap();
+            }
+            session.closed().await;
+            client.close().await;
+        }
+    });
+
+    let server_task = tokio::task::spawn(async move {
+        let conn = server.accept().await.unwrap().await.unwrap();
+        let session = H3Request::accept(conn).await.unwrap().ok().await.unwrap();
+
+        // Two accepters on two clones, exactly as an application would fan out.
+        let mut accepters = Vec::new();
+        for _ in 0..2 {
+            let session = session.clone();
+            accepters.push(tokio::task::spawn(async move {
+                let mut recv = session.accept_uni().await.unwrap();
+                recv.read_to_end(2).await.unwrap()
+            }));
+        }
+
+        for accepter in accepters {
+            assert_eq!(accepter.await.unwrap(), b"hi");
+        }
+
+        session.close(0, b"bye");
+        server.close().await;
+    });
+
+    timeout(Duration::from_secs(10), client_task)
+        .await
+        .expect("client task timed out")
+        .unwrap();
+    timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server task timed out: an accepter was never woken")
+        .unwrap();
+
+    Ok(())
+}

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::{ez, h3, ClientError, RecvStream, SendStream, SessionError};
 
 use bytes::{Bytes, BytesMut};
-use futures::{ready, stream::FuturesUnordered, Stream, StreamExt};
+use futures::{stream::FuturesUnordered, Stream, StreamExt};
 use web_transport_proto::{ConnectRequest, ConnectResponse, Frame, StreamUni, VarInt};
 
 use std::{
@@ -9,7 +9,7 @@ use std::{
     io::Cursor,
     pin::Pin,
     sync::{Arc, Mutex},
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
 };
 
 // "conn" in ascii; if you see this then close(code)
@@ -449,6 +449,14 @@ pub struct SessionAccept {
     // Keep track of work being done to read/write the WebTransport stream header.
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
+
+    // Wakers from concurrent callers of accept_bi / accept_uni.
+    // When one caller gets a stream, all others are woken so they can retry.
+    // Every clone polls this one struct, which would otherwise keep only the most
+    // recent waker, so a second accepter would register through a waker the first
+    // had already replaced and never wake.
+    bi_wakers: Vec<Waker>,
+    uni_wakers: Vec<Waker>,
 }
 
 impl SessionAccept {
@@ -473,6 +481,9 @@ impl SessionAccept {
 
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
+
+            bi_wakers: Vec::new(),
+            uni_wakers: Vec::new(),
         }
     }
 
@@ -487,7 +498,15 @@ impl SessionAccept {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next_unpin(cx) {
                 // Start decoding the header and add the future to the list of pending streams.
-                let recv = res?;
+                let recv = match res {
+                    Ok(recv) => recv,
+                    Err(e) => {
+                        for waker in self.uni_wakers.drain(..) {
+                            waker.wake();
+                        }
+                        return Poll::Ready(Err(e.into()));
+                    }
+                };
                 let pending = Self::decode_uni(recv, self.session_id);
                 self.pending_uni.push(Box::pin(pending));
 
@@ -495,20 +514,28 @@ impl SessionAccept {
             }
 
             // Poll the list of pending streams.
-            let (typ, recv) = match ready!(self.pending_uni.poll_next_unpin(cx)) {
-                Some(Ok(res)) => res,
-                Some(Err(err)) => {
+            let (typ, recv) = match self.pending_uni.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(res))) => res,
+                Poll::Ready(Some(Err(err))) => {
                     // Ignore the error, the stream was probably reset early.
                     tracing::warn!(?err, "failed to decode unidirectional stream");
                     continue;
                 }
-                None => return Poll::Pending,
+                Poll::Ready(None) | Poll::Pending => {
+                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                        self.uni_wakers.push(cx.waker().clone());
+                    }
+                    return Poll::Pending;
+                }
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
+                    for waker in self.uni_wakers.drain(..) {
+                        waker.wake();
+                    }
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -558,7 +585,15 @@ impl SessionAccept {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next_unpin(cx) {
                 // Start decoding the header and add the future to the list of pending streams.
-                let (send, recv) = res?;
+                let (send, recv) = match res {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        for waker in self.bi_wakers.drain(..) {
+                            waker.wake();
+                        }
+                        return Poll::Ready(Err(e.into()));
+                    }
+                };
                 let pending = Self::decode_bi(send, recv, self.session_id);
                 self.pending_bi.push(Box::pin(pending));
 
@@ -566,20 +601,28 @@ impl SessionAccept {
             }
 
             // Poll the list of pending streams.
-            let res = match ready!(self.pending_bi.poll_next_unpin(cx)) {
-                Some(Ok(res)) => res,
-                Some(Err(err)) => {
+            let res = match self.pending_bi.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(res))) => res,
+                Poll::Ready(Some(Err(err))) => {
                     // Ignore the error, the stream was probably reset early.
                     tracing::warn!(?err, "failed to decode bidirectional stream");
                     continue;
                 }
-                None => return Poll::Pending,
+                Poll::Ready(None) | Poll::Pending => {
+                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                        self.bi_wakers.push(cx.waker().clone());
+                    }
+                    return Poll::Pending;
+                }
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
+                for waker in self.bi_wakers.drain(..) {
+                    waker.wake();
+                }
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-quiche/tests/accept_wakers.rs
+++ b/rs/web-transport-quiche/tests/accept_wakers.rs
@@ -138,3 +138,68 @@ async fn concurrent_accept_wakes_every_accepter() -> Result<()> {
     server_task.abort();
     Ok(())
 }
+
+/// The user-visible form of the same bug, matching the original reproducer that
+/// diagnosed it for quinn: two independent tasks each awaiting `accept_uni`, and two
+/// streams to serve them. Without the waker list, whichever task registered first is
+/// never woken again and hangs forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_tasks_can_accept_concurrently() -> Result<()> {
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.expect("a connection");
+        let session = request.ok().await.expect("an established session");
+
+        // Two accepters on two clones, exactly as an application would fan out.
+        let mut accepters = Vec::new();
+        for _ in 0..2 {
+            let session = session.clone();
+            accepters.push(tokio::spawn(async move {
+                let mut recv = session.accept_uni().await.expect("a stream");
+                let mut data = Vec::new();
+                recv.read_to_end(&mut data).await.expect("the payload");
+                data
+            }));
+        }
+
+        for accepter in accepters {
+            assert_eq!(accepter.await.expect("accepter task"), b"hi");
+        }
+
+        done_tx.send(()).expect("client is listening");
+    });
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let session = client()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(url)
+        .await?
+        .established()
+        .await?;
+
+    for _ in 0..2 {
+        let mut send = session.open_uni().await?;
+        send.write_all(b"hi").await?;
+        send.finish()?;
+    }
+
+    timeout(Duration::from_secs(10), done_rx)
+        .await
+        .context("an accepter was never woken")??;
+
+    session.close(0, "bye");
+    server_task.abort();
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/accept_wakers.rs
+++ b/rs/web-transport-quiche/tests/accept_wakers.rs
@@ -1,0 +1,140 @@
+//! Concurrent accepters must all be woken.
+//!
+//! Every clone of a `Session` polls the same `SessionAccept`, and it kept no wakers
+//! of its own — each poll registered with the inner accept stream, which stores
+//! exactly one. A second accepter registered through a waker that replaced the
+//! first's, so the first never woke again even as streams arrived.
+
+use std::{
+    future::Future,
+    net::{Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Wake, Waker},
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::{io::AsyncReadExt, time::timeout};
+use url::Url;
+use web_transport_quiche::{ClientBuilder, ServerBuilder, Settings};
+
+/// A waker that records whether it was ever woken.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl FlagWaker {
+    fn woken(&self) -> bool {
+        self.woken.load(Ordering::SeqCst)
+    }
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+fn client() -> ClientBuilder {
+    let mut settings = Settings::default();
+    settings.verify_peer = false;
+    ClientBuilder::default().with_settings(settings)
+}
+
+/// Register an accepter, let a second one resolve, and assert the first was woken so
+/// it can retry. Deterministic — the client is held on a channel until the first
+/// accepter is registered, so there is no race to lose and no sleep to tune.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_accept_wakes_every_accepter() -> Result<()> {
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    // Held until the first accepter has registered its waker.
+    let (registered_tx, registered_rx) = tokio::sync::oneshot::channel::<()>();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.expect("a connection");
+        let session = request.ok().await.expect("an established session");
+
+        // The first accepter registers, then parks. No stream can have arrived yet:
+        // the client is still waiting on the channel.
+        let flag = Arc::new(FlagWaker::default());
+        let waker = Waker::from(flag.clone());
+        let mut first = std::pin::pin!(session.accept_uni());
+        assert!(
+            first
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending(),
+            "no stream should be available yet"
+        );
+
+        registered_tx.send(()).expect("client is listening");
+
+        // The second accepter registers over the top of the first and resolves.
+        let mut recv = session.accept_uni().await.expect("a stream");
+        let mut data = Vec::new();
+        recv.read_to_end(&mut data).await.expect("the payload");
+        assert_eq!(data, b"hi");
+
+        assert!(
+            flag.woken(),
+            "the first accepter's waker was dropped, so it would never retry"
+        );
+
+        done_tx.send(()).expect("client is listening");
+    });
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let session = client()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(url)
+        .await?
+        .established()
+        .await?;
+
+    registered_rx.await?;
+
+    let mut send = session.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    timeout(Duration::from_secs(10), done_rx)
+        .await
+        .context("the server never confirmed: the first accepter was not woken")??;
+
+    session.close(0, "bye");
+    server_task.abort();
+    Ok(())
+}

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -178,7 +178,10 @@ pub trait SendStream: MaybeSend {
         async move {
             // Just so the arg isn't mut
             let mut c = chunk;
-            self.write_buf(&mut c).await?;
+            // `write_all_buf`, not `write_buf`: this method promises the whole chunk,
+            // and a single `write_buf` may accept only part of it. Stopping there
+            // would drop the rest silently, which the peer decodes as truncation.
+            self.write_all_buf(&mut c).await?;
             Ok(())
         }
     }

--- a/rs/web-transport-trait/tests/defaults.rs
+++ b/rs/web-transport-trait/tests/defaults.rs
@@ -11,8 +11,8 @@ use std::{
     task::{Context, Poll, Wake, Waker},
 };
 
-use bytes::Bytes;
-use web_transport_trait::SendStream;
+use bytes::{Bytes, BytesMut};
+use web_transport_trait::{RecvStream, SendStream};
 
 struct Noop;
 
@@ -116,4 +116,63 @@ fn write_buf_advances_only_by_what_was_accepted() {
     let size = block_on(send.write_buf(&mut buf)).unwrap();
     assert_eq!(size, 1);
     assert_eq!(&buf[..], b"ello");
+}
+
+/// Produces at most one byte per call.
+struct DripRecv {
+    remaining: Bytes,
+}
+
+impl DripRecv {
+    fn new(data: &'static [u8]) -> Self {
+        Self {
+            remaining: Bytes::from_static(data),
+        }
+    }
+}
+
+impl RecvStream for DripRecv {
+    type Error = TestError;
+
+    async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, TestError> {
+        if self.remaining.is_empty() {
+            return Ok(None);
+        }
+        if dst.is_empty() {
+            return Ok(Some(0));
+        }
+
+        dst[0] = self.remaining[0];
+        self.remaining = self.remaining.slice(1..);
+        Ok(Some(1))
+    }
+
+    fn stop(&mut self, _code: u32) {}
+
+    async fn closed(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn read_all_collects_every_byte() {
+    let mut recv = DripRecv::new(b"hello");
+    let data = block_on(recv.read_all()).unwrap();
+    assert_eq!(&data[..], b"hello");
+}
+
+#[test]
+fn read_all_buf_collects_every_byte() {
+    let mut recv = DripRecv::new(b"hello");
+    let mut buf = BytesMut::with_capacity(32);
+    let size = block_on(recv.read_all_buf(&mut buf)).unwrap();
+    assert_eq!(size, 5);
+    assert_eq!(&buf[..], b"hello");
+}
+
+#[test]
+fn read_buf_reports_end_of_stream() {
+    let mut recv = DripRecv::new(b"");
+    let mut buf = BytesMut::with_capacity(8);
+    assert_eq!(block_on(recv.read_buf(&mut buf)).unwrap(), None);
 }

--- a/rs/web-transport-trait/tests/defaults.rs
+++ b/rs/web-transport-trait/tests/defaults.rs
@@ -1,0 +1,119 @@
+//! Tests for the traits' provided methods.
+//!
+//! The streams here accept or produce one byte per call, so a partial transfer is
+//! the normal case rather than an edge case. That is what the `_all` helpers exist
+//! to paper over, and getting it wrong is invisible on a stream that happens to
+//! take everything in one go.
+
+use std::{
+    future::Future,
+    sync::Arc,
+    task::{Context, Poll, Wake, Waker},
+};
+
+use bytes::Bytes;
+use web_transport_trait::SendStream;
+
+struct Noop;
+
+impl Wake for Noop {
+    fn wake(self: Arc<Self>) {}
+}
+
+/// Drive a future to completion. Sound only because nothing in this file ever
+/// returns `Pending`; a real executor would park instead of spinning.
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    loop {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut cx) {
+            return output;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TestError;
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "test error")
+    }
+}
+
+impl std::error::Error for TestError {}
+
+impl web_transport_trait::Error for TestError {
+    fn session_error(&self) -> Option<(u32, String)> {
+        None
+    }
+}
+
+/// Accepts at most one byte per call.
+#[derive(Default)]
+struct DripSend {
+    written: Vec<u8>,
+}
+
+impl SendStream for DripSend {
+    type Error = TestError;
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, TestError> {
+        match buf.first() {
+            Some(&byte) => {
+                self.written.push(byte);
+                Ok(1)
+            }
+            None => Ok(0),
+        }
+    }
+
+    fn set_priority(&mut self, _order: u8) {}
+
+    fn finish(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    fn reset(&mut self, _code: u32) {}
+
+    async fn closed(&mut self) -> Result<(), TestError> {
+        Ok(())
+    }
+}
+
+/// `write_chunk` promises the whole chunk. Built on a single `write_buf` it stopped
+/// at whatever the first call accepted and dropped the rest silently, which the peer
+/// decodes as a truncated frame.
+#[test]
+fn write_chunk_writes_the_whole_chunk() {
+    let mut send = DripSend::default();
+    block_on(send.write_chunk(Bytes::from_static(b"hello"))).unwrap();
+    assert_eq!(send.written, b"hello");
+}
+
+#[test]
+fn write_all_drains_the_buffer() {
+    let mut send = DripSend::default();
+    block_on(send.write_all(b"hello")).unwrap();
+    assert_eq!(send.written, b"hello");
+}
+
+#[test]
+fn write_all_buf_drains_the_buffer() {
+    let mut send = DripSend::default();
+    let mut buf = Bytes::from_static(b"hello");
+    block_on(send.write_all_buf(&mut buf)).unwrap();
+    assert_eq!(send.written, b"hello");
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn write_buf_advances_only_by_what_was_accepted() {
+    let mut send = DripSend::default();
+    let mut buf = Bytes::from_static(b"hello");
+    let size = block_on(send.write_buf(&mut buf)).unwrap();
+    assert_eq!(size, 1);
+    assert_eq!(&buf[..], b"ello");
+}


### PR DESCRIPTION
Bugs that exist on `main` today, split out of #328 so they can land on their own
merits. Each has a regression test verified to fail without its fix.

## `write_chunk` truncated silently

`write_chunk` documents that it writes the entire `Bytes`, but it was built on a
single `write_buf` — explicitly a *partial* write. Any stream that accepted less
than the whole chunk in one call dropped the remainder without an error, and the
peer decodes the gap as a truncated or garbage frame. Now `write_all_buf`.

## iroh and quiche dropped concurrent accepters' wakers

Four backends share the same accept plumbing: an `Arc<Mutex<SessionAccept>>`
holding a `FuturesUnordered` of header-decode futures, polled through `poll_fn` by
every clone of the session. Because the struct is shared, whichever caller polls
last owns the registration inside the inner accept stream — which stores exactly
one waker. An earlier accepter's waker is silently replaced and never fires again.

quinn and noq already track their wakers in a `Vec<Waker>`. iroh and quiche never
got that fix, and their `poll_accept_*` are otherwise line-for-line the same code.

### Evidence that the waker change is load-bearing

This is not a theoretical defect:

- **It was diagnosed and fixed here before.** `815b61c7` ("Fix lost-waker bug in
  concurrent accept_bi/accept_uni calls", Feb 2026) fixed exactly this for quinn,
  with a 390-line reproducer in `ce12526c`. That commit also called out replacing
  `ready!()` with an explicit match "to ensure the waker push isn't bypassed by its
  hidden early return on `Poll::Pending`" — the same change made here. The fix
  survived into `main`; its test file was removed in a later cleanup, which is why
  iroh and quiche were never measured against it.

- **The user-visible failure reproduces on both backends.** The new
  `two_tasks_can_accept_concurrently` tests spawn two tasks that each await
  `accept_uni` on their own clone, with two streams sent to serve them — the shape
  of the original reproducer. Against the unfixed backends both **hang for the full
  10-second timeout** rather than failing an assertion. That is the real symptom: an
  accepter that is never woken again.

- **The mechanism is pinned separately.** `concurrent_accept_wakes_every_accepter`
  registers one accepter with an instrumented waker, lets a second resolve, and
  asserts the first was woken. It is deterministic — the client is held on a channel
  until the first accepter has registered, so there is no race to lose and no sleep
  to tune.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo check` for `wasm32-unknown-unknown` on `web-transport` and `web-transport-wasm` — clean
- `cargo test --workspace --all-features` — green
- Each fix reverted individually to confirm its test fails

## Not included

An earlier revision also zeroed `read_buf`'s destination slice, on the grounds that
transmuting `BufMut::chunk_mut` into a `&mut [u8]` builds a reference over
possibly-uninitialized memory. That has been dropped: a `read` that reports the wrong
count hands the caller stale bytes either way, and reusing a scratch buffer across
reads makes that the ordinary shape of the bug rather than an exotic one, so the
memset bought no observable safety for a per-read cost.

CodeRabbit's suggestion to also drain and wake on the QPACK/ignored-stream path is
declined: those streams satisfy no accepter, so there is nothing to hand out and a
wake would only cause a spurious re-poll. The wakers correctly persist in the list
until a WebTransport stream or an error actually arrives. quinn's proven
implementation does the same.

(written by Opus 5)