### PR TITLE
Add the sans-I/O poll surface, and implement it for quinn and quiche

### DIFF
--- a/rs/qmux/src/credit.rs
+++ b/rs/qmux/src/credit.rs
@@ -1,4 +1,8 @@
-use tokio::sync::watch;
+use std::{
+    future::poll_fn,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
 
 use crate::Error;
 
@@ -18,22 +22,63 @@ struct CreditState {
 /// - **Send**: `try_claim`/`claim` to reserve credit, `release` for rollback, `increase_max` on peer's MAX_DATA.
 /// - **Recv**: `receive` to validate incoming data, `consume` to track app consumption and trigger window updates.
 ///
-/// Clone is cheap (watch::Sender is internally Arc'd).
+/// Clone is cheap (internally `Arc`'d).
+///
+/// Waiters park a [`Waker`] here rather than on a channel: a channel's wait future
+/// owns its registration and drops it with the future, so a caller that polls once
+/// and comes back later would never be woken. Parking the waker in the shared state
+/// is what lets `poll_claim`/`poll_claim_index` be honest `poll_*` methods.
 #[derive(Clone, Debug)]
 pub struct Credit {
-    inner: watch::Sender<CreditState>,
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    state: CreditState,
+    /// Parked on credit becoming available, or the credit closing.
+    wakers: Vec<Waker>,
+}
+
+impl Inner {
+    /// Apply `f`, waking waiters if it reports that availability changed.
+    fn update<T>(&mut self, f: impl FnOnce(&mut CreditState) -> (T, bool)) -> (T, Vec<Waker>) {
+        let (out, notify) = f(&mut self.state);
+        let wakers = if notify {
+            std::mem::take(&mut self.wakers)
+        } else {
+            Vec::new()
+        };
+        (out, wakers)
+    }
+
+    fn park(&mut self, cx: &Context<'_>) {
+        if !self.wakers.iter().any(|w| w.will_wake(cx.waker())) {
+            self.wakers.push(cx.waker().clone());
+        }
+    }
+}
+
+/// Wake outside the lock, so a woken task never immediately blocks on it.
+fn wake_all(wakers: Vec<Waker>) {
+    for waker in wakers {
+        waker.wake();
+    }
 }
 
 impl Credit {
     /// Create with initial max (used starts at 0).
     pub fn new(max: u64) -> Self {
         Self {
-            inner: watch::Sender::new(CreditState {
-                used: 0,
-                max,
-                released: 0,
-                closed: false,
-            }),
+            inner: Arc::new(Mutex::new(Inner {
+                state: CreditState {
+                    used: 0,
+                    max,
+                    released: 0,
+                    closed: false,
+                },
+                wakers: Vec::new(),
+            })),
         }
     }
 
@@ -41,107 +86,94 @@ impl Credit {
 
     /// Try to claim up to `limit` units. Returns amount claimed (0 if none available).
     pub fn try_claim(&self, limit: u64) -> u64 {
-        let mut claimed = 0;
-        self.inner.send_if_modified(|state| {
-            let available = state.max.saturating_sub(state.used);
-            claimed = limit.min(available);
-            if claimed > 0 {
-                state.used += claimed;
-                true
-            } else {
-                false
-            }
-        });
+        let mut inner = self.inner.lock().unwrap();
+        let available = inner.state.max.saturating_sub(inner.state.used);
+        let claimed = limit.min(available);
+        inner.state.used += claimed;
         claimed
     }
 
     /// Claim up to `limit` units, waiting until credit is available.
     pub async fn claim(&self, limit: u64) -> Result<u64, Error> {
-        loop {
-            if self.inner.borrow().closed {
-                return Err(Error::Closed);
-            }
+        poll_fn(|cx| self.poll_claim(cx, limit)).await
+    }
 
-            let claimed = self.try_claim(limit);
-            if claimed > 0 {
-                return Ok(claimed);
-            }
+    /// Poll to claim up to `limit` units.
+    pub fn poll_claim(&self, cx: &mut Context<'_>, limit: u64) -> Poll<Result<u64, Error>> {
+        let mut inner = self.inner.lock().unwrap();
 
-            let mut rx = self.inner.subscribe();
-            rx.wait_for(|state| state.used < state.max || state.closed)
-                .await
-                .map_err(|_| Error::Closed)?;
+        if inner.state.closed {
+            return Poll::Ready(Err(Error::Closed));
         }
+
+        let available = inner.state.max.saturating_sub(inner.state.used);
+        let claimed = limit.min(available);
+        if claimed > 0 {
+            inner.state.used += claimed;
+            return Poll::Ready(Ok(claimed));
+        }
+
+        inner.park(cx);
+        Poll::Pending
     }
 
     /// Claim exactly 1 unit and return the index (value of `used` before incrementing).
     pub async fn claim_index(&self) -> Result<u64, Error> {
-        loop {
-            if self.inner.borrow().closed {
-                return Err(Error::Closed);
-            }
+        poll_fn(|cx| self.poll_claim_index(cx)).await
+    }
 
-            let mut index = 0;
-            let claimed = self.inner.send_if_modified(|state| {
-                if state.used < state.max {
-                    index = state.used;
-                    state.used += 1;
-                    true
-                } else {
-                    false
-                }
-            });
-            if claimed {
-                return Ok(index);
-            }
+    /// Poll to claim exactly 1 unit, returning the index it claimed.
+    pub fn poll_claim_index(&self, cx: &mut Context<'_>) -> Poll<Result<u64, Error>> {
+        let mut inner = self.inner.lock().unwrap();
 
-            let mut rx = self.inner.subscribe();
-            rx.wait_for(|state| state.used < state.max || state.closed)
-                .await
-                .map_err(|_| Error::Closed)?;
+        if inner.state.closed {
+            return Poll::Ready(Err(Error::Closed));
         }
+
+        if inner.state.used < inner.state.max {
+            let index = inner.state.used;
+            inner.state.used += 1;
+            return Poll::Ready(Ok(index));
+        }
+
+        inner.park(cx);
+        Poll::Pending
     }
 
     /// Close the credit, causing all pending and future `claim()`/`claim_index()` calls
     /// to return `Err(Error::Closed)`.
     pub fn close(&self) {
-        self.inner.send_if_modified(|state| {
-            if state.closed {
-                false
-            } else {
-                state.closed = true;
-                true
-            }
+        let (_, wakers) = self.inner.lock().unwrap().update(|state| {
+            let changed = !state.closed;
+            state.closed = true;
+            ((), changed)
         });
+        wake_all(wakers);
     }
 
     /// Return previously claimed credit (rollback on failed send).
     pub fn release(&self, amount: u64) {
-        self.inner.send_if_modified(|state| {
+        let (_, wakers) = self.inner.lock().unwrap().update(|state| {
             let new = state.used.saturating_sub(amount);
-            if new != state.used {
-                state.used = new;
-                true
-            } else {
-                false
-            }
+            let changed = new != state.used;
+            state.used = new;
+            ((), changed)
         });
+        wake_all(wakers);
     }
 
     /// Increase the max. Returns error if new_max < current max.
     pub fn increase_max(&self, new_max: u64) -> Result<(), Error> {
-        let mut ok = true;
-        self.inner.send_if_modified(|state| {
+        let (ok, wakers) = self.inner.lock().unwrap().update(|state| {
             if new_max < state.max {
-                ok = false;
-                return false;
+                return (false, false);
             }
-            if new_max == state.max {
-                return false;
-            }
+            let changed = new_max != state.max;
             state.max = new_max;
-            true
+            (true, changed)
         });
+        wake_all(wakers);
+
         if ok {
             Ok(())
         } else {
@@ -154,41 +186,28 @@ impl Credit {
     /// Set used to max(used, value). Returns false if value > max (flow control violation).
     /// Used for stream count tracking where opening index N implies all indices 0..N.
     pub fn receive_up_to(&self, value: u64) -> bool {
-        let mut ok = true;
-        self.inner.send_if_modified(|state| {
-            if value > state.max {
-                ok = false;
-                false
-            } else if value > state.used {
-                state.used = value;
-                true
-            } else {
-                false
-            }
-        });
-        ok
+        let mut inner = self.inner.lock().unwrap();
+        if value > inner.state.max {
+            return false;
+        }
+        inner.state.used = inner.state.used.max(value);
+        true
     }
 
     /// Validate and account for incoming data. Returns false if flow control is violated.
     pub fn receive(&self, len: u64) -> bool {
-        let mut ok = true;
-        self.inner.send_if_modified(|state| {
-            if state.used + len > state.max {
-                ok = false;
-                false
-            } else {
-                state.used += len;
-                true
-            }
-        });
-        ok
+        let mut inner = self.inner.lock().unwrap();
+        if inner.state.used + len > inner.state.max {
+            return false;
+        }
+        inner.state.used += len;
+        true
     }
 
     /// Report that `len` bytes have been consumed by the application.
     /// Returns `Some(new_max)` if a window update should be sent.
     pub fn consume(&self, len: u64) -> Option<u64> {
-        let mut update = None;
-        self.inner.send_if_modified(|state| {
+        let (update, wakers) = self.inner.lock().unwrap().update(|state| {
             state.released += len;
 
             // Send a window update when: used + 2*released > max
@@ -197,12 +216,12 @@ impl Credit {
                 let new_max = state.max + state.released;
                 state.max = new_max;
                 state.released = 0;
-                update = Some(new_max);
-                true
+                (Some(new_max), true)
             } else {
-                false
+                (None, false)
             }
         });
+        wake_all(wakers);
         update
     }
 }

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -14,6 +14,7 @@ mod proto;
 mod protocol;
 mod sched;
 mod session;
+mod shared;
 mod stream;
 
 /// Transport abstraction and the byte-stream [`transport::Stream`] implementation.

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -19,6 +19,8 @@ use tokio::sync::{mpsc, watch};
 use web_transport_proto::VarInt;
 use web_transport_trait as generic;
 
+use crate::shared::SharedRecv;
+
 /// How many inbound datagrams to buffer before dropping. Datagrams are
 /// unreliable, so a slow `recv_datagram` consumer sheds load here rather than
 /// applying backpressure to the whole session.
@@ -76,8 +78,10 @@ pub struct Session {
     outbound: PriorityQueue,
     outbound_priority: mpsc::UnboundedSender<Frame>,
 
-    accept_bi: Arc<tokio::sync::Mutex<mpsc::Receiver<(SendStream, RecvStream)>>>,
-    accept_uni: Arc<tokio::sync::Mutex<mpsc::Receiver<RecvStream>>>,
+    // Shared by every clone. See `SharedRecv` for why this is not a
+    // `tokio::sync::Mutex` around the receiver.
+    accept_bi: Arc<SharedRecv<(SendStream, RecvStream)>>,
+    accept_uni: Arc<SharedRecv<RecvStream>>,
 
     // Shared per-stream backend state (with the reader and writer tasks). The
     // frontend registers the streams it opens directly under this lock — see
@@ -115,7 +119,7 @@ pub struct Session {
     // Inbound datagrams (RFC 9221). The backend fans DATAGRAM frames into this
     // channel; `recv_datagram` drains it. Bounded and lossy — a slow reader
     // drops datagrams rather than stalling the session.
-    recv_datagram: Arc<tokio::sync::Mutex<mpsc::Receiver<Bytes>>>,
+    recv_datagram: Arc<SharedRecv<Bytes>>,
 
     // Outbound datagrams. `send_datagram` pushes payloads here; the backend loop
     // frames and writes them. Bounded and lossy so a backpressured transport
@@ -1763,8 +1767,8 @@ impl Session {
             config,
             outbound,
             outbound_priority: control_tx,
-            accept_bi: Arc::new(tokio::sync::Mutex::new(accept_bi_rx)),
-            accept_uni: Arc::new(tokio::sync::Mutex::new(accept_uni_rx)),
+            accept_bi: Arc::new(SharedRecv::new(accept_bi_rx)),
+            accept_uni: Arc::new(SharedRecv::new(accept_uni_rx)),
             streams,
             closed,
             negotiated,
@@ -1773,7 +1777,7 @@ impl Session {
             open_uni_credit,
             conn_send_credit,
             conn_recv_credit,
-            recv_datagram: Arc::new(tokio::sync::Mutex::new(recv_datagram_rx)),
+            recv_datagram: Arc::new(SharedRecv::new(recv_datagram_rx)),
             datagram_max_size,
             outbound_datagram: outbound_datagram_tx,
             _guard: guard,
@@ -1787,21 +1791,11 @@ impl generic::Session for Session {
     type Error = Error;
 
     async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-        self.accept_uni
-            .lock()
-            .await
-            .recv()
-            .await
-            .ok_or(Error::Closed)
+        self.accept_uni.recv().await.ok_or(Error::Closed)
     }
 
     async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-        self.accept_bi
-            .lock()
-            .await
-            .recv()
-            .await
-            .ok_or(Error::Closed)
+        self.accept_bi.recv().await.ok_or(Error::Closed)
     }
 
     async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
@@ -1991,12 +1985,7 @@ impl generic::Session for Session {
     }
 
     async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
-        self.recv_datagram
-            .lock()
-            .await
-            .recv()
-            .await
-            .ok_or(Error::Closed)
+        self.recv_datagram.recv().await.ok_or(Error::Closed)
     }
 
     fn protocol(&self) -> Option<&str> {

--- a/rs/qmux/src/shared.rs
+++ b/rs/qmux/src/shared.rs
@@ -1,0 +1,81 @@
+//! A receiver shared by every clone of a session.
+
+use std::{
+    future::poll_fn,
+    sync::Mutex,
+    task::{Context, Poll, Waker},
+};
+
+use tokio::sync::mpsc;
+
+/// An `mpsc::Receiver` that any number of handles can poll.
+///
+/// Two things make this different from wrapping the receiver in a
+/// `tokio::sync::Mutex`:
+///
+/// - **The lock is held only for the poll itself.** A `tokio::sync::Mutex` invites
+///   `lock().await` followed by `recv().await`, which holds the guard across the
+///   wait — so a handle that starts an accept and stops polling blocks every other
+///   clone until it is polled again or dropped. That is a hang, not a slowdown, and
+///   it is unrepresentable here: a `std::sync::MutexGuard` is not `Send`, so the
+///   compiler rejects holding one across an await.
+///
+/// - **Wakers are tracked per caller.** `mpsc::Receiver::poll_recv` stores exactly
+///   one waker, so a second caller would replace the first's registration and the
+///   first would never wake. Every waiter is parked here instead, and they are all
+///   woken whenever one of them takes a value, so the losers re-poll and
+///   re-register.
+#[derive(Debug)]
+pub(crate) struct SharedRecv<T> {
+    inner: Mutex<Inner<T>>,
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    rx: mpsc::Receiver<T>,
+    wakers: Vec<Waker>,
+}
+
+impl<T> SharedRecv<T> {
+    pub fn new(rx: mpsc::Receiver<T>) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                rx,
+                wakers: Vec::new(),
+            }),
+        }
+    }
+
+    /// Poll for the next value, `None` once the channel is closed and drained.
+    pub fn poll_recv(&self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let mut inner = self.inner.lock().unwrap();
+
+        match inner.rx.poll_recv(cx) {
+            Poll::Ready(value) => {
+                // Whoever else is parked lost the race for this value, but the
+                // receiver now holds only *our* waker. Wake them so they re-poll and
+                // re-register, otherwise they wait forever on a registration that no
+                // longer exists.
+                let wakers = std::mem::take(&mut inner.wakers);
+                drop(inner);
+
+                for waker in wakers {
+                    waker.wake();
+                }
+
+                Poll::Ready(value)
+            }
+            Poll::Pending => {
+                if !inner.wakers.iter().any(|w| w.will_wake(cx.waker())) {
+                    inner.wakers.push(cx.waker().clone());
+                }
+                Poll::Pending
+            }
+        }
+    }
+
+    /// Wait for the next value, `None` once the channel is closed and drained.
+    pub async fn recv(&self) -> Option<T> {
+        poll_fn(|cx| self.poll_recv(cx)).await
+    }
+}

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
     io::Cursor,
     pin::Pin,
     sync::{Arc, Mutex},
-    task::{Context, Poll, Waker},
+    task::{ready, Context, Poll, Waker},
 };
 
 // "conn" in ascii; if you see this then close(code)
@@ -63,6 +63,50 @@ pub struct Connection {
     // The request and response that were sent and received.
     request: ConnectRequest,
     response: ConnectResponse,
+
+    // Opening a stream is two steps — take the stream, then write the WebTransport
+    // header — so a `Pending` in the middle has to resume rather than start over.
+    //
+    // A plain state machine, not a retained future: `ez` exposes every step as a
+    // `poll_*`, so there is nothing to box. Per-clone, matching the poll trait's
+    // "clone the session for concurrency".
+    open_uni: OpenUni,
+    open_bi: OpenBi,
+}
+
+/// Where an in-progress `poll_open_uni` got to.
+#[derive(Default)]
+enum OpenUni {
+    #[default]
+    Idle,
+    /// Stream taken, header partially written.
+    Header { send: ez::SendStream, offset: usize },
+}
+
+/// Where an in-progress `poll_open_bi` got to.
+#[derive(Default)]
+enum OpenBi {
+    #[default]
+    Idle,
+    Header {
+        send: ez::SendStream,
+        recv: ez::RecvStream,
+        offset: usize,
+    },
+}
+
+impl Clone for OpenUni {
+    /// A clone starts idle; the operation in flight stays with the handle that
+    /// started it.
+    fn clone(&self) -> Self {
+        Self::Idle
+    }
+}
+
+impl Clone for OpenBi {
+    fn clone(&self) -> Self {
+        Self::Idle
+    }
 }
 
 impl Connection {
@@ -102,6 +146,8 @@ impl Connection {
             request: connect.request.clone(),
             response: connect.response.clone(),
             settings: Some(Arc::new(settings)),
+            open_uni: OpenUni::Idle,
+            open_bi: OpenBi::Idle,
         };
 
         // Run a background task to check if the connect stream is closed.
@@ -227,12 +273,17 @@ impl Connection {
     /// peer over the connection.
     /// It waits for a datagram to become available and returns the received bytes.
     pub async fn read_datagram(&self) -> Result<Bytes, SessionError> {
-        let mut datagram = self
+        let datagram = self
             .conn
             .read_datagram()
             .await
             .map_err(SessionError::from)?;
 
+        self.strip_datagram_header(datagram)
+    }
+
+    /// Validate and remove the session ID a WebTransport datagram carries.
+    fn strip_datagram_header(&self, mut datagram: Bytes) -> Result<Bytes, SessionError> {
         let mut cursor = Cursor::new(&datagram);
 
         if let Some(session_id) = self.session_id {
@@ -244,9 +295,7 @@ impl Connection {
         }
 
         // Return the datagram without the session ID.
-        let datagram = datagram.split_off(cursor.position() as usize);
-
-        Ok(datagram)
+        Ok(datagram.split_off(cursor.position() as usize))
     }
 
     /// Sends an application datagram to the remote peer.
@@ -325,6 +374,8 @@ impl Connection {
             settings: None,
             request: request.into(),
             response: response.into(),
+            open_uni: OpenUni::Idle,
+            open_bi: OpenBi::Idle,
         }
     }
 
@@ -653,5 +704,137 @@ impl SessionAccept {
         }
 
         Ok(Some((send, recv)))
+    }
+}
+
+impl web_transport_trait::poll::Session for Connection {
+    type SendStream = SendStream;
+    type RecvStream = RecvStream;
+    type Error = SessionError;
+
+    fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
+        match self.accept.clone() {
+            // `SessionAccept` decodes stream headers, so it keeps its own state and
+            // waker list; forward to it.
+            Some(accept) => accept.lock().unwrap().poll_accept_uni(cx),
+            None => {
+                let recv = ready!(self.conn.poll_accept_uni(cx.waker()))?;
+                Poll::Ready(Ok(RecvStream::new(recv)))
+            }
+        }
+    }
+
+    fn poll_accept_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        match self.accept.clone() {
+            Some(accept) => accept.lock().unwrap().poll_accept_bi(cx),
+            None => {
+                let (send, recv) = ready!(self.conn.poll_accept_bi(cx.waker()))?;
+                Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))))
+            }
+        }
+    }
+
+    fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<SendStream, SessionError>> {
+        loop {
+            match &mut self.open_uni {
+                OpenUni::Idle => {
+                    let send = ready!(self.conn.poll_open_uni(cx.waker()))?;
+                    self.open_uni = OpenUni::Header { send, offset: 0 };
+                }
+                OpenUni::Header { send, offset } => {
+                    while *offset < self.header_uni.len() {
+                        let size = ready!(send.poll_write(cx, &self.header_uni[*offset..]))
+                            .map_err(SessionError::Header)?;
+                        *offset += size;
+                    }
+
+                    // Header written: hand the stream over and go idle.
+                    let OpenUni::Header { send, .. } =
+                        std::mem::replace(&mut self.open_uni, OpenUni::Idle)
+                    else {
+                        unreachable!("checked above");
+                    };
+
+                    return Poll::Ready(Ok(SendStream::new(send)));
+                }
+            }
+        }
+    }
+
+    fn poll_open_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        loop {
+            match &mut self.open_bi {
+                OpenBi::Idle => {
+                    let (send, recv) = ready!(self.conn.poll_open_bi(cx.waker()))?;
+                    self.open_bi = OpenBi::Header {
+                        send,
+                        recv,
+                        offset: 0,
+                    };
+                }
+                OpenBi::Header { send, offset, .. } => {
+                    while *offset < self.header_bi.len() {
+                        let size = ready!(send.poll_write(cx, &self.header_bi[*offset..]))
+                            .map_err(SessionError::Header)?;
+                        *offset += size;
+                    }
+
+                    let OpenBi::Header { send, recv, .. } =
+                        std::mem::replace(&mut self.open_bi, OpenBi::Idle)
+                    else {
+                        unreachable!("checked above");
+                    };
+
+                    return Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))));
+                }
+            }
+        }
+    }
+
+    fn poll_send_datagram(
+        &mut self,
+        _cx: &mut Context<'_>,
+        payload: &[u8],
+    ) -> Poll<Result<(), SessionError>> {
+        // `ez` queues outbound datagrams into a bounded channel and drops on full,
+        // which is the unreliable contract — there is no capacity to wait for, so
+        // this never parks.
+        let mut buf = BytesMut::with_capacity(self.header_datagram.len() + payload.len());
+        buf.extend_from_slice(&self.header_datagram);
+        buf.extend_from_slice(payload);
+
+        Poll::Ready(self.conn.send_datagram(buf.into()).map_err(Into::into))
+    }
+
+    fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {
+        let datagram = ready!(self.conn.poll_read_datagram(cx.waker()))?;
+        Poll::Ready(self.strip_datagram_header(datagram))
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        Self::max_datagram_size(self)
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        self.response.protocol.as_deref()
+    }
+
+    fn close(&mut self, code: u32, reason: &str) {
+        Self::close(self, code, reason);
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<SessionError> {
+        self.conn.poll_closed(cx.waker()).map(Into::into)
+    }
+
+    #[allow(refining_impl_trait)]
+    fn stats(&self) -> ez::ConnectionStats {
+        Self::stats(self)
     }
 }

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -234,18 +234,12 @@ impl ClientBuilder {
 
         let params = tokio_quiche::ConnectionParams::new_client(self.settings, tls_cert, hooks);
 
-        let accept_bi = flume::unbounded();
-        let accept_uni = flume::unbounded();
-        let dgram_in = flume::bounded(DGRAM_CHANNEL_CAPACITY);
         let dgram_out = flume::bounded(DGRAM_CHANNEL_CAPACITY);
         let dgram_max = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
         let driver = Lock::new(DriverState::new(false));
         let app = Driver::new(
             driver.clone(),
-            accept_bi.0,
-            accept_uni.0,
-            dgram_in.0,
             dgram_out.1,
             dgram_max.clone(),
             self.keep_alive,
@@ -255,15 +249,7 @@ impl ClientBuilder {
             .await
             .map_err(|e| io::Error::other(e.to_string()))?;
 
-        let conn = Connection::new(
-            conn,
-            driver.clone(),
-            accept_bi.1,
-            accept_uni.1,
-            dgram_in.1,
-            dgram_out.0,
-            dgram_max,
-        );
+        let conn = Connection::new(conn, driver.clone(), dgram_out.0, dgram_max);
         Ok(Connecting {
             connection: conn,
             driver,

--- a/rs/web-transport-quiche/src/ez/connection.rs
+++ b/rs/web-transport-quiche/src/ez/connection.rs
@@ -9,7 +9,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Mutex,
     },
-    task::{Poll, Waker},
+    task::{ready, Poll, Waker},
 };
 use thiserror::Error;
 use tokio_quiche::quiche;
@@ -141,12 +141,15 @@ impl ConnectionClose {
         }
     }
 
-    pub async fn wait(&self) -> ConnectionError {
-        poll_fn(|cx| self.driver.lock().closed(cx.waker())).await
-    }
-
+    /// Only the test below still needs this: accept and datagram reads used to race
+    /// it in a `select!`, and now poll the driver's own error state directly.
+    #[cfg(test)]
     pub async fn error(&self) -> ConnectionError {
         poll_fn(|cx| self.driver.lock().error(cx.waker())).await
+    }
+
+    pub async fn wait(&self) -> ConnectionError {
+        poll_fn(|cx| self.driver.lock().closed(cx.waker())).await
     }
 
     pub fn is_closed(&self) -> bool {
@@ -176,13 +179,12 @@ impl Drop for ConnectionClose {
 pub struct Connection {
     inner: Arc<tokio_quiche::QuicConnection>,
 
-    // Unbounded
-    accept_bi: flume::Receiver<(SendStream, RecvStream)>,
-    accept_uni: flume::Receiver<RecvStream>,
-
-    // Datagram plumbing. Both channels are bounded; drops on full are silent
-    // and consistent with the unreliable QUIC datagram contract.
-    dgram_in: flume::Receiver<Bytes>,
+    // Accepted streams and inbound datagrams are queued in `DriverState`, not in a
+    // channel, so they can be polled: a channel's receive future owns its waker
+    // registration and drops it with the future.
+    //
+    // Outbound datagrams stay a channel — bounded, and dropping on full is
+    // consistent with the unreliable QUIC datagram contract.
     dgram_out: flume::Sender<Bytes>,
     dgram_max: Arc<AtomicUsize>,
 
@@ -196,9 +198,6 @@ impl Connection {
     pub(super) fn new(
         conn: tokio_quiche::QuicConnection,
         driver: Lock<DriverState>,
-        accept_bi: flume::Receiver<(SendStream, RecvStream)>,
-        accept_uni: flume::Receiver<RecvStream>,
-        dgram_in: flume::Receiver<Bytes>,
         dgram_out: flume::Sender<Bytes>,
         dgram_max: Arc<AtomicUsize>,
     ) -> Self {
@@ -206,9 +205,6 @@ impl Connection {
 
         Self {
             inner: Arc::new(conn),
-            accept_bi,
-            accept_uni,
-            dgram_in,
             dgram_out,
             dgram_max,
             driver,
@@ -218,18 +214,31 @@ impl Connection {
 
     /// Accept a bidirectional stream created by the remote peer.
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), ConnectionError> {
-        tokio::select! {
-            Ok(res) = self.accept_bi.recv_async() => Ok(res),
-            err = self.close.error() => Err(err),
-        }
+        poll_fn(|cx| self.poll_accept_bi(cx.waker())).await
+    }
+
+    /// Poll for a bidirectional stream created by the remote peer.
+    pub fn poll_accept_bi(
+        &self,
+        waker: &Waker,
+    ) -> Poll<Result<(SendStream, RecvStream), ConnectionError>> {
+        let (id, send, recv) = ready!(self.driver.lock().poll_accept_bi(waker))?;
+
+        Poll::Ready(Ok((
+            SendStream::new(id, send, self.driver.clone()),
+            RecvStream::new(id, recv, self.driver.clone()),
+        )))
     }
 
     /// Accept a unidirectional stream created by the remote peer.
     pub async fn accept_uni(&self) -> Result<RecvStream, ConnectionError> {
-        tokio::select! {
-            Ok(res) = self.accept_uni.recv_async() => Ok(res),
-            err = self.close.error() => Err(err),
-        }
+        poll_fn(|cx| self.poll_accept_uni(cx.waker())).await
+    }
+
+    /// Poll for a unidirectional stream created by the remote peer.
+    pub fn poll_accept_uni(&self, waker: &Waker) -> Poll<Result<RecvStream, ConnectionError>> {
+        let (id, recv) = ready!(self.driver.lock().poll_accept_uni(waker))?;
+        Poll::Ready(Ok(RecvStream::new(id, recv, self.driver.clone())))
     }
 
     /// Open a new bidirectional stream.
@@ -260,18 +269,47 @@ impl Connection {
         Ok(send)
     }
 
+    /// Poll to open a new unidirectional stream.
+    pub fn poll_open_uni(&self, waker: &Waker) -> Poll<Result<SendStream, ConnectionError>> {
+        let (wakeup, id, send) = ready!(self.driver.lock().open_uni(waker))?;
+        if let Some(wakeup) = wakeup {
+            wakeup.wake();
+        }
+
+        Poll::Ready(Ok(SendStream::new(id, send, self.driver.clone())))
+    }
+
+    /// Poll to open a new bidirectional stream.
+    pub fn poll_open_bi(
+        &self,
+        waker: &Waker,
+    ) -> Poll<Result<(SendStream, RecvStream), ConnectionError>> {
+        let (wakeup, id, send, recv) = ready!(self.driver.lock().open_bi(waker))?;
+        if let Some(wakeup) = wakeup {
+            wakeup.wake();
+        }
+
+        Poll::Ready(Ok((
+            SendStream::new(id, send, self.driver.clone()),
+            RecvStream::new(id, recv, self.driver.clone()),
+        )))
+    }
+
+    /// Poll until the connection is closed and drained.
+    pub fn poll_closed(&self, waker: &Waker) -> Poll<ConnectionError> {
+        self.driver.lock().closed(waker)
+    }
+
     /// Receive the next application datagram from the remote peer.
     ///
     /// Waits until a datagram arrives or the connection is closed.
     pub async fn read_datagram(&self) -> Result<Bytes, ConnectionError> {
-        tokio::select! {
-            res = self.dgram_in.recv_async() => match res {
-                Ok(bytes) => Ok(bytes),
-                // Sender dropped — the driver closed; surface the close reason.
-                Err(_) => Err(self.close.error().await),
-            },
-            err = self.close.error() => Err(err),
-        }
+        poll_fn(|cx| self.poll_read_datagram(cx.waker())).await
+    }
+
+    /// Poll for the next application datagram from the remote peer.
+    pub fn poll_read_datagram(&self, waker: &Waker) -> Poll<Result<Bytes, ConnectionError>> {
+        self.driver.lock().poll_dgram_in(waker)
     }
 
     /// Queue an application datagram for the driver to send.

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use rustls_pki_types::CertificateDer;
 use std::{
-    collections::{hash_map, HashMap, HashSet},
+    collections::{hash_map, HashMap, HashSet, VecDeque},
     future::poll_fn,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -19,12 +19,25 @@ use tokio_quiche::{
 use crate::ez::Lock;
 
 use super::{
-    ConnectionClosed, ConnectionError, ConnectionStats, Metrics, RecvState, RecvStream, SendState,
-    SendStream, StreamId,
+    ConnectionClosed, ConnectionError, ConnectionStats, Metrics, RecvState, SendState, StreamId,
 };
 
 // "drop" in ascii; if you see this then close(code)
 const DROP_CODE: u64 = 0x64726F70;
+
+/// How many datagrams to hold for the application before dropping the oldest.
+const DGRAM_QUEUE_CAPACITY: usize = 32;
+
+/// Register `waker` unless an equivalent one is already parked.
+fn park(wakers: &mut Vec<Waker>, waker: &Waker) {
+    if !wakers.iter().any(|w| w.will_wake(waker)) {
+        wakers.push(waker.clone());
+    }
+}
+
+type AcceptBiResult = Poll<Result<(StreamId, Lock<SendState>, Lock<RecvState>), ConnectionError>>;
+
+type AcceptUniResult = Poll<Result<(StreamId, Lock<RecvState>), ConnectionError>>;
 
 type OpenBiResult =
     Poll<Result<(Option<Waker>, StreamId, Lock<SendState>, Lock<RecvState>), ConnectionError>>;
@@ -62,6 +75,27 @@ pub(super) struct DriverState {
 
     /// Latest connection statistics, refreshed by the driver each poll.
     stats: ConnectionStats,
+
+    /// Streams the peer opened, waiting to be handed out, and whoever is parked on
+    /// them.
+    ///
+    /// These hold the stream *parts* rather than built `SendStream`/`RecvStream`:
+    /// those keep a `Lock<DriverState>`, so parking one here would be a reference
+    /// cycle. `Connection` assembles them, exactly as it does for `open_uni`.
+    ///
+    /// A channel would be the obvious home, but its receive future owns the waker
+    /// registration and drops it with the future — so an abandoned poll would never
+    /// be woken again. Parking the waker here is what makes `poll_accept_*` honest.
+    accept_bi: VecDeque<(StreamId, Lock<SendState>, Lock<RecvState>)>,
+    accept_uni: VecDeque<(StreamId, Lock<RecvState>)>,
+    accept_bi_wakers: Vec<Waker>,
+    accept_uni_wakers: Vec<Waker>,
+
+    /// Datagrams received from the peer. Bounded: when the application cannot keep
+    /// up the *oldest* is dropped, which is the unreliable-datagram contract and
+    /// keeps the freshest data, unlike a channel that rejects the newest.
+    dgram_in: VecDeque<Bytes>,
+    dgram_in_wakers: Vec<Waker>,
 }
 
 impl DriverState {
@@ -88,6 +122,12 @@ impl DriverState {
             server_name: None,
             peer_certs: None,
             handshake_wakers: Vec::new(),
+            accept_bi: VecDeque::new(),
+            accept_uni: VecDeque::new(),
+            accept_bi_wakers: Vec::new(),
+            accept_uni_wakers: Vec::new(),
+            dgram_in: VecDeque::new(),
+            dgram_in_wakers: Vec::new(),
             stats: ConnectionStats::default(),
         }
     }
@@ -214,6 +254,80 @@ impl DriverState {
         Poll::Ready(Ok((wakeup, id, send, recv)))
     }
 
+    /// Queue a stream the peer opened, returning the wakers to notify.
+    ///
+    /// The caller wakes them after releasing the lock, matching the rest of this
+    /// type.
+    pub fn push_accept_bi(
+        &mut self,
+        id: StreamId,
+        send: Lock<SendState>,
+        recv: Lock<RecvState>,
+    ) -> Vec<Waker> {
+        self.accept_bi.push_back((id, send, recv));
+        std::mem::take(&mut self.accept_bi_wakers)
+    }
+
+    pub fn push_accept_uni(&mut self, id: StreamId, recv: Lock<RecvState>) -> Vec<Waker> {
+        self.accept_uni.push_back((id, recv));
+        std::mem::take(&mut self.accept_uni_wakers)
+    }
+
+    pub fn poll_accept_bi(&mut self, waker: &Waker) -> AcceptBiResult {
+        // Drain what already arrived before reporting a close: streams the peer
+        // opened are finite and the application is entitled to them.
+        if let Some(parts) = self.accept_bi.pop_front() {
+            return Poll::Ready(Ok(parts));
+        }
+
+        if let Poll::Ready(err) = self.error(waker) {
+            return Poll::Ready(Err(err));
+        }
+
+        park(&mut self.accept_bi_wakers, waker);
+        Poll::Pending
+    }
+
+    pub fn poll_accept_uni(&mut self, waker: &Waker) -> AcceptUniResult {
+        if let Some(parts) = self.accept_uni.pop_front() {
+            return Poll::Ready(Ok(parts));
+        }
+
+        if let Poll::Ready(err) = self.error(waker) {
+            return Poll::Ready(Err(err));
+        }
+
+        park(&mut self.accept_uni_wakers, waker);
+        Poll::Pending
+    }
+
+    /// Queue a datagram from the peer, returning the wakers to notify.
+    ///
+    /// Drops the oldest when full rather than the new arrival: for unreliable
+    /// datagrams the freshest data is the useful data.
+    pub fn push_dgram_in(&mut self, datagram: Bytes) -> Vec<Waker> {
+        while self.dgram_in.len() >= DGRAM_QUEUE_CAPACITY {
+            tracing::trace!("dropping oldest incoming datagram: queue full");
+            self.dgram_in.pop_front();
+        }
+
+        self.dgram_in.push_back(datagram);
+        std::mem::take(&mut self.dgram_in_wakers)
+    }
+
+    pub fn poll_dgram_in(&mut self, waker: &Waker) -> Poll<Result<Bytes, ConnectionError>> {
+        if let Some(datagram) = self.dgram_in.pop_front() {
+            return Poll::Ready(Ok(datagram));
+        }
+
+        if let Poll::Ready(err) = self.error(waker) {
+            return Poll::Ready(Err(err));
+        }
+
+        park(&mut self.dgram_in_wakers, waker);
+        Poll::Pending
+    }
+
     pub fn open_uni(&mut self, waker: &Waker) -> OpenUniResult {
         if let Poll::Ready(err) = self.error(waker) {
             return Poll::Ready(Err(err));
@@ -281,11 +395,8 @@ pub(super) struct Driver {
 
     buf: Vec<u8>,
 
-    accept_bi: flume::Sender<(SendStream, RecvStream)>,
-    accept_uni: flume::Sender<RecvStream>,
-
-    // Datagrams.
-    dgram_in: flume::Sender<Bytes>,
+    // Datagrams. Only the outbound half is a channel now; inbound datagrams and
+    // accepted streams are queued in `DriverState` so they can be polled.
     dgram_out: flume::Receiver<Bytes>,
     // Writable datagram size in bytes, published once at handshake. 0 means the
     // peer didn't negotiate the datagram extension.
@@ -297,9 +408,6 @@ pub(super) struct Driver {
 impl Driver {
     pub fn new(
         state: Lock<DriverState>,
-        accept_bi: flume::Sender<(SendStream, RecvStream)>,
-        accept_uni: flume::Sender<RecvStream>,
-        dgram_in: flume::Sender<Bytes>,
         dgram_out: flume::Receiver<Bytes>,
         dgram_max: Arc<AtomicUsize>,
         keep_alive: Option<Duration>,
@@ -309,9 +417,6 @@ impl Driver {
             send: HashMap::new(),
             recv: HashMap::new(),
             buf: vec![0u8; BufFactory::MAX_BUF_SIZE],
-            accept_bi,
-            accept_uni,
-            dgram_in,
             dgram_out,
             dgram_max,
             keep_alive: keep_alive.map(KeepAlive::new),
@@ -420,7 +525,7 @@ impl Driver {
         let state = Lock::new(state);
 
         self.recv.insert(stream_id, state.clone());
-        let recv = RecvStream::new(stream_id, state.clone(), self.state.clone());
+        let recv_state = state.clone();
 
         let mut state = SendState::new(stream_id);
         state.flush(qconn)?;
@@ -428,10 +533,14 @@ impl Driver {
         let state = Lock::new(state);
         self.send.insert(stream_id, state.clone());
 
-        let send = SendStream::new(stream_id, state.clone(), self.state.clone());
-        self.accept_bi
-            .send((send, recv))
-            .map_err(|_| ConnectionError::Dropped)?;
+        let wakers = self
+            .state
+            .lock()
+            .push_accept_bi(stream_id, state.clone(), recv_state);
+
+        for waker in wakers {
+            waker.wake();
+        }
 
         Ok(())
     }
@@ -449,10 +558,11 @@ impl Driver {
         let state = Lock::new(state);
         self.recv.insert(stream_id, state.clone());
 
-        let recv = RecvStream::new(stream_id, state.clone(), self.state.clone());
-        self.accept_uni
-            .send(recv)
-            .map_err(|_| ConnectionError::Dropped)?;
+        let wakers = self.state.lock().push_accept_uni(stream_id, state);
+
+        for waker in wakers {
+            waker.wake();
+        }
 
         Ok(())
     }
@@ -717,15 +827,10 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
             match qconn.dgram_recv(&mut self.buf) {
                 Ok(len) => {
                     let buf = Bytes::copy_from_slice(&self.buf[..len]);
-                    match self.dgram_in.try_send(buf) {
-                        Ok(()) => {}
-                        Err(flume::TrySendError::Full(_)) => {
-                            tracing::trace!("dropping incoming datagram: channel full");
-                        }
-                        Err(flume::TrySendError::Disconnected(_)) => {
-                            // Receiver dropped — connection gone or not interested.
-                            break;
-                        }
+                    let wakers = self.state.lock().push_dgram_in(buf);
+
+                    for waker in wakers {
+                        waker.wake();
                     }
                 }
                 Err(quiche::Error::Done) => break,

--- a/rs/web-transport-quiche/src/ez/recv.rs
+++ b/rs/web-transport-quiche/src/ez/recv.rs
@@ -251,7 +251,26 @@ impl RecvStream {
         poll_fn(|cx| self.poll_read_chunk(cx.waker(), max)).await
     }
 
-    fn poll_read_chunk(
+    /// Poll to read some data into the buffer, returning the amount read.
+    ///
+    /// Returns `None` if the stream has been finished by the remote.
+    pub fn poll_read(
+        &mut self,
+        waker: &Waker,
+        buf: &mut [u8],
+    ) -> Poll<Result<Option<usize>, StreamError>> {
+        let chunk = ready!(self.poll_read_chunk(waker, buf.len()))?;
+
+        Poll::Ready(Ok(chunk.map(|chunk| {
+            buf[..chunk.len()].copy_from_slice(&chunk);
+            chunk.len()
+        })))
+    }
+
+    /// Poll to read a chunk of data from the stream, avoiding a copy.
+    ///
+    /// Returns `None` if the stream has been finished by the remote.
+    pub fn poll_read_chunk(
         &mut self,
         waker: &Waker,
         max: usize,
@@ -325,7 +344,8 @@ impl RecvStream {
         self.state.lock().is_closed()
     }
 
-    fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+    /// Poll until the stream is closed by either side.
+    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
         if let Poll::Ready(res) = self.state.lock().poll_closed(waker) {
             return Poll::Ready(res);
         }

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -249,10 +249,21 @@ impl SendStream {
         poll_fn(|cx| self.poll_write_buf(cx, &mut buf)).await
     }
 
-    // Write some of the buffer to the stream, advancing the internal position.
-    //
-    // Returns the number of bytes written for convenience.
-    fn poll_write_buf<B: Buf>(
+    /// Poll to write some data to the stream, returning the size written.
+    pub fn poll_write(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, StreamError>> {
+        let mut buf = io::Cursor::new(buf);
+        self.poll_write_buf(cx, &mut buf)
+    }
+
+    /// Poll to write some of the buffer to the stream, advancing the internal
+    /// position.
+    ///
+    /// Returns the number of bytes written for convenience.
+    pub fn poll_write_buf<B: Buf>(
         &mut self,
         cx: &mut Context<'_>,
         buf: &mut B,
@@ -352,7 +363,8 @@ impl SendStream {
         self.state.lock().is_closed()
     }
 
-    fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+    /// Poll until the stream is closed by either side.
+    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
         if let Poll::Ready(res) = self.state.lock().poll_closed(waker) {
             return Poll::Ready(res);
         }

--- a/rs/web-transport-quiche/src/ez/server.rs
+++ b/rs/web-transport-quiche/src/ez/server.rs
@@ -379,33 +379,14 @@ impl<M: Metrics> Server<M> {
         while let Some(initial) = rx.recv().await {
             let initial = initial?;
 
-            let accept_bi = flume::unbounded();
-            let accept_uni = flume::unbounded();
-            let dgram_in = flume::bounded(DGRAM_CHANNEL_CAPACITY);
             let dgram_out = flume::bounded(DGRAM_CHANNEL_CAPACITY);
             let dgram_max = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
             let state = Lock::new(DriverState::new(true));
-            let session = Driver::new(
-                state.clone(),
-                accept_bi.0,
-                accept_uni.0,
-                dgram_in.0,
-                dgram_out.1,
-                dgram_max.clone(),
-                keep_alive,
-            );
+            let session = Driver::new(state.clone(), dgram_out.1, dgram_max.clone(), keep_alive);
 
             let inner = initial.start(session);
-            let connection = Connection::new(
-                inner,
-                state.clone(),
-                accept_bi.1,
-                accept_uni.1,
-                dgram_in.1,
-                dgram_out.0,
-                dgram_max,
-            );
+            let connection = Connection::new(inner, state.clone(), dgram_out.0, dgram_max);
             let incoming = Incoming {
                 connection,
                 driver: state,

--- a/rs/web-transport-quiche/src/recv.rs
+++ b/rs/web-transport-quiche/src/recv.rs
@@ -102,3 +102,34 @@ impl web_transport_trait::RecvStream for RecvStream {
         self.closed().await
     }
 }
+
+impl web_transport_trait::poll::RecvStream for RecvStream {
+    type Error = StreamError;
+
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, Self::Error>> {
+        self.inner.poll_read(cx.waker(), dst).map_err(Into::into)
+    }
+
+    fn poll_read_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+        max: usize,
+    ) -> Poll<Result<Option<Bytes>, Self::Error>> {
+        // ez already owns the bytes, so this hands them over instead of copying.
+        self.inner
+            .poll_read_chunk(cx.waker(), max)
+            .map_err(Into::into)
+    }
+
+    fn stop(&mut self, code: u32) {
+        self.stop(code);
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_closed(cx.waker()).map_err(Into::into)
+    }
+}

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -130,3 +130,37 @@ impl web_transport_trait::SendStream for SendStream {
         self.closed().await
     }
 }
+
+impl web_transport_trait::poll::SendStream for SendStream {
+    type Error = StreamError;
+
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+        self.inner.poll_write(cx, buf).map_err(Into::into)
+    }
+
+    fn poll_write_buf<B: Buf>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>> {
+        // ez advances `buf` by exactly what it accepted, so this keeps the
+        // partial-write contract while skipping the default's extra copy.
+        self.inner.poll_write_buf(cx, buf).map_err(Into::into)
+    }
+
+    fn set_priority(&mut self, order: u8) {
+        self.set_priority(order)
+    }
+
+    fn reset(&mut self, code: u32) {
+        self.reset(code)
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        self.finish()
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_closed(cx.waker()).map_err(Into::into)
+    }
+}

--- a/rs/web-transport-quiche/tests/poll.rs
+++ b/rs/web-transport-quiche/tests/poll.rs
@@ -1,0 +1,125 @@
+//! Drive a real quiche session entirely through the poll surface.
+//!
+//! Nothing here calls an `async` method on the transport — every operation goes
+//! through `web_transport_trait::poll`, stepped with `poll_fn`. Unlike quinn, quiche
+//! reaches this with no retained futures at all: `ez` exposes a `poll_*` for every
+//! step, so opening a stream is a plain state machine over them.
+
+use std::{
+    future::poll_fn,
+    net::{Ipv4Addr, SocketAddr},
+};
+
+use anyhow::{Context as _, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use url::Url;
+use web_transport_quiche::{ClientBuilder, ServerBuilder, Settings};
+use web_transport_trait::poll::{RecvStream, SendStream, Session};
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+fn client() -> ClientBuilder {
+    let mut settings = Settings::default();
+    settings.verify_peer = false;
+    ClientBuilder::default().with_settings(settings)
+}
+
+/// A client and server session, already connected.
+async fn pair() -> Result<(
+    web_transport_quiche::Connection,
+    web_transport_quiche::Connection,
+)> {
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("no connection")?;
+        anyhow::Ok(request.ok().await?)
+    });
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let client = client()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(url)
+        .await?
+        .established()
+        .await?;
+
+    let server = server_task.await??;
+    Ok((client, server))
+}
+
+/// Open, write, finish, accept and read — all through `poll_*`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_uni_stream_round_trips_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let mut send = poll_fn(|cx| client.poll_open_uni(cx)).await?;
+    poll_fn(|cx| send.poll_write(cx, b"hello")).await?;
+    send.finish()?;
+
+    let mut recv = poll_fn(|cx| server.poll_accept_uni(cx)).await?;
+
+    let mut dst = [0u8; 16];
+    let size = poll_fn(|cx| recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"hello");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bi_stream_round_trips_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let (mut client_send, mut client_recv) = poll_fn(|cx| client.poll_open_bi(cx)).await?;
+    poll_fn(|cx| client_send.poll_write(cx, b"ping")).await?;
+
+    let (mut server_send, mut server_recv) = poll_fn(|cx| server.poll_accept_bi(cx)).await?;
+
+    let mut dst = [0u8; 16];
+    let size = poll_fn(|cx| server_recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"ping");
+
+    poll_fn(|cx| server_send.poll_write(cx, b"pong")).await?;
+    let size = poll_fn(|cx| client_recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"pong");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    poll_fn(|cx| client.poll_send_datagram(cx, b"dgram")).await?;
+
+    let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
+    assert_eq!(&received[..], b"dgram");
+
+    Ok(())
+}

--- a/rs/web-transport-quinn/Cargo.toml
+++ b/rs/web-transport-quinn/Cargo.toml
@@ -57,3 +57,4 @@ rcgen = "0.14"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2"

--- a/rs/web-transport-quinn/src/lib.rs
+++ b/rs/web-transport-quinn/src/lib.rs
@@ -26,6 +26,7 @@
 // External
 mod client;
 mod error;
+mod op;
 mod recv;
 mod send;
 mod server;

--- a/rs/web-transport-quinn/src/op.rs
+++ b/rs/web-transport-quinn/src/op.rs
@@ -1,0 +1,85 @@
+//! A future retained across `poll` calls.
+//!
+//! Quinn exposes most connection-level operations only as futures, and those
+//! futures hold the thing that matters between polls: the `Notify` registration
+//! that will wake us. Building a fresh one inside every `poll_*` call would drop
+//! that registration the moment we returned `Pending`, and nothing would ever wake
+//! the caller again. So the future has to outlive the poll that created it.
+//!
+//! This is deliberately private to this crate. It boxes a `Send` future, which a
+//! transport pinned to one thread could not use, so it has no business in
+//! `web-transport-trait` — the poll traits describe what an implementation must do,
+//! not how a runtime-backed one gets there.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Mutex,
+    task::{ready, Context, Poll},
+};
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+
+/// One in-flight operation.
+///
+/// The future is created on first poll, kept while it is pending, and dropped once
+/// it resolves so the next poll starts a fresh operation. Cloning yields an idle
+/// slot: the in-progress operation stays with the handle that started it, which is
+/// what makes cloning a session the way to run operations concurrently.
+pub(crate) struct Op<T> {
+    // The `Mutex` is here only so the enclosing `Session` stays `Sync`: a boxed
+    // `Send` future is not itself `Sync`. Polling goes through `&mut self` and uses
+    // `get_mut`, so there is no runtime locking on that path.
+    future: Mutex<Option<BoxFuture<T>>>,
+}
+
+impl<T: 'static> Op<T> {
+    /// Poll the operation in progress, starting one with `make` when idle.
+    ///
+    /// `make` is only called when there is nothing in flight, so the caller can
+    /// build its arguments lazily rather than on every poll.
+    pub(crate) fn poll<F>(&mut self, cx: &mut Context<'_>, make: impl FnOnce() -> F) -> Poll<T>
+    where
+        F: Future<Output = T> + Send + 'static,
+    {
+        let slot = self.future.get_mut().unwrap();
+        let future = slot.get_or_insert_with(|| Box::pin(make()));
+        let output = ready!(future.as_mut().poll(cx));
+        *slot = None;
+        Poll::Ready(output)
+    }
+}
+
+impl<T> Default for Op<T> {
+    fn default() -> Self {
+        Self {
+            future: Mutex::new(None),
+        }
+    }
+}
+
+impl<T> Clone for Op<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> std::fmt::Debug for Op<T> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("Op").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Op;
+
+    /// The reason `Op` holds a `Mutex`. Every backend `Session` was `Send + Sync`
+    /// before this existed, and embedding a bare boxed future would have silently
+    /// taken `Sync` away.
+    #[test]
+    fn op_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Op<()>>();
+    }
+}

--- a/rs/web-transport-quinn/src/op.rs
+++ b/rs/web-transport-quinn/src/op.rs
@@ -34,6 +34,25 @@ pub(crate) struct Op<T> {
 }
 
 impl<T: 'static> Op<T> {
+    /// Poll an operation already in flight, if there is one.
+    ///
+    /// `Some` is its result; `None` means the slot is idle and the caller should
+    /// start one. This exists so a caller can build the future's arguments only when
+    /// they will actually be used — `poll` takes them eagerly, and `make` is ignored
+    /// while something is already in flight.
+    pub(crate) fn poll_pending(&mut self, cx: &mut Context<'_>) -> Option<Poll<T>> {
+        let slot = self.future.get_mut().unwrap();
+        let future = slot.as_mut()?;
+
+        match future.as_mut().poll(cx) {
+            Poll::Pending => Some(Poll::Pending),
+            Poll::Ready(output) => {
+                *slot = None;
+                Some(Poll::Ready(output))
+            }
+        }
+    }
+
     /// Poll the operation in progress, starting one with `make` when idle.
     ///
     /// `make` is only called when there is nothing in flight, so the caller can
@@ -72,6 +91,8 @@ impl<T> std::fmt::Debug for Op<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::task::Poll;
+
     use super::Op;
 
     /// The reason `Op` holds a `Mutex`. Every backend `Session` was `Send + Sync`
@@ -81,5 +102,32 @@ mod tests {
     fn op_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Op<()>>();
+    }
+
+    #[test]
+    fn poll_pending_reports_an_idle_slot() {
+        let mut op = Op::<()>::default();
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+
+        assert!(op.poll_pending(&mut cx).is_none(), "nothing started yet");
+    }
+
+    /// Why callers check `poll_pending` before building arguments: once an operation
+    /// is in flight, `poll` ignores `make` entirely. A caller that computed its
+    /// argument first would allocate it on every poll and then silently discard it —
+    /// and if the argument had *changed*, the change would go missing with no error.
+    #[test]
+    fn an_in_flight_operation_ignores_later_arguments() {
+        let mut op = Op::default();
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+
+        // Start one that never finishes.
+        assert!(op.poll(&mut cx, std::future::pending::<u32>).is_pending());
+
+        // A second call hands over a different value; it must not take effect.
+        assert!(op.poll(&mut cx, || std::future::ready(2)).is_pending());
+
+        // And `poll_pending` sees the original, still in flight.
+        assert!(matches!(op.poll_pending(&mut cx), Some(Poll::Pending)));
     }
 }

--- a/rs/web-transport-quinn/src/recv.rs
+++ b/rs/web-transport-quinn/src/recv.rs
@@ -1,8 +1,9 @@
 use std::{
+    future::Future,
     io,
     pin::Pin,
     sync::{Arc, OnceLock},
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use bytes::Bytes;
@@ -147,5 +148,39 @@ impl web_transport_trait::RecvStream for RecvStream {
     async fn closed(&mut self) -> Result<(), Self::Error> {
         self.received_reset().await?;
         Ok(())
+    }
+}
+
+impl web_transport_trait::poll::RecvStream for RecvStream {
+    type Error = ReadError;
+
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, Self::Error>> {
+        if dst.is_empty() {
+            // Asking for no bytes is not end of stream.
+            return Poll::Ready(Ok(Some(0)));
+        }
+
+        let size = ready!(quinn::RecvStream::poll_read(&mut self.inner, cx, dst))
+            .map_err(|e| self.map_error(e))?;
+
+        // Quinn reports a finished stream as zero bytes into a non-empty buffer.
+        Poll::Ready(Ok((size != 0).then_some(size)))
+    }
+
+    fn stop(&mut self, code: u32) {
+        Self::stop(self, code).ok();
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Nothing to retain: Quinn parks this waker in the connection's
+        // `blocked_readers` map keyed by stream ID, not inside the future, so the
+        // registration outlives the future we build here and drop again.
+        let mut reset = std::pin::pin!(self.received_reset());
+        ready!(reset.as_mut().poll(cx))?;
+        Poll::Ready(Ok(()))
     }
 }

--- a/rs/web-transport-quinn/src/send.rs
+++ b/rs/web-transport-quinn/src/send.rs
@@ -2,7 +2,7 @@ use std::{
     io,
     pin::Pin,
     sync::{Arc, OnceLock},
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use bytes::Bytes;
@@ -17,11 +17,18 @@ use crate::{ClosedStream, SessionError, WriteError};
 pub struct SendStream {
     stream: quinn::SendStream,
     error: Arc<OnceLock<SessionError>>,
+
+    // Retains the `stopped()` future across `poll_closed` calls.
+    closed: crate::op::Op<Result<(), WriteError>>,
 }
 
 impl SendStream {
     pub(crate) fn new(stream: quinn::SendStream, error: Arc<OnceLock<SessionError>>) -> Self {
-        Self { stream, error }
+        Self {
+            stream,
+            error,
+            closed: Default::default(),
+        }
     }
 
     /// Replace connection-level errors with the stored session error if available.
@@ -185,5 +192,61 @@ impl web_transport_trait::SendStream for SendStream {
             Some(code) => Err(WriteError::Stopped(code)),
             None => Ok(()),
         }
+    }
+}
+
+impl web_transport_trait::poll::SendStream for SendStream {
+    type Error = WriteError;
+
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+        let size = ready!(quinn::SendStream::poll_write(
+            Pin::new(&mut self.stream),
+            cx,
+            buf
+        ))
+        .map_err(|e| self.map_error(e))?;
+        Poll::Ready(Ok(size))
+    }
+
+    // `poll_write_buf` is deliberately left to the trait's default, which writes out
+    // of `buf.chunk()` and advances only by what Quinn accepted. Overriding it to
+    // `copy_to_bytes` up front and then write the zero-copy `write_chunk` would be
+    // faster but loses data: the chunk would be gone from `buf` before Quinn
+    // accepted it, a silent hole in the stream if the write does not complete.
+
+    fn set_priority(&mut self, order: u8) {
+        Self::set_priority(self, order.into()).ok();
+    }
+
+    fn reset(&mut self, code: u32) {
+        Self::reset(self, code).ok();
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        Self::finish(self).map_err(|_| WriteError::ClosedStream)
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `stopped()` registers with the connection's notifier on its first poll, so
+        // the future has to be retained — rebuilding it every poll would drop that
+        // registration and we would never be woken.
+        let stopped = self.stream.stopped();
+        let error = self.error.clone();
+
+        self.closed.poll(cx, move || async move {
+            match stopped.await {
+                Ok(Some(code)) => match web_transport_proto::error_from_http3(code.into_inner()) {
+                    Some(code) => Err(WriteError::Stopped(code)),
+                    None => Err(WriteError::InvalidStopped(code)),
+                },
+                Ok(None) => Ok(()),
+                Err(quinn::StoppedError::ConnectionLost(conn_err)) => {
+                    Err(WriteError::SessionError(
+                        error.get().cloned().unwrap_or_else(|| conn_err.into()),
+                    ))
+                }
+                Err(quinn::StoppedError::ZeroRttRejected) => unreachable!("0-RTT not supported"),
+            }
+        })
     }
 }

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -973,6 +973,25 @@ impl Session {
         ))
     }
 
+    fn send_datagram_framed(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: Bytes,
+    ) -> Poll<Result<(), SessionError>> {
+        let conn = self.conn.clone();
+        let payload = Self::frame_datagram(&self.header_datagram, payload);
+        let error = self.error.clone();
+
+        // `send_datagram_wait` is what makes this pollable rather than a drop: it
+        // parks until the transport has room. Retained, because its `Notify`
+        // registration lives in the future.
+        self.op_send_datagram.poll(cx, move || async move {
+            conn.send_datagram_wait(payload)
+                .await
+                .map_err(|e| Session::map_error_owned(&error, e))
+        })
+    }
+
     // Prepend the session ID, as `send_datagram`/`send_datagram_wait` do.
     fn frame_datagram(header: &Bytes, data: Bytes) -> Bytes {
         if header.is_empty() {
@@ -1086,20 +1105,21 @@ impl web_transport_trait::poll::Session for Session {
     fn poll_send_datagram(
         &mut self,
         cx: &mut Context<'_>,
+        payload: &[u8],
+    ) -> Poll<Result<(), SessionError>> {
+        // Quinn's datagram API needs an owned `Bytes`, so a slice costs a copy here.
+        // Callers holding a `Bytes` should use `poll_send_datagram_chunk`, which is
+        // overridden below to avoid it.
+        self.send_datagram_framed(cx, Bytes::copy_from_slice(payload))
+    }
+
+    fn poll_send_datagram_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
         payload: &Bytes,
     ) -> Poll<Result<(), SessionError>> {
-        let conn = self.conn.clone();
-        let payload = Self::frame_datagram(&self.header_datagram, payload.clone());
-        let error = self.error.clone();
-
-        // `send_datagram_wait` is what makes this pollable rather than a drop: it
-        // parks until the transport has room. Retained, because its `Notify`
-        // registration lives in the future.
-        self.op_send_datagram.poll(cx, move || async move {
-            conn.send_datagram_wait(payload)
-                .await
-                .map_err(|e| Session::map_error_owned(&error, e))
-        })
+        // Free on the raw path, where there is no session-ID header to prepend.
+        self.send_datagram_framed(cx, payload.clone())
     }
 
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -37,9 +37,9 @@ pub struct Session {
     accept: Option<Arc<Mutex<SessionAccept>>>,
 
     // Cache the headers in front of each stream we open.
-    header_uni: Vec<u8>,
-    header_bi: Vec<u8>,
-    header_datagram: Vec<u8>,
+    header_uni: Bytes,
+    header_bi: Bytes,
+    header_datagram: Bytes,
 
     // Keep a reference to the settings and connect stream to avoid closing them until dropped.
     #[allow(dead_code)]
@@ -59,6 +59,23 @@ pub struct Session {
 
     // The response sent by the server.
     response: ConnectResponse,
+
+    // Quinn exposes these only as futures, and those futures hold the `Notify`
+    // registration that will wake us — rebuilding one per poll would drop the
+    // registration and we would never be woken. Each is per-clone, so cloning the
+    // session is what gives you concurrent operations.
+    //
+    // Accept is absent on purpose: `SessionAccept` already holds its stream
+    // persistently, so `poll_accept_*` forwards natively.
+    // Only used by `Session::raw`, where there is no `SessionAccept` to forward to
+    // and Quinn's own accept futures hold the registration.
+    op_accept_uni: crate::op::Op<Result<RecvStream, SessionError>>,
+    op_accept_bi: crate::op::Op<Result<(SendStream, RecvStream), SessionError>>,
+    op_open_uni: crate::op::Op<Result<SendStream, SessionError>>,
+    op_open_bi: crate::op::Op<Result<(SendStream, RecvStream), SessionError>>,
+    op_send_datagram: crate::op::Op<Result<(), SessionError>>,
+    op_recv_datagram: crate::op::Op<Result<Bytes, SessionError>>,
+    op_closed: crate::op::Op<SessionError>,
 }
 
 impl Session {
@@ -87,14 +104,21 @@ impl Session {
             conn,
             accept: Some(Arc::new(Mutex::new(accept))),
             session_id: Some(session_id),
-            header_uni,
-            header_bi,
-            header_datagram,
+            header_uni: header_uni.into(),
+            header_bi: header_bi.into(),
+            header_datagram: header_datagram.into(),
             settings: Some(Arc::new(settings)),
             connect_send: Arc::new(Mutex::new(Some(connect.send))),
             error: error.clone(),
             request: connect.request.clone(),
             response: connect.response.clone(),
+            op_accept_uni: Default::default(),
+            op_accept_bi: Default::default(),
+            op_open_uni: Default::default(),
+            op_open_bi: Default::default(),
+            op_send_datagram: Default::default(),
+            op_recv_datagram: Default::default(),
+            op_closed: Default::default(),
         };
 
         // Run a background task to read capsules from the CONNECT recv stream.
@@ -466,8 +490,20 @@ impl Session {
 
     /// Replace connection-level errors with the stored session error if available.
     fn map_error(&self, e: impl Into<SessionError>) -> SessionError {
+        map_error_with(&self.error, e)
+    }
+
+    // The owned-argument form, for futures that outlive the borrow that created them.
+    fn map_error_owned(error: &OnceLock<SessionError>, e: impl Into<SessionError>) -> SessionError {
+        map_error_with(error, e)
+    }
+}
+
+/// Replace connection-level errors with the stored session error if available.
+fn map_error_with(stored: &OnceLock<SessionError>, e: impl Into<SessionError>) -> SessionError {
+    {
         let e = e.into();
-        if let Some(err) = self.error.get() {
+        if let Some(err) = stored.get() {
             if matches!(
                 &e,
                 SessionError::ConnectionError(_)
@@ -479,7 +515,9 @@ impl Session {
         }
         e
     }
+}
 
+impl Session {
     async fn write_full(send: &mut quinn::SendStream, buf: &[u8]) -> Result<(), SessionError> {
         match send.write_all(buf).await {
             Ok(_) => Ok(()),
@@ -504,6 +542,13 @@ impl Session {
             header_bi: Default::default(),
             header_datagram: Default::default(),
             accept: None,
+            op_accept_uni: Default::default(),
+            op_accept_bi: Default::default(),
+            op_open_uni: Default::default(),
+            op_open_bi: Default::default(),
+            op_send_datagram: Default::default(),
+            op_recv_datagram: Default::default(),
+            op_closed: Default::default(),
             settings: None,
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
@@ -874,6 +919,218 @@ impl web_transport_trait::Session for Session {
 
     fn protocol(&self) -> Option<&str> {
         self.response.protocol.as_deref()
+    }
+
+    #[allow(refining_impl_trait)]
+    fn stats(&self) -> SessionStats {
+        Self::stats(self)
+    }
+}
+
+impl Session {
+    // Open plus stream-header write, over owned arguments so the result can live in
+    // a retained future. Mirrors `open_uni`/`open_bi`, including the priority dance.
+    async fn open_uni_owned(
+        conn: quinn::Connection,
+        header: Bytes,
+        error: Arc<OnceLock<SessionError>>,
+    ) -> Result<SendStream, SessionError> {
+        let mut send = conn
+            .open_uni()
+            .await
+            .map_err(|e| Self::map_error_owned(&error, e))?;
+
+        // Max priority for the header so the application cannot queue lower-priority
+        // data in front of it, then back to the default.
+        send.set_priority(i32::MAX).ok();
+        Self::write_full(&mut send, &header)
+            .await
+            .map_err(|e| Self::map_error_owned(&error, e))?;
+        send.set_priority(0).ok();
+
+        Ok(SendStream::new(send, error))
+    }
+
+    async fn open_bi_owned(
+        conn: quinn::Connection,
+        header: Bytes,
+        error: Arc<OnceLock<SessionError>>,
+    ) -> Result<(SendStream, RecvStream), SessionError> {
+        let (mut send, recv) = conn
+            .open_bi()
+            .await
+            .map_err(|e| Self::map_error_owned(&error, e))?;
+
+        send.set_priority(i32::MAX).ok();
+        Self::write_full(&mut send, &header)
+            .await
+            .map_err(|e| Self::map_error_owned(&error, e))?;
+        send.set_priority(0).ok();
+
+        Ok((
+            SendStream::new(send, error.clone()),
+            RecvStream::new(recv, error),
+        ))
+    }
+
+    // Prepend the session ID, as `send_datagram`/`send_datagram_wait` do.
+    fn frame_datagram(header: &Bytes, data: Bytes) -> Bytes {
+        if header.is_empty() {
+            return data;
+        }
+
+        // Unfortunately, we need to allocate/copy each datagram because of the Quinn API.
+        // Pls go +1 if you care: https://github.com/quinn-rs/quinn/issues/1724
+        let mut buf = BytesMut::with_capacity(header.len() + data.len());
+        buf.extend_from_slice(header);
+        buf.extend_from_slice(&data);
+        buf.into()
+    }
+
+    async fn read_datagram_owned(
+        conn: quinn::Connection,
+        session_id: Option<VarInt>,
+        error: Arc<OnceLock<SessionError>>,
+    ) -> Result<Bytes, SessionError> {
+        let mut datagram = conn
+            .read_datagram()
+            .await
+            .map_err(|e| Self::map_error_owned(&error, e))?;
+
+        let mut cursor = Cursor::new(&datagram);
+
+        if let Some(session_id) = session_id {
+            // We have to check and strip the session ID from the datagram.
+            let actual_id =
+                VarInt::decode(&mut cursor).map_err(|_| WebTransportError::UnknownSession)?;
+            if actual_id != session_id {
+                return Err(WebTransportError::UnknownSession.into());
+            }
+        }
+
+        // Return the datagram without the session ID.
+        Ok(datagram.split_off(cursor.position() as usize))
+    }
+}
+
+impl web_transport_trait::poll::Session for Session {
+    type SendStream = SendStream;
+    type RecvStream = RecvStream;
+    type Error = SessionError;
+
+    // Accept forwards natively: `SessionAccept` already drives a persistent stream
+    // and keeps a waker list, so there is nothing to retain here.
+    fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
+        if let Some(accept) = self.accept.clone() {
+            return accept.lock().unwrap().poll_accept_uni(cx);
+        }
+
+        let conn = self.conn.clone();
+        let error = self.error.clone();
+
+        self.op_accept_uni.poll(cx, move || async move {
+            let recv = conn
+                .accept_uni()
+                .await
+                .map_err(|e| Session::map_error_owned(&error, e))?;
+            Ok(RecvStream::new(recv, error))
+        })
+    }
+
+    fn poll_accept_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        if let Some(accept) = self.accept.clone() {
+            return accept.lock().unwrap().poll_accept_bi(cx);
+        }
+
+        let conn = self.conn.clone();
+        let error = self.error.clone();
+
+        self.op_accept_bi.poll(cx, move || async move {
+            let (send, recv) = conn
+                .accept_bi()
+                .await
+                .map_err(|e| Session::map_error_owned(&error, e))?;
+            Ok((
+                SendStream::new(send, error.clone()),
+                RecvStream::new(recv, error),
+            ))
+        })
+    }
+
+    fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<SendStream, SessionError>> {
+        let conn = self.conn.clone();
+        let header = self.header_uni.clone();
+        let error = self.error.clone();
+
+        self.op_open_uni.poll(cx, move || async move {
+            Session::open_uni_owned(conn, header, error).await
+        })
+    }
+
+    fn poll_open_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        let conn = self.conn.clone();
+        let header = self.header_bi.clone();
+        let error = self.error.clone();
+
+        self.op_open_bi.poll(cx, move || async move {
+            Session::open_bi_owned(conn, header, error).await
+        })
+    }
+
+    fn poll_send_datagram(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: &Bytes,
+    ) -> Poll<Result<(), SessionError>> {
+        let conn = self.conn.clone();
+        let payload = Self::frame_datagram(&self.header_datagram, payload.clone());
+        let error = self.error.clone();
+
+        // `send_datagram_wait` is what makes this pollable rather than a drop: it
+        // parks until the transport has room. Retained, because its `Notify`
+        // registration lives in the future.
+        self.op_send_datagram.poll(cx, move || async move {
+            conn.send_datagram_wait(payload)
+                .await
+                .map_err(|e| Session::map_error_owned(&error, e))
+        })
+    }
+
+    fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {
+        let conn = self.conn.clone();
+        let session_id = self.session_id;
+        let error = self.error.clone();
+
+        self.op_recv_datagram.poll(cx, move || {
+            Session::read_datagram_owned(conn, session_id, error)
+        })
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        Self::max_datagram_size(self)
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        self.response.protocol.as_deref()
+    }
+
+    fn close(&mut self, code: u32, reason: &str) {
+        Self::close(self, code, reason.as_bytes());
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<SessionError> {
+        let conn = self.conn.clone();
+        let error = self.error.clone();
+
+        self.op_closed.poll(cx, move || async move {
+            Session::map_error_owned(&error, conn.closed().await)
+        })
     }
 
     #[allow(refining_impl_trait)]

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -976,9 +976,11 @@ impl Session {
     fn send_datagram_framed(
         &mut self,
         cx: &mut Context<'_>,
-        payload: Bytes,
+        payload: &[u8],
     ) -> Poll<Result<(), SessionError>> {
         let conn = self.conn.clone();
+        // Quinn's datagram API needs an owned `Bytes` either way, and the HTTP/3 path
+        // has to copy regardless to prepend the session ID.
         let payload = Self::frame_datagram(&self.header_datagram, payload);
         let error = self.error.clone();
 
@@ -993,16 +995,13 @@ impl Session {
     }
 
     // Prepend the session ID, as `send_datagram`/`send_datagram_wait` do.
-    fn frame_datagram(header: &Bytes, data: Bytes) -> Bytes {
-        if header.is_empty() {
-            return data;
-        }
-
-        // Unfortunately, we need to allocate/copy each datagram because of the Quinn API.
-        // Pls go +1 if you care: https://github.com/quinn-rs/quinn/issues/1724
+    //
+    // Unfortunately, we need to allocate/copy each datagram because of the Quinn API.
+    // Pls go +1 if you care: https://github.com/quinn-rs/quinn/issues/1724
+    fn frame_datagram(header: &Bytes, data: &[u8]) -> Bytes {
         let mut buf = BytesMut::with_capacity(header.len() + data.len());
         buf.extend_from_slice(header);
-        buf.extend_from_slice(&data);
+        buf.extend_from_slice(data);
         buf.into()
     }
 
@@ -1107,19 +1106,7 @@ impl web_transport_trait::poll::Session for Session {
         cx: &mut Context<'_>,
         payload: &[u8],
     ) -> Poll<Result<(), SessionError>> {
-        // Quinn's datagram API needs an owned `Bytes`, so a slice costs a copy here.
-        // Callers holding a `Bytes` should use `poll_send_datagram_chunk`, which is
-        // overridden below to avoid it.
-        self.send_datagram_framed(cx, Bytes::copy_from_slice(payload))
-    }
-
-    fn poll_send_datagram_chunk(
-        &mut self,
-        cx: &mut Context<'_>,
-        payload: &Bytes,
-    ) -> Poll<Result<(), SessionError>> {
-        // Free on the raw path, where there is no session-ID header to prepend.
-        self.send_datagram_framed(cx, payload.clone())
+        self.send_datagram_framed(cx, payload)
     }
 
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -65,8 +65,6 @@ pub struct Session {
     // registration and we would never be woken. Each is per-clone, so cloning the
     // session is what gives you concurrent operations.
     //
-    // Accept is absent on purpose: `SessionAccept` already holds its stream
-    // persistently, so `poll_accept_*` forwards natively.
     // Only used by `Session::raw`, where there is no `SessionAccept` to forward to
     // and Quinn's own accept futures hold the registration.
     op_accept_uni: crate::op::Op<Result<RecvStream, SessionError>>,
@@ -240,39 +238,22 @@ impl Session {
 
     /// Open a new unidirectional stream. See [`quinn::Connection::open_uni`].
     pub async fn open_uni(&self) -> Result<SendStream, SessionError> {
-        let mut send = self.conn.open_uni().await.map_err(|e| self.map_error(e))?;
-
-        // Set the stream priority to max and then write the stream header.
-        // Otherwise the application could write data with lower priority than the header, resulting in queuing.
-        // Also the header is very important for determining the session ID without reliable reset.
-        send.set_priority(i32::MAX).ok();
-        Self::write_full(&mut send, &self.header_uni)
-            .await
-            .map_err(|e| self.map_error(e))?;
-
-        // Reset the stream priority back to the default of 0.
-        send.set_priority(0).ok();
-        Ok(SendStream::new(send, self.error.clone()))
+        Self::open_uni_owned(
+            self.conn.clone(),
+            self.header_uni.clone(),
+            self.error.clone(),
+        )
+        .await
     }
 
     /// Open a new bidirectional stream. See [`quinn::Connection::open_bi`].
     pub async fn open_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
-        let (mut send, recv) = self.conn.open_bi().await.map_err(|e| self.map_error(e))?;
-
-        // Set the stream priority to max and then write the stream header.
-        // Otherwise the application could write data with lower priority than the header, resulting in queuing.
-        // Also the header is very important for determining the session ID without reliable reset.
-        send.set_priority(i32::MAX).ok();
-        Self::write_full(&mut send, &self.header_bi)
-            .await
-            .map_err(|e| self.map_error(e))?;
-
-        // Reset the stream priority back to the default of 0.
-        send.set_priority(0).ok();
-        Ok((
-            SendStream::new(send, self.error.clone()),
-            RecvStream::new(recv, self.error.clone()),
-        ))
+        Self::open_bi_owned(
+            self.conn.clone(),
+            self.header_bi.clone(),
+            self.error.clone(),
+        )
+        .await
     }
 
     /// Asynchronously receives an application datagram from the remote peer.
@@ -281,27 +262,7 @@ impl Session {
     /// peer over the connection.
     /// It waits for a datagram to become available and returns the received bytes.
     pub async fn read_datagram(&self) -> Result<Bytes, SessionError> {
-        let mut datagram = self
-            .conn
-            .read_datagram()
-            .await
-            .map_err(|e| self.map_error(e))?;
-
-        let mut cursor = Cursor::new(&datagram);
-
-        if let Some(session_id) = self.session_id {
-            // We have to check and strip the session ID from the datagram.
-            let actual_id =
-                VarInt::decode(&mut cursor).map_err(|_| WebTransportError::UnknownSession)?;
-            if actual_id != session_id {
-                return Err(WebTransportError::UnknownSession.into());
-            }
-        }
-
-        // Return the datagram without the session ID.
-        let datagram = datagram.split_off(cursor.position() as usize);
-
-        Ok(datagram)
+        Self::read_datagram_owned(self.conn.clone(), self.session_id, self.error.clone()).await
     }
 
     /// Sends an application datagram to the remote peer.
@@ -978,6 +939,14 @@ impl Session {
         cx: &mut Context<'_>,
         payload: &[u8],
     ) -> Poll<Result<(), SessionError>> {
+        // Resume an in-flight send before touching `payload`. Framing first would
+        // allocate on every poll and then discard it, and would quietly ignore a
+        // caller that retried with a different datagram — the retained future
+        // already owns the one it started with.
+        if let Some(result) = self.op_send_datagram.poll_pending(cx) {
+            return result;
+        }
+
         let conn = self.conn.clone();
         // Quinn's datagram API needs an owned `Bytes` either way, and the HTTP/3 path
         // has to copy regardless to prepend the session ID.

--- a/rs/web-transport-quinn/tests/poll.rs
+++ b/rs/web-transport-quinn/tests/poll.rs
@@ -125,10 +125,10 @@ async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
     Ok(())
 }
 
-/// A `Pending` open must be *resumed*, not restarted. Poll the open once against a
-/// waker that goes nowhere, then drive it to completion on a different one: if the
-/// implementation rebuilt its future per poll it would have dropped Quinn's notifier
-/// registration and this would hang.
+/// A `Pending` operation must be *resumed*, not restarted. Poll `poll_closed` once
+/// against a waker that goes nowhere, then drive it to completion on a different one:
+/// if the implementation rebuilt its close-wait future per poll it would have dropped
+/// Quinn's notifier registration and this would hang.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_pending_operation_is_resumed_not_restarted() -> Result<()> {
     let (mut client, mut server) = pair().await?;

--- a/rs/web-transport-quinn/tests/poll.rs
+++ b/rs/web-transport-quinn/tests/poll.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
-use bytes::Bytes;
 use rcgen::{CertifiedKey, KeyPair};
 use web_transport_proto::ConnectRequest;
 use web_transport_quinn::quinn::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
@@ -118,20 +117,10 @@ async fn a_bi_stream_round_trips_through_the_poll_surface() -> Result<()> {
 async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
     let (mut client, mut server) = pair().await?;
 
-    // The zero-copy form, for a caller that already holds a `Bytes`.
-    let payload = Bytes::from_static(b"dgram");
-    poll_fn(|cx| client.poll_send_datagram_chunk(cx, &payload)).await?;
+    poll_fn(|cx| client.poll_send_datagram(cx, b"dgram")).await?;
 
     let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
     assert_eq!(&received[..], b"dgram");
-
-    // The caller still owns it, which is the point of taking it by reference.
-    assert_eq!(&payload[..], b"dgram");
-
-    // And the slice form, for a caller that does not.
-    poll_fn(|cx| client.poll_send_datagram(cx, b"slice")).await?;
-    let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
-    assert_eq!(&received[..], b"slice");
 
     Ok(())
 }

--- a/rs/web-transport-quinn/tests/poll.rs
+++ b/rs/web-transport-quinn/tests/poll.rs
@@ -118,14 +118,20 @@ async fn a_bi_stream_round_trips_through_the_poll_surface() -> Result<()> {
 async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
     let (mut client, mut server) = pair().await?;
 
+    // The zero-copy form, for a caller that already holds a `Bytes`.
     let payload = Bytes::from_static(b"dgram");
-    poll_fn(|cx| client.poll_send_datagram(cx, &payload)).await?;
+    poll_fn(|cx| client.poll_send_datagram_chunk(cx, &payload)).await?;
 
     let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
     assert_eq!(&received[..], b"dgram");
 
     // The caller still owns it, which is the point of taking it by reference.
     assert_eq!(&payload[..], b"dgram");
+
+    // And the slice form, for a caller that does not.
+    poll_fn(|cx| client.poll_send_datagram(cx, b"slice")).await?;
+    let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
+    assert_eq!(&received[..], b"slice");
 
     Ok(())
 }

--- a/rs/web-transport-quinn/tests/poll.rs
+++ b/rs/web-transport-quinn/tests/poll.rs
@@ -1,0 +1,164 @@
+//! Drive a real Quinn session entirely through the poll surface.
+//!
+//! Nothing here calls an `async` method on the transport. Every operation goes
+//! through `web_transport_trait::poll`, stepped with `poll_fn` so the trait's own
+//! `Poll` contract is what is under test — including that a `Pending` open or accept
+//! is actually resumed rather than restarted, which is the part that breaks if a
+//! retained future is rebuilt per poll.
+
+use std::{
+    future::{poll_fn, Future},
+    net::Ipv4Addr,
+};
+
+use anyhow::{Context as _, Result};
+use bytes::Bytes;
+use rcgen::{CertifiedKey, KeyPair};
+use web_transport_proto::ConnectRequest;
+use web_transport_quinn::quinn::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+use web_transport_quinn::{ClientBuilder, ServerBuilder};
+use web_transport_trait::{
+    poll::{RecvStream, SendStream, Session},
+    Error as _,
+};
+
+/// With both crypto features enabled — as `--all-features` does — the crate cannot
+/// pick a provider for us, so the test installs one. Harmless when only one feature
+/// is on, since a default is already set by then.
+fn install_crypto_provider() {
+    #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+    {
+        let _ = web_transport_quinn::quinn::rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
+    }
+}
+
+/// A client and server session, already connected.
+async fn pair() -> Result<(web_transport_quinn::Session, web_transport_quinn::Session)> {
+    install_crypto_provider();
+
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])?;
+    let chain = vec![cert.der().clone()];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
+
+    let mut server = ServerBuilder::new()
+        .with_addr((Ipv4Addr::LOCALHOST, 0).into())
+        .with_certificate(chain.clone(), key)?;
+
+    let addr = server.local_addr()?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("no connection")?;
+        let session = request.ok().await?;
+        anyhow::Ok(session)
+    });
+
+    let url: url::Url = format!("https://127.0.0.1:{}/", addr.port()).parse()?;
+    let client = ClientBuilder::new().with_server_certificates(chain)?;
+    let client = client.connect(ConnectRequest::new(url)).await?;
+
+    let server = server_task.await??;
+    Ok((client, server))
+}
+
+/// Open, write, finish, accept and read — all through `poll_*`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_uni_stream_round_trips_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let mut send = poll_fn(|cx| client.poll_open_uni(cx)).await?;
+    let size = poll_fn(|cx| send.poll_write(cx, b"hello")).await?;
+    assert_eq!(size, 5);
+    send.finish()?;
+
+    let mut recv = poll_fn(|cx| server.poll_accept_uni(cx)).await?;
+
+    let mut dst = [0u8; 16];
+    let size = poll_fn(|cx| recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"hello");
+
+    // Drained and finished.
+    assert_eq!(poll_fn(|cx| recv.poll_read(cx, &mut dst)).await?, None);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bi_stream_round_trips_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let (mut client_send, mut client_recv) = poll_fn(|cx| client.poll_open_bi(cx)).await?;
+    poll_fn(|cx| client_send.poll_write(cx, b"ping")).await?;
+
+    let (mut server_send, mut server_recv) = poll_fn(|cx| server.poll_accept_bi(cx)).await?;
+
+    let mut dst = [0u8; 16];
+    let size = poll_fn(|cx| server_recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"ping");
+
+    poll_fn(|cx| server_send.poll_write(cx, b"pong")).await?;
+    let size = poll_fn(|cx| client_recv.poll_read(cx, &mut dst))
+        .await?
+        .context("stream ended early")?;
+    assert_eq!(&dst[..size], b"pong");
+
+    Ok(())
+}
+
+/// The datagram path, including that `poll_send_datagram` is retried with the same
+/// payload rather than taking ownership.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let payload = Bytes::from_static(b"dgram");
+    poll_fn(|cx| client.poll_send_datagram(cx, &payload)).await?;
+
+    let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
+    assert_eq!(&received[..], b"dgram");
+
+    // The caller still owns it, which is the point of taking it by reference.
+    assert_eq!(&payload[..], b"dgram");
+
+    Ok(())
+}
+
+/// A `Pending` open must be *resumed*, not restarted. Poll the open once against a
+/// waker that goes nowhere, then drive it to completion on a different one: if the
+/// implementation rebuilt its future per poll it would have dropped Quinn's notifier
+/// registration and this would hang.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_pending_operation_is_resumed_not_restarted() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let mut closed = std::pin::pin!(poll_fn(|cx| client.poll_closed(cx)));
+
+    // Register, then abandon that poll.
+    let noop = std::task::Waker::noop();
+    assert!(
+        closed
+            .as_mut()
+            .poll(&mut std::task::Context::from_waker(noop))
+            .is_pending(),
+        "the session should still be open"
+    );
+
+    // Disambiguate from the inherent `close`, which takes bytes.
+    Session::close(&mut server, 42, "bye");
+
+    // Now drive it on the real task waker.
+    let err = closed.await;
+    assert!(
+        err.session_error().is_some(),
+        "expected an application close, got {err:?}"
+    );
+
+    Ok(())
+}

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -59,8 +59,11 @@ impl Stats for StatsUnavailable {}
 
 /// Error trait for WebTransport operations.
 ///
-/// Implementations must be Send + Sync + 'static for use across async boundaries.
-pub trait Error: std::error::Error + MaybeSend + MaybeSync + 'static {
+/// Deliberately *not* `Send + Sync`. Those are required by the async traits below,
+/// whose futures must be spawnable, and are declared there. The [`poll`] traits need
+/// neither, so a transport pinned to one thread can carry an error that borrows its
+/// connection state.
+pub trait Error: std::error::Error + 'static {
     /// Returns the error code and reason if this was an application error.
     ///
     /// NOTE: Reason reasons are technically bytes on the wire, but we convert to a String for convenience.
@@ -79,7 +82,9 @@ pub trait Error: std::error::Error + MaybeSend + MaybeSync + 'static {
 pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
     type SendStream: SendStream;
     type RecvStream: RecvStream;
-    type Error: Error;
+    // `Send` so a spawned future can carry it out; `Sync` so it boxes into
+    // `Box<dyn Error + Send + Sync>` and `anyhow::Error` like any other error.
+    type Error: Error + MaybeSend + MaybeSync;
 
     /// Block until the peer creates a new unidirectional stream.
     fn accept_uni(&self)
@@ -137,7 +142,7 @@ pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
 /// QUIC streams have flow control, which means the send rate is limited by the peer's receive window.
 /// The stream will be closed with a graceful FIN when dropped.
 pub trait SendStream: MaybeSend {
-    type Error: Error;
+    type Error: Error + MaybeSend + MaybeSync;
 
     /// Write some of the buffer to the stream, returning how many bytes were
     /// written. See [`write_buf`](Self::write_buf) for the cancel-safety contract,
@@ -253,7 +258,7 @@ pub trait SendStream: MaybeSend {
 /// All bytes are flushed in order and the stream is flow controlled.
 /// The stream will be closed with STOP_SENDING code=0 when dropped.
 pub trait RecvStream: MaybeSend {
-    type Error: Error;
+    type Error: Error + MaybeSend + MaybeSync;
 
     /// Read the next chunk of data, up to the max size.
     ///

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -61,8 +61,9 @@ impl Stats for StatsUnavailable {}
 ///
 /// Deliberately *not* `Send + Sync`. Those are required by the async traits below,
 /// whose futures must be spawnable, and are declared there. The [`poll`] traits need
-/// neither, so a transport pinned to one thread can carry an error that borrows its
-/// connection state.
+/// neither, so a transport pinned to one thread can use an error type that is
+/// neither — one holding an [`std::rc::Rc`] to shared connection state, say.
+/// (Still `'static`, so an error cannot *borrow* that state.)
 pub trait Error: std::error::Error + 'static {
     /// Returns the error code and reason if this was an application error.
     ///

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -1,8 +1,10 @@
+mod poll;
 mod util;
 
 use std::future::Future;
 use std::time::Duration;
 
+pub use crate::poll::{BiStreams, PollRecvStream, PollSendStream, PollSession};
 pub use crate::util::{MaybeSend, MaybeSync};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -1,10 +1,9 @@
-mod poll;
+pub mod poll;
 mod util;
 
 use std::future::Future;
 use std::time::Duration;
 
-pub use crate::poll::{BiStreams, PollRecvStream, PollSendStream, PollSession};
 pub use crate::util::{MaybeSend, MaybeSync};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -120,20 +120,6 @@ pub trait Session {
         payload: &[u8],
     ) -> Poll<Result<(), Self::Error>>;
 
-    /// Poll to send a datagram the caller already owns as a [`Bytes`].
-    ///
-    /// The default copies through [`poll_send_datagram`](Self::poll_send_datagram).
-    /// Override it when the transport can take the [`Bytes`] as-is, so a caller
-    /// holding one is not charged a copy — the same split as
-    /// [`SendStream::poll_write`] and a zero-copy chunk write.
-    fn poll_send_datagram_chunk(
-        &mut self,
-        cx: &mut Context<'_>,
-        payload: &Bytes,
-    ) -> Poll<Result<(), Self::Error>> {
-        self.poll_send_datagram(cx, payload)
-    }
-
     /// Poll for a datagram from the network.
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>>;
 

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -102,9 +102,11 @@ pub trait Session {
     /// Returns [`Poll::Pending`] while the transport has no room for it, so a caller
     /// can wait for capacity rather than having the payload dropped underneath it.
     ///
-    /// `payload` is taken by reference because a [`Poll::Pending`] return means the
-    /// caller retries with the same datagram; an implementation clones it — a
-    /// refcount bump — only once it has accepted it.
+    /// `payload` is taken by reference, not by value or as a [`Buf`]: a
+    /// [`Poll::Pending`] return means the caller retries with the same datagram, and
+    /// both of those would have consumed it. (A datagram also needs *contiguous*
+    /// bytes, and the only way to get those from a generic [`Buf`] is
+    /// [`Buf::copy_to_bytes`], which consumes.)
     ///
     /// Accepting a datagram is not delivery. QUIC datagrams may still be dropped:
     /// - Network congestion.
@@ -115,8 +117,22 @@ pub trait Session {
     fn poll_send_datagram(
         &mut self,
         cx: &mut Context<'_>,
-        payload: &Bytes,
+        payload: &[u8],
     ) -> Poll<Result<(), Self::Error>>;
+
+    /// Poll to send a datagram the caller already owns as a [`Bytes`].
+    ///
+    /// The default copies through [`poll_send_datagram`](Self::poll_send_datagram).
+    /// Override it when the transport can take the [`Bytes`] as-is, so a caller
+    /// holding one is not charged a copy — the same split as
+    /// [`SendStream::poll_write`] and a zero-copy chunk write.
+    fn poll_send_datagram_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: &Bytes,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.poll_send_datagram(cx, payload)
+    }
 
     /// Poll for a datagram from the network.
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>>;

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -1,0 +1,316 @@
+//! The `poll`-based surface of a WebTransport session and its streams.
+//!
+//! These traits are the sans-I/O half of this crate. They describe a transport as a
+//! state machine that a caller steps from its own loop, rather than a set of futures
+//! that a runtime drives.
+//!
+//! Two properties are deliberate, and both are constraints on what an implementation
+//! is *allowed* to be rather than features it gets:
+//!
+//! - **No `Send` or `Sync` bound.** A transport pinned to one thread — a
+//!   thread-per-core `io_uring` runtime, say — can implement these. The async traits
+//!   in the crate root add `MaybeSend` on top, because their futures need it; the
+//!   poll traits do not, so a `!Send` stack stays expressible all the way down.
+//!   [`PollSession`]'s associated stream types only require the poll halves, so the
+//!   bound cannot leak back in through them.
+//!
+//! - **`&mut self` throughout, and no `Clone`.** A sans-I/O state machine owns its
+//!   state and mutates it in place. A `&self` surface would force every
+//!   implementation into interior mutability — an `Arc<Mutex<..>>` around the
+//!   connection, or a slot shared between callers — whether or not its own design
+//!   needs one. Taking `&mut self` gives each handle exactly one owner by
+//!   construction, which is also what makes retained in-progress state safe: a
+//!   `poll_open_uni` that claimed stream credit before returning [`Poll::Pending`]
+//!   has an unambiguous owner to resume it.
+//!
+//! Run operations concurrently by cloning the concrete session, where each clone
+//! gets its own state. `Clone` is deliberately *not* a supertrait, so a session that
+//! cannot be duplicated is still expressible.
+//!
+//! # Retaining state between calls
+//!
+//! A `poll_*` method may keep its own progress across calls, and often should —
+//! [`PollSendStream::poll_write_buf`] will typically have reserved send capacity by
+//! the time it returns [`Poll::Pending`], and starting over would give that back.
+//! What it must not keep is anything belonging to the *caller*:
+//!
+//! - Nothing about a buffer argument may be assumed to survive. Every call gets a
+//!   fresh one, and a caller is free to retry a pending write with a shorter buffer.
+//!   Retained progress must be reconciled against the buffer actually presented, not
+//!   the one that started the operation.
+//! - Whatever ends the stream — [`PollSendStream::reset`],
+//!   [`PollSendStream::finish`], a peer STOP_SENDING seen by
+//!   [`PollSendStream::poll_closed`] — must release retained progress. Nothing else
+//!   will: the guards at the top of a write return early once the stream is closed,
+//!   so no later call reaches the cleanup, and a reservation held past that point is
+//!   leaked for the life of the stream.
+//! - A resource that other handles contend for — a queue slot, a shared lock —
+//!   should not be held across a wait. A caller may abandon an operation simply by
+//!   never polling it again, and anything the retained state owns is abandoned with
+//!   it. Retain the *waiting*, not the resource.
+
+use std::task::{ready, Context, Poll};
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use crate::{Error, Stats, StatsUnavailable};
+
+/// The stream pair produced by opening or accepting a bidirectional stream.
+pub type BiStreams<S> = (
+    <S as PollSession>::SendStream,
+    <S as PollSession>::RecvStream,
+);
+
+/// The `poll`-based surface of a WebTransport session.
+///
+/// See the [module docs](self) for why this takes `&mut self` and carries no `Send`
+/// bound.
+pub trait PollSession {
+    /// The outgoing stream type. Only the poll half is required, so a `!Send`
+    /// session can hang `!Send` streams off it.
+    type SendStream: PollSendStream;
+
+    /// The incoming stream type. Only the poll half is required, so a `!Send`
+    /// session can hang `!Send` streams off it.
+    type RecvStream: PollRecvStream;
+
+    /// The error type for every operation on this session.
+    type Error: Error;
+
+    /// Poll for a unidirectional stream created by the peer.
+    fn poll_accept_uni(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Self::RecvStream, Self::Error>>;
+
+    /// Poll for a bidirectional stream created by the peer.
+    fn poll_accept_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<BiStreams<Self>, Self::Error>>;
+
+    /// Poll to open a unidirectional stream, which blocks while there are too many
+    /// concurrent streams.
+    fn poll_open_uni(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Self::SendStream, Self::Error>>;
+
+    /// Poll to open a bidirectional stream, which blocks while there are too many
+    /// concurrent streams.
+    fn poll_open_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<BiStreams<Self>, Self::Error>>;
+
+    /// Send a datagram over the network.
+    ///
+    /// QUIC datagrams may be dropped for any reason:
+    /// - Network congestion.
+    /// - Random packet loss.
+    /// - Payload is larger than `max_datagram_size()`
+    /// - Peer is not receiving datagrams.
+    /// - Peer has too many outstanding datagrams.
+    /// - ???
+    fn send_datagram(&mut self, payload: Bytes) -> Result<(), Self::Error>;
+
+    /// Poll for a datagram from the network.
+    fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>>;
+
+    /// The maximum size of a datagram that can be sent.
+    fn max_datagram_size(&self) -> usize;
+
+    /// Return the negotiated WebTransport subprotocol, if any.
+    fn protocol(&self) -> Option<&str> {
+        None
+    }
+
+    /// Close the connection immediately with a code and reason.
+    fn close(&mut self, code: u32, reason: &str);
+
+    /// Poll until the connection is closed by either side.
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error>;
+
+    /// Return connection-level statistics, if supported.
+    fn stats(&self) -> impl Stats {
+        StatsUnavailable
+    }
+}
+
+/// The `poll`-based surface of an outgoing stream.
+///
+/// See the [module docs](self) for what a `poll_*` method may retain between calls.
+pub trait PollSendStream {
+    /// The error type for every operation on this stream.
+    type Error: Error;
+
+    /// Poll to write some of the buffer to the stream, returning how many bytes were
+    /// written. See [`poll_write_buf`](Self::poll_write_buf) for the partial-write
+    /// contract, which this shares.
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>>;
+
+    /// Poll to write some of the given buffer to the stream, advancing it by the
+    /// number of bytes written. This may be less than the whole buffer, so callers
+    /// loop.
+    ///
+    /// # Partial writes
+    ///
+    /// Implementations must not advance `buf` past the bytes they accepted for
+    /// sending. (Whether those bytes reach the peer is a separate matter — a reset
+    /// or a dead connection can still discard accepted bytes.) A returned
+    /// [`Poll::Pending`] must leave `buf` exactly where the accepted bytes end.
+    /// Callers race writes against other work, so a byte taken from `buf` but never
+    /// accepted becomes a silent hole in the stream, which the peer decodes as a
+    /// truncated or garbage frame. Wait for send capacity *before* consuming from
+    /// `buf`, never after.
+    ///
+    /// Override this to avoid a copy when the underlying transport can take
+    /// ownership of `buf`'s bytes — see [`Buf::copy_to_bytes`], which is free for a
+    /// [`Bytes`] source.
+    fn poll_write_buf<B: Buf>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>> {
+        let size = ready!(self.poll_write(cx, buf.chunk()))?;
+        buf.advance(size);
+        Poll::Ready(Ok(size))
+    }
+
+    /// Set the stream's priority.
+    ///
+    /// Streams with higher values will be sent first, but are not guaranteed to
+    /// arrive first. This matches the W3C WebTransport `sendOrder` convention (and
+    /// quinn's scheduler).
+    fn set_priority(&mut self, order: u8);
+
+    /// Mark the stream as finished, erroring on any future writes.
+    ///
+    /// [`reset`](Self::reset) can still be called to abandon any queued data.
+    /// [`poll_closed`](Self::poll_closed) should resolve when the FIN is acknowledged
+    /// by the peer.
+    ///
+    /// NOTE: Quinn implicitly calls this on Drop, but it's a common footgun.
+    /// Implementations SHOULD [`reset`](Self::reset) on Drop instead.
+    fn finish(&mut self) -> Result<(), Self::Error>;
+
+    /// Immediately closes the stream and discards any remaining data.
+    ///
+    /// This translates into a RESET_STREAM QUIC code.
+    /// The peer may not receive the reset code if the stream is already closed.
+    fn reset(&mut self, code: u32);
+
+    /// Poll until the stream is closed by either side.
+    ///
+    /// This includes:
+    /// - We sent a RESET_STREAM via [`reset`](Self::reset)
+    /// - We received a STOP_SENDING via [`PollRecvStream::stop`]
+    /// - A FIN is acknowledged by the peer via [`finish`](Self::finish)
+    ///
+    /// Some implementations do not support FIN acknowledgement, in which case this
+    /// resolves once the FIN is sent.
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+}
+
+/// The `poll`-based surface of an incoming stream.
+///
+/// See the [module docs](self) for what a `poll_*` method may retain between calls.
+pub trait PollRecvStream {
+    /// The error type for every operation on this stream.
+    type Error: Error;
+
+    /// Poll to read some data into the provided slice.
+    ///
+    /// Returns the number of bytes read, or `None` once the peer has finished the
+    /// stream. An empty `dst` reads nothing and returns `Some(0)` — asking for no
+    /// bytes is not end of stream.
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, Self::Error>>;
+
+    /// Poll to read some data into the provided buffer, advancing it by the number
+    /// of bytes read.
+    ///
+    /// Override this to avoid a copy when the underlying transport already owns the
+    /// bytes as a [`Bytes`], which can be handed to [`BufMut::put`] directly.
+    fn poll_read_buf<B: BufMut>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<Option<usize>, Self::Error>> {
+        let len = buf.chunk_mut().len();
+
+        // A destination with no room is not a closed stream. Collapsing the two
+        // would turn "buffer full" into "stream ended", which reads as truncation.
+        if len == 0 {
+            return Poll::Ready(Ok(Some(0)));
+        }
+
+        let dst = unsafe {
+            std::mem::transmute::<&mut bytes::buf::UninitSlice, &mut [u8]>(buf.chunk_mut())
+        };
+
+        let size = match ready!(self.poll_read(cx, dst))? {
+            Some(size) if size > 0 => size,
+            Some(_) => return Poll::Ready(Ok(Some(0))),
+            None => return Poll::Ready(Ok(None)),
+        };
+
+        unsafe { buf.advance_mut(size) };
+
+        Poll::Ready(Ok(Some(size)))
+    }
+
+    /// Poll for the next chunk of data, up to `max` bytes.
+    ///
+    /// Override this when the transport can hand over a [`Bytes`] it already owns;
+    /// the default allocates and copies.
+    fn poll_read_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+        max: usize,
+    ) -> Poll<Result<Option<Bytes>, Self::Error>> {
+        // As in `poll_read_buf`: asking for nothing is not end of stream.
+        if max == 0 {
+            return Poll::Ready(Ok(Some(Bytes::new())));
+        }
+
+        // Don't allocate too much. Override this to avoid the copy, or to use a
+        // larger per-poll buffer.
+        let capacity = max.min(8 * 1024);
+        let mut buf = BytesMut::with_capacity(capacity);
+
+        // Slice to `capacity` rather than trusting the allocation: `with_capacity`
+        // promises only a lower bound, so an over-allocation would let this return
+        // more than `max`, which the method documents it won't.
+        let dst = unsafe {
+            std::mem::transmute::<&mut bytes::buf::UninitSlice, &mut [u8]>(buf.chunk_mut())
+        };
+        let dst = &mut dst[..capacity];
+
+        let size = match ready!(self.poll_read(cx, dst))? {
+            Some(size) if size > 0 => size,
+            Some(_) => return Poll::Ready(Ok(Some(Bytes::new()))),
+            None => return Poll::Ready(Ok(None)),
+        };
+
+        // The read wrote into spare capacity, so the length is still zero.
+        unsafe { buf.advance_mut(size) };
+
+        Poll::Ready(Ok(Some(buf.freeze())))
+    }
+
+    /// Send a `STOP_SENDING` QUIC code, informing the peer that no more data will be
+    /// read.
+    ///
+    /// An implementation MUST do this on Drop otherwise flow control will be leaked.
+    /// Call this method manually if you want to specify a code yourself.
+    fn stop(&mut self, code: u32);
+
+    /// Poll until the stream has been closed by either side.
+    ///
+    /// This includes:
+    /// - We received a RESET_STREAM via [`PollSendStream::reset`]
+    /// - We sent a STOP_SENDING via [`stop`](Self::stop)
+    /// - We received a FIN via [`PollSendStream::finish`] and read all data.
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+}

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -11,7 +11,7 @@
 //!   thread-per-core `io_uring` runtime, say — can implement these. The async traits
 //!   in the crate root add `MaybeSend` on top, because their futures need it; the
 //!   poll traits do not, so a `!Send` stack stays expressible all the way down.
-//!   [`PollSession`]'s associated stream types only require the poll halves, so the
+//!   [`Session`]'s associated stream types only require the poll halves, so the
 //!   bound cannot leak back in through them.
 //!
 //! - **`&mut self` throughout, and no `Clone`.** A sans-I/O state machine owns its
@@ -30,7 +30,7 @@
 //! # Retaining state between calls
 //!
 //! A `poll_*` method may keep its own progress across calls, and often should —
-//! [`PollSendStream::poll_write_buf`] will typically have reserved send capacity by
+//! [`SendStream::poll_write_buf`] will typically have reserved send capacity by
 //! the time it returns [`Poll::Pending`], and starting over would give that back.
 //! What it must not keep is anything belonging to the *caller*:
 //!
@@ -38,9 +38,9 @@
 //!   fresh one, and a caller is free to retry a pending write with a shorter buffer.
 //!   Retained progress must be reconciled against the buffer actually presented, not
 //!   the one that started the operation.
-//! - Whatever ends the stream — [`PollSendStream::reset`],
-//!   [`PollSendStream::finish`], a peer STOP_SENDING seen by
-//!   [`PollSendStream::poll_closed`] — must release retained progress. Nothing else
+//! - Whatever ends the stream — [`SendStream::reset`],
+//!   [`SendStream::finish`], a peer STOP_SENDING seen by
+//!   [`SendStream::poll_closed`] — must release retained progress. Nothing else
 //!   will: the guards at the top of a write return early once the stream is closed,
 //!   so no later call reaches the cleanup, and a reservation held past that point is
 //!   leaked for the life of the stream.
@@ -53,26 +53,23 @@ use std::task::{ready, Context, Poll};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use crate::{Error, Stats, StatsUnavailable};
+use crate::{Error, Stats};
 
 /// The stream pair produced by opening or accepting a bidirectional stream.
-pub type BiStreams<S> = (
-    <S as PollSession>::SendStream,
-    <S as PollSession>::RecvStream,
-);
+pub type BiStreams<S> = (<S as Session>::SendStream, <S as Session>::RecvStream);
 
 /// The `poll`-based surface of a WebTransport session.
 ///
 /// See the [module docs](self) for why this takes `&mut self` and carries no `Send`
 /// bound.
-pub trait PollSession {
+pub trait Session {
     /// The outgoing stream type. Only the poll half is required, so a `!Send`
     /// session can hang `!Send` streams off it.
-    type SendStream: PollSendStream;
+    type SendStream: SendStream;
 
     /// The incoming stream type. Only the poll half is required, so a `!Send`
     /// session can hang `!Send` streams off it.
-    type RecvStream: PollRecvStream;
+    type RecvStream: RecvStream;
 
     /// The error type for every operation on this session.
     type Error: Error;
@@ -100,16 +97,26 @@ pub trait PollSession {
     /// concurrent streams.
     fn poll_open_bi(&mut self, cx: &mut Context<'_>) -> Poll<Result<BiStreams<Self>, Self::Error>>;
 
-    /// Send a datagram over the network.
+    /// Poll to send a datagram over the network.
     ///
-    /// QUIC datagrams may be dropped for any reason:
+    /// Returns [`Poll::Pending`] while the transport has no room for it, so a caller
+    /// can wait for capacity rather than having the payload dropped underneath it.
+    ///
+    /// `payload` is taken by reference because a [`Poll::Pending`] return means the
+    /// caller retries with the same datagram; an implementation clones it — a
+    /// refcount bump — only once it has accepted it.
+    ///
+    /// Accepting a datagram is not delivery. QUIC datagrams may still be dropped:
     /// - Network congestion.
     /// - Random packet loss.
     /// - Payload is larger than `max_datagram_size()`
     /// - Peer is not receiving datagrams.
-    /// - Peer has too many outstanding datagrams.
     /// - ???
-    fn send_datagram(&mut self, payload: Bytes) -> Result<(), Self::Error>;
+    fn poll_send_datagram(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: &Bytes,
+    ) -> Poll<Result<(), Self::Error>>;
 
     /// Poll for a datagram from the network.
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Self::Error>>;
@@ -118,26 +125,33 @@ pub trait PollSession {
     fn max_datagram_size(&self) -> usize;
 
     /// Return the negotiated WebTransport subprotocol, if any.
-    fn protocol(&self) -> Option<&str> {
-        None
-    }
+    ///
+    /// Return `None` if the transport does not negotiate one. This is required
+    /// rather than defaulted: a transport that negotiates a subprotocol and forgets
+    /// to report it is a silent bug, and the default hid that.
+    fn protocol(&self) -> Option<&str>;
 
     /// Close the connection immediately with a code and reason.
+    ///
+    /// Idempotent, and deliberately infallible: closing an already-closed connection
+    /// achieved what the caller asked for, and there is nothing they could do with an
+    /// error.
     fn close(&mut self, code: u32, reason: &str);
 
     /// Poll until the connection is closed by either side.
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Self::Error>;
 
-    /// Return connection-level statistics, if supported.
-    fn stats(&self) -> impl Stats {
-        StatsUnavailable
-    }
+    /// Return connection-level statistics.
+    ///
+    /// Return [`crate::StatsUnavailable`] if the transport does not track them. Required
+    /// rather than defaulted for the same reason as [`protocol`](Self::protocol).
+    fn stats(&self) -> impl Stats;
 }
 
 /// The `poll`-based surface of an outgoing stream.
 ///
 /// See the [module docs](self) for what a `poll_*` method may retain between calls.
-pub trait PollSendStream {
+pub trait SendStream {
     /// The error type for every operation on this stream.
     type Error: Error;
 
@@ -195,13 +209,18 @@ pub trait PollSendStream {
     ///
     /// This translates into a RESET_STREAM QUIC code.
     /// The peer may not receive the reset code if the stream is already closed.
+    ///
+    /// Takes `&mut self` rather than `self` even though it is terminal, so a caller
+    /// can still [`poll_closed`](Self::poll_closed) afterwards to await the peer —
+    /// and so it matches [`finish`](Self::finish), which must not consume the stream
+    /// for exactly that reason.
     fn reset(&mut self, code: u32);
 
     /// Poll until the stream is closed by either side.
     ///
     /// This includes:
     /// - We sent a RESET_STREAM via [`reset`](Self::reset)
-    /// - We received a STOP_SENDING via [`PollRecvStream::stop`]
+    /// - We received a STOP_SENDING via [`RecvStream::stop`]
     /// - A FIN is acknowledged by the peer via [`finish`](Self::finish)
     ///
     /// Some implementations do not support FIN acknowledgement, in which case this
@@ -212,7 +231,7 @@ pub trait PollSendStream {
 /// The `poll`-based surface of an incoming stream.
 ///
 /// See the [module docs](self) for what a `poll_*` method may retain between calls.
-pub trait PollRecvStream {
+pub trait RecvStream {
     /// The error type for every operation on this stream.
     type Error: Error;
 
@@ -309,8 +328,8 @@ pub trait PollRecvStream {
     /// Poll until the stream has been closed by either side.
     ///
     /// This includes:
-    /// - We received a RESET_STREAM via [`PollSendStream::reset`]
+    /// - We received a RESET_STREAM via [`SendStream::reset`]
     /// - We sent a STOP_SENDING via [`stop`](Self::stop)
-    /// - We received a FIN via [`PollSendStream::finish`] and read all data.
+    /// - We received a FIN via [`SendStream::finish`] and read all data.
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
 }

--- a/rs/web-transport-trait/tests/sans_io.rs
+++ b/rs/web-transport-trait/tests/sans_io.rs
@@ -5,7 +5,7 @@
 //! properties that are easy to lose in a refactor.
 //!
 //! 1. **It is `!Send`.** Every type here holds an [`Rc`]. A `Send` bound anywhere on
-//!    [`PollSession`], [`PollSendStream`], [`PollRecvStream`] — or on the associated
+//!    [`Session`], [`SendStream`], [`RecvStream`] — or on the associated
 //!    stream types, which is the subtle way it creeps back in — would reject this
 //!    file at compile time. `requires_*` below force the bounds to be checked.
 //!
@@ -26,7 +26,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use web_transport_trait::{PollRecvStream, PollSendStream, PollSession};
+use web_transport_trait::poll::{RecvStream, SendStream, Session};
 
 // --- error --------------------------------------------------------------------
 
@@ -106,7 +106,7 @@ struct LocalSend {
     priority: u8,
 }
 
-impl PollSendStream for LocalSend {
+impl SendStream for LocalSend {
     type Error = LocalError;
 
     fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, LocalError>> {
@@ -151,7 +151,7 @@ struct LocalRecv {
     buf: Shared,
 }
 
-impl PollRecvStream for LocalRecv {
+impl RecvStream for LocalRecv {
     type Error = LocalError;
 
     fn poll_read(
@@ -225,7 +225,7 @@ impl LocalSession {
     }
 }
 
-impl PollSession for LocalSession {
+impl Session for LocalSession {
     type SendStream = LocalSend;
     type RecvStream = LocalRecv;
     type Error = LocalError;
@@ -298,14 +298,28 @@ impl PollSession for LocalSession {
         )))
     }
 
-    fn send_datagram(&mut self, payload: Bytes) -> Result<(), LocalError> {
+    fn poll_send_datagram(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: &Bytes,
+    ) -> Poll<Result<(), LocalError>> {
         let mut inbox = self.tx.borrow_mut();
         if inbox.closed {
-            return Err(LocalError);
+            return Poll::Ready(Err(LocalError));
         }
-        inbox.datagrams.push_back(payload);
+        // A tiny queue, so the backpressure path is exercised rather than
+        // theoretical.
+        if inbox.datagrams.len() >= 2 {
+            inbox.park(cx);
+            return Poll::Pending;
+        }
+        inbox.datagrams.push_back(payload.clone());
         inbox.wake();
-        Ok(())
+        Poll::Ready(Ok(()))
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        None
     }
 
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, LocalError>> {
@@ -322,6 +336,10 @@ impl PollSession for LocalSession {
 
     fn max_datagram_size(&self) -> usize {
         1200
+    }
+
+    fn stats(&self) -> impl web_transport_trait::Stats {
+        web_transport_trait::StatsUnavailable
     }
 
     fn close(&mut self, _code: u32, _reason: &str) {
@@ -345,10 +363,10 @@ impl PollSession for LocalSession {
 // --- the bounds themselves ----------------------------------------------------
 
 /// These would not compile if the poll traits carried a `Send` bound, or if
-/// `PollSession` required `Send` of its associated stream types.
-fn requires_poll_session<S: PollSession>() {}
-fn requires_poll_send_stream<S: PollSendStream>() {}
-fn requires_poll_recv_stream<S: PollRecvStream>() {}
+/// `Session` required `Send` of its associated stream types.
+fn requires_poll_session<S: Session>() {}
+fn requires_poll_send_stream<S: SendStream>() {}
+fn requires_poll_recv_stream<S: RecvStream>() {}
 
 #[test]
 fn a_not_send_transport_implements_the_poll_surface() {
@@ -432,7 +450,8 @@ fn datagrams_round_trip() {
 
     assert!(server.poll_recv_datagram(&mut cx).is_pending());
 
-    client.send_datagram(Bytes::from_static(b"dgram")).unwrap();
+    let payload = Bytes::from_static(b"dgram");
+    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
     let datagram = ready(server.poll_recv_datagram(&mut cx)).unwrap();
     assert_eq!(&datagram[..], b"dgram");
 }
@@ -491,4 +510,28 @@ fn a_full_destination_is_not_end_of_stream() {
         Some(Bytes::new()),
         "asking for zero bytes must not look like a finished stream"
     );
+}
+
+/// The reason `poll_send_datagram` is pollable rather than infallible: a caller can
+/// wait for room instead of having the payload silently dropped. The loopback queues
+/// two, so the third parks until the peer drains one.
+#[test]
+fn send_datagram_reports_backpressure() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+    let payload = Bytes::from_static(b"dgram");
+
+    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
+    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
+
+    assert!(
+        client.poll_send_datagram(&mut cx, &payload).is_pending(),
+        "a full transport must park rather than drop the datagram"
+    );
+
+    // The peer drains one, so there is room again.
+    ready(server.poll_recv_datagram(&mut cx)).unwrap();
+    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
 }

--- a/rs/web-transport-trait/tests/sans_io.rs
+++ b/rs/web-transport-trait/tests/sans_io.rs
@@ -301,7 +301,7 @@ impl Session for LocalSession {
     fn poll_send_datagram(
         &mut self,
         cx: &mut Context<'_>,
-        payload: &Bytes,
+        payload: &[u8],
     ) -> Poll<Result<(), LocalError>> {
         let mut inbox = self.tx.borrow_mut();
         if inbox.closed {
@@ -313,7 +313,7 @@ impl Session for LocalSession {
             inbox.park(cx);
             return Poll::Pending;
         }
-        inbox.datagrams.push_back(payload.clone());
+        inbox.datagrams.push_back(Bytes::copy_from_slice(payload));
         inbox.wake();
         Poll::Ready(Ok(()))
     }
@@ -451,7 +451,7 @@ fn datagrams_round_trip() {
     assert!(server.poll_recv_datagram(&mut cx).is_pending());
 
     let payload = Bytes::from_static(b"dgram");
-    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
+    ready(client.poll_send_datagram_chunk(&mut cx, &payload)).unwrap();
     let datagram = ready(server.poll_recv_datagram(&mut cx)).unwrap();
     assert_eq!(&datagram[..], b"dgram");
 }

--- a/rs/web-transport-trait/tests/sans_io.rs
+++ b/rs/web-transport-trait/tests/sans_io.rs
@@ -451,7 +451,7 @@ fn datagrams_round_trip() {
     assert!(server.poll_recv_datagram(&mut cx).is_pending());
 
     let payload = Bytes::from_static(b"dgram");
-    ready(client.poll_send_datagram_chunk(&mut cx, &payload)).unwrap();
+    ready(client.poll_send_datagram(&mut cx, &payload)).unwrap();
     let datagram = ready(server.poll_recv_datagram(&mut cx)).unwrap();
     assert_eq!(&datagram[..], b"dgram");
 }

--- a/rs/web-transport-trait/tests/sans_io.rs
+++ b/rs/web-transport-trait/tests/sans_io.rs
@@ -1,0 +1,494 @@
+//! A sans-I/O transport implementing the poll traits, driven with no runtime.
+//!
+//! This is the acceptance test for the poll surface: if a transport like this cannot
+//! be written against these traits, the traits are wrong. Specifically it pins three
+//! properties that are easy to lose in a refactor.
+//!
+//! 1. **It is `!Send`.** Every type here holds an [`Rc`]. A `Send` bound anywhere on
+//!    [`PollSession`], [`PollSendStream`], [`PollRecvStream`] — or on the associated
+//!    stream types, which is the subtle way it creeps back in — would reject this
+//!    file at compile time. `requires_*` below force the bounds to be checked.
+//!
+//! 2. **It needs no `Arc<Mutex<..>>`.** The session owns its state and mutates it
+//!    through `&mut self`. The `RefCell`s here are the *wire* between the two peers,
+//!    standing in for a network; they are not a lock around a session handle.
+//!
+//! 3. **Nothing drives it but the test.** No executor, no futures, no `.await`, no
+//!    timer. The test steps `poll_*` by hand with a plain [`Waker`], which is what a
+//!    caller like a thread-per-core `io_uring` loop would do.
+
+use std::{
+    cell::RefCell,
+    collections::VecDeque,
+    rc::Rc,
+    sync::Arc,
+    task::{Context, Poll, Wake, Waker},
+};
+
+use bytes::Bytes;
+use web_transport_trait::{PollRecvStream, PollSendStream, PollSession};
+
+// --- error --------------------------------------------------------------------
+
+#[derive(Debug)]
+struct LocalError;
+
+impl std::fmt::Display for LocalError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "local transport error")
+    }
+}
+
+impl std::error::Error for LocalError {}
+
+impl web_transport_trait::Error for LocalError {
+    fn session_error(&self) -> Option<(u32, String)> {
+        None
+    }
+}
+
+// --- the wire -----------------------------------------------------------------
+
+/// One direction of a stream: bytes plus the terminal flags.
+#[derive(Default)]
+struct StreamBuf {
+    data: VecDeque<u8>,
+    fin: bool,
+    reset: bool,
+    wakers: Vec<Waker>,
+}
+
+impl StreamBuf {
+    fn wake(&mut self) {
+        for waker in self.wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    fn park(&mut self, cx: &Context<'_>) {
+        if !self.wakers.iter().any(|w| w.will_wake(cx.waker())) {
+            self.wakers.push(cx.waker().clone());
+        }
+    }
+}
+
+type Shared = Rc<RefCell<StreamBuf>>;
+
+/// A peer's inbox. Standing in for the network, not for a session lock.
+#[derive(Default)]
+struct Inbox {
+    uni: VecDeque<Shared>,
+    bi: VecDeque<(Shared, Shared)>,
+    datagrams: VecDeque<Bytes>,
+    closed: bool,
+    wakers: Vec<Waker>,
+}
+
+impl Inbox {
+    fn wake(&mut self) {
+        for waker in self.wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    fn park(&mut self, cx: &Context<'_>) {
+        if !self.wakers.iter().any(|w| w.will_wake(cx.waker())) {
+            self.wakers.push(cx.waker().clone());
+        }
+    }
+}
+
+// --- streams ------------------------------------------------------------------
+
+/// `!Send`: holds an [`Rc`].
+struct LocalSend {
+    buf: Shared,
+    priority: u8,
+}
+
+impl PollSendStream for LocalSend {
+    type Error = LocalError;
+
+    fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, LocalError>> {
+        let mut state = self.buf.borrow_mut();
+        if state.reset {
+            return Poll::Ready(Err(LocalError));
+        }
+        state.data.extend(buf.iter().copied());
+        state.wake();
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn set_priority(&mut self, order: u8) {
+        self.priority = order;
+    }
+
+    fn finish(&mut self) -> Result<(), LocalError> {
+        let mut state = self.buf.borrow_mut();
+        state.fin = true;
+        state.wake();
+        Ok(())
+    }
+
+    fn reset(&mut self, _code: u32) {
+        let mut state = self.buf.borrow_mut();
+        state.reset = true;
+        state.wake();
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), LocalError>> {
+        let mut state = self.buf.borrow_mut();
+        if state.reset || (state.fin && state.data.is_empty()) {
+            return Poll::Ready(Ok(()));
+        }
+        state.park(cx);
+        Poll::Pending
+    }
+}
+
+/// `!Send`: holds an [`Rc`].
+struct LocalRecv {
+    buf: Shared,
+}
+
+impl PollRecvStream for LocalRecv {
+    type Error = LocalError;
+
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, LocalError>> {
+        let mut state = self.buf.borrow_mut();
+        if state.reset {
+            return Poll::Ready(Err(LocalError));
+        }
+        if dst.is_empty() {
+            // Asking for no bytes is not end of stream.
+            return Poll::Ready(Ok(Some(0)));
+        }
+
+        let size = dst.len().min(state.data.len());
+        if size == 0 {
+            if state.fin {
+                return Poll::Ready(Ok(None));
+            }
+            state.park(cx);
+            return Poll::Pending;
+        }
+
+        for slot in dst.iter_mut().take(size) {
+            *slot = state.data.pop_front().expect("checked above");
+        }
+        Poll::Ready(Ok(Some(size)))
+    }
+
+    fn stop(&mut self, _code: u32) {
+        let mut state = self.buf.borrow_mut();
+        state.reset = true;
+        state.wake();
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), LocalError>> {
+        let mut state = self.buf.borrow_mut();
+        if state.reset || (state.fin && state.data.is_empty()) {
+            return Poll::Ready(Ok(()));
+        }
+        state.park(cx);
+        Poll::Pending
+    }
+}
+
+// --- session ------------------------------------------------------------------
+
+/// `!Send`: holds [`Rc`]s. Not `Clone`, which the traits no longer require.
+struct LocalSession {
+    /// What we write into: the peer's inbox.
+    tx: Rc<RefCell<Inbox>>,
+    /// What we read from: our own inbox.
+    rx: Rc<RefCell<Inbox>>,
+}
+
+impl LocalSession {
+    /// A connected pair sharing two inboxes.
+    fn pair() -> (Self, Self) {
+        let a = Rc::new(RefCell::new(Inbox::default()));
+        let b = Rc::new(RefCell::new(Inbox::default()));
+
+        let client = Self {
+            tx: b.clone(),
+            rx: a.clone(),
+        };
+        let server = Self { tx: a, rx: b };
+
+        (client, server)
+    }
+}
+
+impl PollSession for LocalSession {
+    type SendStream = LocalSend;
+    type RecvStream = LocalRecv;
+    type Error = LocalError;
+
+    fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<LocalRecv, LocalError>> {
+        let mut inbox = self.rx.borrow_mut();
+        match inbox.uni.pop_front() {
+            Some(buf) => Poll::Ready(Ok(LocalRecv { buf })),
+            None if inbox.closed => Poll::Ready(Err(LocalError)),
+            None => {
+                inbox.park(cx);
+                Poll::Pending
+            }
+        }
+    }
+
+    fn poll_accept_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(LocalSend, LocalRecv), LocalError>> {
+        let mut inbox = self.rx.borrow_mut();
+        match inbox.bi.pop_front() {
+            Some((send, recv)) => Poll::Ready(Ok((
+                LocalSend {
+                    buf: send,
+                    priority: 0,
+                },
+                LocalRecv { buf: recv },
+            ))),
+            None if inbox.closed => Poll::Ready(Err(LocalError)),
+            None => {
+                inbox.park(cx);
+                Poll::Pending
+            }
+        }
+    }
+
+    fn poll_open_uni(&mut self, _cx: &mut Context<'_>) -> Poll<Result<LocalSend, LocalError>> {
+        let buf: Shared = Rc::new(RefCell::new(StreamBuf::default()));
+        let mut inbox = self.tx.borrow_mut();
+        if inbox.closed {
+            return Poll::Ready(Err(LocalError));
+        }
+        inbox.uni.push_back(buf.clone());
+        inbox.wake();
+        Poll::Ready(Ok(LocalSend { buf, priority: 0 }))
+    }
+
+    fn poll_open_bi(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(LocalSend, LocalRecv), LocalError>> {
+        // Our send is the peer's recv, and vice versa.
+        let ours: Shared = Rc::new(RefCell::new(StreamBuf::default()));
+        let theirs: Shared = Rc::new(RefCell::new(StreamBuf::default()));
+
+        let mut inbox = self.tx.borrow_mut();
+        if inbox.closed {
+            return Poll::Ready(Err(LocalError));
+        }
+        inbox.bi.push_back((theirs.clone(), ours.clone()));
+        inbox.wake();
+
+        Poll::Ready(Ok((
+            LocalSend {
+                buf: ours,
+                priority: 0,
+            },
+            LocalRecv { buf: theirs },
+        )))
+    }
+
+    fn send_datagram(&mut self, payload: Bytes) -> Result<(), LocalError> {
+        let mut inbox = self.tx.borrow_mut();
+        if inbox.closed {
+            return Err(LocalError);
+        }
+        inbox.datagrams.push_back(payload);
+        inbox.wake();
+        Ok(())
+    }
+
+    fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, LocalError>> {
+        let mut inbox = self.rx.borrow_mut();
+        match inbox.datagrams.pop_front() {
+            Some(datagram) => Poll::Ready(Ok(datagram)),
+            None if inbox.closed => Poll::Ready(Err(LocalError)),
+            None => {
+                inbox.park(cx);
+                Poll::Pending
+            }
+        }
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        1200
+    }
+
+    fn close(&mut self, _code: u32, _reason: &str) {
+        for inbox in [&self.tx, &self.rx] {
+            let mut inbox = inbox.borrow_mut();
+            inbox.closed = true;
+            inbox.wake();
+        }
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<LocalError> {
+        let mut inbox = self.rx.borrow_mut();
+        if inbox.closed {
+            return Poll::Ready(LocalError);
+        }
+        inbox.park(cx);
+        Poll::Pending
+    }
+}
+
+// --- the bounds themselves ----------------------------------------------------
+
+/// These would not compile if the poll traits carried a `Send` bound, or if
+/// `PollSession` required `Send` of its associated stream types.
+fn requires_poll_session<S: PollSession>() {}
+fn requires_poll_send_stream<S: PollSendStream>() {}
+fn requires_poll_recv_stream<S: PollRecvStream>() {}
+
+#[test]
+fn a_not_send_transport_implements_the_poll_surface() {
+    requires_poll_session::<LocalSession>();
+    requires_poll_send_stream::<LocalSend>();
+    requires_poll_recv_stream::<LocalRecv>();
+}
+
+// --- driving it, with no runtime ----------------------------------------------
+
+struct Noop;
+
+impl Wake for Noop {
+    fn wake(self: Arc<Self>) {}
+}
+
+fn ready<T>(poll: Poll<T>) -> T {
+    match poll {
+        Poll::Ready(value) => value,
+        Poll::Pending => panic!("expected Ready"),
+    }
+}
+
+#[test]
+fn a_uni_stream_moves_bytes_without_an_executor() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+
+    // Nothing has been opened, so the server parks.
+    assert!(server.poll_accept_uni(&mut cx).is_pending());
+
+    let mut send = ready(client.poll_open_uni(&mut cx)).unwrap();
+    assert_eq!(ready(send.poll_write(&mut cx, b"hello")).unwrap(), 5);
+    send.finish().unwrap();
+
+    let mut recv = ready(server.poll_accept_uni(&mut cx)).unwrap();
+
+    let mut dst = [0u8; 16];
+    let size = ready(recv.poll_read(&mut cx, &mut dst)).unwrap().unwrap();
+    assert_eq!(&dst[..size], b"hello");
+
+    // Drained and finished: end of stream, and both halves agree it is closed.
+    assert_eq!(ready(recv.poll_read(&mut cx, &mut dst)).unwrap(), None);
+    ready(recv.poll_closed(&mut cx)).unwrap();
+    ready(send.poll_closed(&mut cx)).unwrap();
+}
+
+#[test]
+fn a_bi_stream_moves_bytes_in_both_directions() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+
+    let (mut client_send, mut client_recv) = ready(client.poll_open_bi(&mut cx)).unwrap();
+    ready(client_send.poll_write(&mut cx, b"ping")).unwrap();
+
+    let (mut server_send, mut server_recv) = ready(server.poll_accept_bi(&mut cx)).unwrap();
+
+    let mut dst = [0u8; 16];
+    let size = ready(server_recv.poll_read(&mut cx, &mut dst))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&dst[..size], b"ping");
+
+    ready(server_send.poll_write(&mut cx, b"pong")).unwrap();
+    let size = ready(client_recv.poll_read(&mut cx, &mut dst))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&dst[..size], b"pong");
+}
+
+#[test]
+fn datagrams_round_trip() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+
+    assert!(server.poll_recv_datagram(&mut cx).is_pending());
+
+    client.send_datagram(Bytes::from_static(b"dgram")).unwrap();
+    let datagram = ready(server.poll_recv_datagram(&mut cx)).unwrap();
+    assert_eq!(&datagram[..], b"dgram");
+}
+
+/// The provided `poll_read_buf`/`poll_read_chunk` work against a bare
+/// implementation that only wrote `poll_read`.
+#[test]
+fn the_provided_read_helpers_work_over_poll_read() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+
+    let mut send = ready(client.poll_open_uni(&mut cx)).unwrap();
+    ready(send.poll_write(&mut cx, b"chunky")).unwrap();
+    send.finish().unwrap();
+
+    let mut recv = ready(server.poll_accept_uni(&mut cx)).unwrap();
+
+    let chunk = ready(recv.poll_read_chunk(&mut cx, 4)).unwrap().unwrap();
+    assert_eq!(&chunk[..], b"chun");
+    assert!(chunk.len() <= 4, "poll_read_chunk exceeded max");
+
+    let mut buf = bytes::BytesMut::with_capacity(16);
+    let size = ready(recv.poll_read_buf(&mut cx, &mut buf))
+        .unwrap()
+        .unwrap();
+    assert_eq!(size, 2);
+    assert_eq!(&buf[..], b"ky");
+}
+
+/// A caller with no room left is not at end of stream. Backends distinguish the two
+/// and the defaults must not collapse them into `None`, which reads as truncation.
+#[test]
+fn a_full_destination_is_not_end_of_stream() {
+    let waker = Waker::from(Arc::new(Noop));
+    let mut cx = Context::from_waker(&waker);
+
+    let (mut client, mut server) = LocalSession::pair();
+
+    let mut send = ready(client.poll_open_uni(&mut cx)).unwrap();
+    ready(send.poll_write(&mut cx, b"data")).unwrap();
+
+    let mut recv = ready(server.poll_accept_uni(&mut cx)).unwrap();
+
+    // A zero-length slice, not a `BytesMut`: `BytesMut::chunk_mut` reserves more
+    // capacity on demand, so it is never actually full.
+    let mut full: &mut [u8] = &mut [];
+    assert_eq!(
+        ready(recv.poll_read_buf(&mut cx, &mut full)).unwrap(),
+        Some(0),
+        "a full buffer must not look like a finished stream"
+    );
+    assert_eq!(
+        ready(recv.poll_read_chunk(&mut cx, 0)).unwrap(),
+        Some(Bytes::new()),
+        "asking for zero bytes must not look like a finished stream"
+    );
+}


### PR DESCRIPTION
Stacked on #349 (merged). Replaces #328.

Adds `web_transport_trait::poll` — a transport described as a state machine a caller
steps from its own loop, rather than a set of futures a runtime drives — and
implements it for quinn and quiche.

## The interface

```rust
pub trait Session {
    type SendStream: SendStream;   // poll half only, so the bound can't leak in
    type RecvStream: RecvStream;
    type Error: Error;

    fn poll_accept_uni/bi(&mut self, cx) -> Poll<Result<..>>;
    fn poll_open_uni/bi(&mut self, cx) -> Poll<Result<..>>;
    fn poll_send_datagram(&mut self, cx, payload: &[u8]) -> Poll<Result<()>>;
    fn poll_recv_datagram(&mut self, cx) -> Poll<Result<Bytes>>;
    fn poll_closed(&mut self, cx) -> Poll<Self::Error>;
    fn close(&mut self, code: u32, reason: &str);
    fn max_datagram_size(&self) -> usize;
    fn protocol(&self) -> Option<&str>;
    fn stats(&self) -> impl Stats;
}
```

Two properties are the point, and both restrict what an implementation may be rather
than adding features:

- **No `Send`/`Sync` anywhere**, including on the associated stream types — the subtle
  way the bound creeps back in. `Error` was relaxed too: `Send + Sync` moved onto the
  *async* traits, whose futures must be spawnable and whose errors should box into
  `anyhow`. Nothing reachable from `poll` requires either now.
- **`&mut self`, no `Clone`.** A `&self` surface forces every implementation into
  interior mutability whether its own design needs one or not. Concurrency comes from
  cloning the concrete session.

`protocol`/`stats` are required rather than defaulted — that default only existed for
compatibility the new module doesn't owe anyone. `close`/`reset` stay infallible and
`&mut self`: consuming `self` would make `reset` then `poll_closed` unwritable.

## The two backends landed very differently, which is the useful result

| | retained futures | why |
|---|---|---|
| **quinn** | 5 | open, raw accept, datagrams, `closed`, `stopped` hold their `Notify` registration *inside* the future — rebuilding one per poll drops it and the caller never wakes |
| **quiche** | **0** | `ez` is ours, so the registration lives in `DriverState` where it belongs |

quinn's shim (`op::Op`) is private to `web-transport-quinn`. It boxes a `Send`
future — exactly what a thread-pinned transport cannot use — so it has no business in
the contract crate.

Not everything in quinn needs it: `RecvStream::poll_closed` needs nothing retained,
because quinn parks that waker in the connection's `blocked_readers` map keyed by
stream rather than in the future.

quiche needed an `ez` change to get to zero. Accept and inbound datagrams went through
`flume`, and a channel's receive future owns its waker registration and drops it with
the future — the same trap. Both moved into `DriverState` as a queue plus waker list,
alongside the machinery already there. The queues hold stream *parts*, not built
streams: a `SendStream` keeps a `Lock<DriverState>`, so parking one inside it is a
reference cycle.

Opening a stream is still two steps (take stream, write header), so a `Pending`
between them must resume — but in quiche that's a plain `enum OpenUni { Idle, Header
{ send, offset } }` over ez's poll methods. No box. That state machine only works
because `&mut self` gives it one owner.

**One behaviour change:** quiche's inbound datagram queue drops the *oldest* when
full, where the bounded channel rejected the newest. For unreliable datagrams the
freshest data is the useful data, and a full queue means the application is behind.

## qmux groundwork

qmux's trait impl is **not** in this PR. Its two blocking primitives are, because they
had the same defect and it's worth fixing regardless:

- `Credit` waited through a `watch::Receiver`, whose `wait_for` future owns the
  registration. It now holds its own state with a waker list; `claim`/`claim_index`
  are `poll_fn` wrappers over new poll forms.
- accept and datagram receivers were `Arc<tokio::sync::Mutex<Receiver>>`, which
  invites `lock().await` then `recv().await` — guard held across the wait, so a handle
  that starts an accept and stops polling blocks every other clone. `SharedRecv` locks
  only for the poll, and the bad shape is now unrepresentable: a
  `std::sync::MutexGuard` isn't `Send`. It keeps a waker list too, since `poll_recv`
  stores exactly one.

What remains for qmux is `SendStream::poll_write`: reserve a queue slot, claim
flow-control credit, enqueue — without taking bytes from `buf` before both are
secured, and without holding the slot across the credit wait. That is the code #328
found two leaks in, so it gets its own pass.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — 43 test binaries green
- `cargo check` for `wasm32-unknown-unknown` — clean
- `tests/sans_io.rs`: a loopback transport where every type holds an `Rc`, driven with
  no executor, no futures, no timer. If this stops compiling, a `Send` bound came back.
- `web-transport-quinn/tests/poll.rs` and `web-transport-quiche/tests/poll.rs`: real
  connections driven through `poll_*` exclusively, never an async method.

## Review findings addressed

`poll_send_datagram` framed its payload before `Op::poll` decided whether anything was
in flight — so a pending send reallocated every poll, and a retry with a *different*
datagram silently sent the first. Fixed via `Op::poll_pending`, with a test.

Declined: reworking `poll_read_buf`/`poll_read_chunk` to avoid the `UninitSlice`
transmute. That matches `read_buf` on `main` and is a deliberate call — a `read` that
misreports its count hands back stale bytes either way, and reused scratch buffers make
that the ordinary shape of the bug, so a memset buys no observable safety for a
per-read cost.

(written by Opus 5)