### PR TITLE
docs(qmux): correct the `closed` contract for the 0x1c/0x1d split

### DIFF
--- a/js/qmux/README.md
+++ b/js/qmux/README.md
@@ -60,11 +60,12 @@ the stream-id space each side owns.
 
 `closed` follows the WebTransport contract:
 
-- **Fulfills** with `{ closeCode, reason }` when the session ends gracefully — a `CONNECTION_CLOSE`
-  arrived, from either side calling `close()`. That includes a peer that closes because *it* caught
-  a protocol violation: it told us why, so you get its close code and reason.
-- **Rejects** when the session ends abnormally, with no `CONNECTION_CLOSE`: the socket dropped, the
-  peer went idle, or *this* endpoint caught the peer violating the protocol.
+- **Fulfills** with `{ closeCode, reason }` on a graceful end: either side called `close()`, which
+  puts an `APPLICATION_CLOSE` (`0x1d`) on the wire.
+- **Rejects** on an abnormal end: a `CONNECTION_CLOSE` (`0x1c`) arrived — the transport variant a
+  peer sends when *it* caught a protocol violation — or no close frame arrived at all, because the
+  socket dropped or the peer went idle. This endpoint rejects the same way when it catches the peer
+  violating the protocol, and sends a `CONNECTION_CLOSE` so the peer rejects too.
 
 ```ts
 try {
@@ -76,8 +77,10 @@ try {
 }
 ```
 
-Don't reach for `closeCode` to tell the two apart — close codes are application-defined, so an app
-closing with `1006` is indistinguishable from a dropped socket. The settled state is the signal.
+Don't reach for `closeCode` to tell the two apart — close codes are application-defined, so a
+graceful close may carry any value, including one that looks like a violation, and an app closing
+with `1006` is indistinguishable from a dropped socket. Which frame arrived is the signal, and the
+settled state is how you read it.
 
 ### Stream reset codes
 


### PR DESCRIPTION
Found while verifying #290 as fixed (now closed).

`js/qmux/README.md` still documents the semantics of #291, which #292 replaced. #292 added this section itself, carrying the prose over from #291's branch, so the docs went out of date in the same commit that made them wrong. It shipped in `@moq/qmux` 0.3.0–0.3.2.

## What's wrong

> - **Fulfills** with `{ closeCode, reason }` when the session ends gracefully — a `CONNECTION_CLOSE` arrived, from either side calling `close()`. **That includes a peer that closes because *it* caught a protocol violation: it told us why, so you get its close code and reason.**
> - **Rejects** when the session ends abnormally, **with no `CONNECTION_CLOSE`**: the socket dropped, the peer went idle, or *this* endpoint caught the peer violating the protocol.

Under #292 a peer reporting a violation sends a **CONNECTION_CLOSE (`0x1c`)** — `rs/qmux/src/session.rs:1746` for the Rust side, `session.ts:860` for JS — and `0x1c` routes to `#abort` (`session.ts:891`), which **rejects**. Only **APPLICATION_CLOSE (`0x1d`)** fulfills. The "with no `CONNECTION_CLOSE`" qualifier on the reject bullet is wrong for the same reason.

So the README puts a peer-reported violation in the fulfill arm — telling a consumer to skip reconnecting on exactly the end the peer bothered to explain.

## Reproduction

Driving a real session over a real WebSocket, with the peer closing the way a peer that caught a violation does:

```
  peer sends CONNECTION_CLOSE 0x1c  ->  REJECTED  WebTransportError (source: session)
  peer sends APPLICATION_CLOSE 0x1d ->  FULFILLED with { closeCode: 1002, reason: "you violated the protocol" }
```

Both frames carry code 1002 here, which is the point: the code is application-defined, so the frame *type* is the only signal — exactly as the section's closing paragraph already says.

Confirmed against a real Rust peer too, not just a synthetic one: point a JS client at `rs/qmux`'s `interop-server` example and send it a malformed frame, and the Rust session detects the violation, emits `0x1c`/1002, and the JS `closed` rejects with `Connection closed: 1002 short frame` on both qmux-01 and qmux-02.

## The change

Docs only — no behavior change, nothing to test. The bullets now key off which frame arrived, and the closing paragraph absorbs the "a graceful close may carry any value" point that makes code-sniffing unsound.

Not bumping the version, since JS publishing is manual and you may want to batch this; happy to add a patch bump if you'd rather it went out on its own.
