### PR TITLE
fix!: release accept and ez waker registrations when a caller gives up

### DIFF
--- a/rs/web-transport-iroh/Cargo.toml
+++ b/rs/web-transport-iroh/Cargo.toml
@@ -22,6 +22,7 @@ qlog = ["iroh/qlog"]
 bytes = "1"
 http = "1"
 iroh = { version = "1", default-features = false, features = ["fast-apple-datapath"] }
+kio = "0.5.2"
 n0-error = "1"
 n0-future = "0.3.1"
 tokio = { version = "1", default-features = false, features = [

--- a/rs/web-transport-iroh/src/lib.rs
+++ b/rs/web-transport-iroh/src/lib.rs
@@ -32,6 +32,7 @@ mod session;
 mod settings;
 #[cfg(test)]
 mod tests;
+mod waiters;
 
 pub use client::*;
 pub use connect::*;

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    future::{Future, poll_fn},
+    future::Future,
     io::Cursor,
     ops::Deref,
     pin::Pin,
@@ -10,6 +10,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use iroh::endpoint::{self, Connection, PathStats};
+use kio::Waiter;
 use n0_future::{
     FuturesUnordered,
     stream::{Stream, StreamExt},
@@ -18,6 +19,7 @@ use web_transport_proto::{ConnectRequest, ConnectResponse, Frame, StreamUni, Var
 
 use crate::{
     ClientError, Connected, RecvStream, SendStream, SessionError, Settings, WebTransportError,
+    waiters::AcceptWaiters,
 };
 
 /// An established WebTransport session, acting like a full QUIC connection. See [`iroh::endpoint::Connection`].
@@ -99,7 +101,9 @@ impl Session {
     /// Accept a new unidirectional stream. See [`iroh::endpoint::Connection::accept_uni`].
     pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
         if let Some(h3) = &self.h3 {
-            poll_fn(|cx| h3.accept.lock().unwrap().poll_accept_uni(cx)).await
+            // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
+            // expires, say — also drops its registration in `H3SessionAccept`.
+            kio::wait(|waiter| h3.accept.lock().unwrap().poll_accept_uni(waiter)).await
         } else {
             self.conn
                 .accept_uni()
@@ -112,7 +116,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`iroh::endpoint::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(h3) = &self.h3 {
-            poll_fn(|cx| h3.accept.lock().unwrap().poll_accept_bi(cx)).await
+            kio::wait(|waiter| h3.accept.lock().unwrap().poll_accept_bi(waiter)).await
         } else {
             self.conn
                 .accept_bi()
@@ -363,13 +367,19 @@ struct H3SessionAccept {
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
 
-    // Wakers from concurrent callers of accept_bi / accept_uni.
-    // When one caller gets a stream, all others are woken so they can retry.
-    // Every clone polls this one struct, which would otherwise keep only the most
-    // recent waker, so a second accepter would register through a waker the first
-    // had already replaced and never wake.
-    bi_wakers: Vec<Waker>,
-    uni_wakers: Vec<Waker>,
+    // Waiters from concurrent callers of accept_bi / accept_uni.
+    // Every clone of the session polls this one struct, so an arrival has to be fanned
+    // out: each caller registers here and all of them are woken when a stream lands.
+    //
+    bi_waiters: Arc<AcceptWaiters>,
+    uni_waiters: Arc<AcceptWaiters>,
+
+    // `Waker::from(waiters.clone())`, cached so the inner accept futures are polled with
+    // the same waker every time. That waker outlives every caller, so an accepter that
+    // drops its future cannot take the wakeup path with it, and the layer below holds
+    // one registration rather than one per caller.
+    bi_waker: Waker,
+    uni_waker: Waker,
 }
 
 impl H3SessionAccept {
@@ -383,6 +393,11 @@ impl H3SessionAccept {
             Some((conn.accept_bi().await, conn))
         }));
 
+        let bi_waiters = Arc::new(AcceptWaiters::default());
+        let uni_waiters = Arc::new(AcceptWaiters::default());
+        let bi_waker = Waker::from(bi_waiters.clone());
+        let uni_waker = Waker::from(uni_waiters.clone());
+
         Self {
             session_id,
 
@@ -395,18 +410,25 @@ impl H3SessionAccept {
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
 
-            bi_wakers: Vec::new(),
-            uni_wakers: Vec::new(),
+            bi_waiters,
+            uni_waiters,
+            bi_waker,
+            uni_waker,
         }
     }
 
     // This is poll-based because we accept and decode streams in parallel.
     // In async land I would use tokio::JoinSet, but that requires a runtime.
     // It's better to use FuturesUnordered instead because it's agnostic.
-    pub fn poll_accept_uni(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<RecvStream, SessionError>> {
+    pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
+        // Register before polling, not on the way out: the shared waker can fire from the
+        // layer below at any point here, and a wake that lands before the caller is on
+        // the list would be lost.
+        self.uni_waiters.register(waiter);
+
+        let waker = self.uni_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next(cx) {
@@ -414,9 +436,7 @@ impl H3SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        for waker in self.uni_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -434,21 +454,14 @@ impl H3SessionAccept {
                     tracing::warn!("failed to decode unidirectional stream: {err:?}");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.uni_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
-                    for waker in self.uni_wakers.drain(..) {
-                        waker.wake();
-                    }
+                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -492,8 +505,14 @@ impl H3SessionAccept {
 
     pub fn poll_accept_bi(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        // Register before polling; see `poll_accept_uni`.
+        self.bi_waiters.register(waiter);
+
+        let waker = self.bi_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next(cx) {
@@ -501,9 +520,7 @@ impl H3SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        for waker in self.bi_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -521,21 +538,14 @@ impl H3SessionAccept {
                     tracing::warn!("failed to decode bidirectional stream: {err:?}");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.bi_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
-                for waker in self.bi_wakers.drain(..) {
-                    waker.wake();
-                }
+                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -374,7 +374,7 @@ fn poll_accept_uni_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
@@ -398,7 +398,7 @@ fn poll_accept_bi_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -364,12 +364,18 @@ fn poll_accept_uni_shared(
 ) -> Poll<Result<RecvStream, SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.uni_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_uni(waiter);
-        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 
@@ -382,12 +388,18 @@ fn poll_accept_bi_shared(
 ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.bi_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_bi(waiter);
-        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -460,9 +460,20 @@ impl H3SessionAccept {
         }
     }
 
-    // This is poll-based because we accept and decode streams in parallel.
-    // In async land I would use tokio::JoinSet, but that requires a runtime.
-    // It's better to use FuturesUnordered instead because it's agnostic.
+    /// Poll for the next unidirectional WebTransport stream.
+    ///
+    /// `waiter` is parked until a stream arrives, the accept fails, or the caller drops
+    /// it. The registration is weak and owned by the caller: keep the [`Waiter`] alive
+    /// until it is woken, or it will be reclaimed and nothing will wake you. Drive this
+    /// with [`kio::wait`], which holds the waiter inside the future it builds.
+    ///
+    /// A `Ready` here means every *other* parked accepter should be woken so it can
+    /// retry. This does not do that itself — see `poll_accept_uni_shared`, which wakes
+    /// them once the lock on this struct is released.
+    //
+    // Poll-based because we accept and decode streams in parallel. In async land this
+    // would be a `tokio::JoinSet`, but that needs a runtime; `FuturesUnordered` is
+    // runtime-agnostic.
     pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
         // Register before polling, not on the way out: the shared waker can fire from the
         // layer below at any point here, and a wake that lands before the caller is on
@@ -544,6 +555,11 @@ impl H3SessionAccept {
         Ok((typ, recv))
     }
 
+    /// Poll for the next bidirectional WebTransport stream.
+    ///
+    /// The same contract as [`poll_accept_uni`](Self::poll_accept_uni): the `waiter`
+    /// registration is weak and owned by the caller, and a `Ready` is what the other
+    /// parked accepters need to be woken for.
     pub fn poll_accept_bi(
         &mut self,
         waiter: &Waiter,

--- a/rs/web-transport-iroh/src/session.rs
+++ b/rs/web-transport-iroh/src/session.rs
@@ -103,7 +103,7 @@ impl Session {
         if let Some(h3) = &self.h3 {
             // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
             // expires, say — also drops its registration in `H3SessionAccept`.
-            kio::wait(|waiter| h3.accept.lock().unwrap().poll_accept_uni(waiter)).await
+            kio::wait(|waiter| poll_accept_uni_shared(&h3.accept, waiter)).await
         } else {
             self.conn
                 .accept_uni()
@@ -116,7 +116,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`iroh::endpoint::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(h3) = &self.h3 {
-            kio::wait(|waiter| h3.accept.lock().unwrap().poll_accept_bi(waiter)).await
+            kio::wait(|waiter| poll_accept_bi_shared(&h3.accept, waiter)).await
         } else {
             self.conn
                 .accept_bi()
@@ -351,6 +351,49 @@ type PendingUni =
 type PendingBi = dyn Future<Output = Result<Option<(endpoint::SendStream, endpoint::RecvStream)>, SessionError>>
     + Send;
 
+// Poll the shared accept state, then wake the *other* accepters once the lock is
+// released.
+//
+// `H3SessionAccept` does not wake them itself: a waker is free to resume its task
+// inline, and the first thing a resumed accepter does is take this same lock. An
+// arrival or a failure is exactly what the others are parked waiting to retry
+// after, so `Ready` is the signal.
+fn poll_accept_uni_shared(
+    accept: &Mutex<H3SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<RecvStream, SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_uni(waiter);
+        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
+fn poll_accept_bi_shared(
+    accept: &Mutex<H3SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_bi(waiter);
+        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
 // Logic just for accepting streams, which is annoying because of the stream header.
 struct H3SessionAccept {
     session_id: VarInt,
@@ -369,8 +412,8 @@ struct H3SessionAccept {
 
     // Waiters from concurrent callers of accept_bi / accept_uni.
     // Every clone of the session polls this one struct, so an arrival has to be fanned
-    // out: each caller registers here and all of them are woken when a stream lands.
-    //
+    // out: each caller registers here and all of them are woken when a stream lands —
+    // by the caller that saw it, once it has released the lock on this struct.
     bi_waiters: Arc<AcceptWaiters>,
     uni_waiters: Arc<AcceptWaiters>,
 
@@ -436,7 +479,6 @@ impl H3SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -461,7 +503,6 @@ impl H3SessionAccept {
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
-                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -520,7 +561,6 @@ impl H3SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -545,7 +585,6 @@ impl H3SessionAccept {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
-                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-iroh/src/tests.rs
+++ b/rs/web-transport-iroh/src/tests.rs
@@ -330,3 +330,97 @@ async fn two_tasks_can_accept_concurrently() -> n0_error::Result<()> {
 
     Ok(())
 }
+
+/// An accepter that walks away must not leave its waker behind.
+///
+/// `H3SessionAccept` used to keep a `Vec<Waker>` with no way to say "I'm gone": it was
+/// only ever cleared by a stream arriving or the connection failing. A caller that
+/// started an accept and dropped the future — a `timeout` around `accept_uni()`, say —
+/// left its waker there forever, so distinct tasks doing that on a quiet connection grew
+/// the list without bound, retaining a task allocation apiece.
+///
+/// No stream is ever delivered here: an arrival drains the list, which would hide
+/// exactly what is under test.
+#[tokio::test]
+#[traced_test]
+async fn abandoned_accepters_release_their_wakers() -> n0_error::Result<()> {
+    /// Well past any plausible bound on concurrent accepters.
+    const ABANDONED: usize = 256;
+
+    let client = Endpoint::bind(presets::Minimal).await.unwrap();
+    let client = Client::new(client);
+
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![ALPN_H3.as_bytes().to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    let server_id = server.id();
+    let server_addr = server.addr();
+
+    let url: Url = format!("https://{}/foo", server_id).parse().unwrap();
+
+    // The client holds the connection open until the server has finished checking, and
+    // the server waits for the handshake to complete before it starts.
+    let (connected_tx, connected_rx) = tokio::sync::oneshot::channel::<()>();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let client_task = tokio::task::spawn(async move {
+        let session = client.connect_h3(server_addr, url).await.unwrap();
+        connected_tx.send(()).unwrap();
+        done_rx.await.unwrap();
+        session.close(0, b"bye");
+        client.close().await;
+    });
+
+    let server_task = tokio::task::spawn(async move {
+        let conn = server.accept().await.unwrap().await.unwrap();
+        let session = H3Request::accept(conn).await.unwrap().ok().await.unwrap();
+        connected_rx.await.unwrap();
+
+        // Each iteration is a distinct task's worth of waker, registered by a single
+        // poll and abandoned when the future drops at the end of the scope.
+        let mut abandoned = Vec::with_capacity(ABANDONED);
+        for _ in 0..ABANDONED {
+            let flag = Arc::new(FlagWaker::default());
+            let waker = Waker::from(flag.clone());
+
+            let mut accept = std::pin::pin!(session.accept_uni());
+            assert!(
+                accept
+                    .as_mut()
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending(),
+                "no stream should be available yet"
+            );
+
+            abandoned.push(flag);
+        }
+
+        // Every abandoned waker should be uniquely owned by this test again. The inner
+        // accept future holds the shared waker, not the caller's, so there is nothing to
+        // displace first.
+        let retained = abandoned
+            .iter()
+            .filter(|flag| Arc::strong_count(flag) > 1)
+            .count();
+        assert_eq!(
+            retained, 0,
+            "{retained} of {ABANDONED} abandoned accepters are still parked"
+        );
+
+        done_tx.send(()).unwrap();
+        server.close().await;
+    });
+
+    timeout(Duration::from_secs(10), client_task)
+        .await
+        .expect("client task timed out")
+        .unwrap();
+    timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server task timed out")
+        .unwrap();
+
+    Ok(())
+}

--- a/rs/web-transport-iroh/src/waiters.rs
+++ b/rs/web-transport-iroh/src/waiters.rs
@@ -49,6 +49,17 @@ impl AcceptWaiters {
         let mut waiters = self.waiters.lock().unwrap().take();
         waiters.wake();
     }
+
+    /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
+    /// exposes no length, and the test below has to see that repeated polls do not stack
+    /// entries. Panics rather than guessing if kio's format ever changes.
+    #[cfg(test)]
+    fn slots(&self) -> usize {
+        let list = format!("{:?}", self.waiters.lock().unwrap());
+        list.rsplit_once("len: ")
+            .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
+            .expect("WaiterList Debug should report a length")
+    }
 }
 
 impl Wake for AcceptWaiters {
@@ -113,5 +124,35 @@ mod tests {
 
         rx.recv_timeout(Duration::from_secs(5))
             .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
+    }
+
+    /// Repeated polls must not stack registrations.
+    ///
+    /// Both routes in build a fresh `Waiter` per poll and drop the previous one — kio's
+    /// `wait` for the `async` methods, the `Context` bridge for the `poll_*` ones — so
+    /// the list reclaims the dead slot instead of growing. A bridge that reused a *live*
+    /// waiter would add an entry on every re-poll, which is the trap `kio::WaiterCell`
+    /// warns about, and this is the guard for whatever ends up replacing that bridge.
+    #[test]
+    fn repeated_polls_do_not_stack_registrations() {
+        let waiters = AcceptWaiters::default();
+
+        // Retained across iterations exactly as a poll bridge retains it: assigning the
+        // next one drops the previous, killing the registration it left behind.
+        let mut held = None;
+
+        for _ in 0..100 {
+            let waiter = Waiter::new(std::task::Waker::noop().clone());
+            waiters.register(&waiter);
+            held = Some(waiter);
+        }
+
+        assert!(
+            waiters.slots() <= 2,
+            "100 polls left {} registrations behind",
+            waiters.slots()
+        );
+
+        drop(held);
     }
 }

--- a/rs/web-transport-iroh/src/waiters.rs
+++ b/rs/web-transport-iroh/src/waiters.rs
@@ -15,6 +15,18 @@ use std::{
 
 use kio::{Waiter, WaiterList};
 
+#[derive(Default)]
+struct AcceptState {
+    waiters: WaiterList,
+
+    /// A poll is holding the lock on the accept state, so a wake arriving now is
+    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
+    armed: bool,
+
+    /// A wake arrived while `armed`, and is owed to the list.
+    deferred: bool,
+}
+
 /// The accepters parked on one direction, plus the waker that wakes all of them.
 ///
 /// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
@@ -25,9 +37,7 @@ use kio::{Waiter, WaiterList};
 /// everyone on the list.
 #[derive(Default)]
 pub(crate) struct AcceptWaiters {
-    // Held only to register or to wake, never across a poll of the inner futures, which
-    // take locks of their own further down.
-    waiters: Mutex<WaiterList>,
+    state: Mutex<AcceptState>,
 }
 
 impl AcceptWaiters {
@@ -37,17 +47,49 @@ impl AcceptWaiters {
     /// `timeout` around `accept_uni`, or a task that just drops the future — releases
     /// its slot instead of leaving a waker parked here forever.
     pub(crate) fn register(&self, waiter: &Waiter) {
-        waiter.register(&mut self.waiters.lock().unwrap());
+        waiter.register(&mut self.state.lock().unwrap().waiters);
     }
 
-    /// Wake every parked accepter so it can retry.
+    /// Wake every parked accepter so it can retry, or record the wake while a poll is
+    /// [armed](Self::arm).
     ///
     /// The list is taken under the lock and woken outside it. A waker is free to resume
     /// its task inline, and the first thing a resumed accepter does is register here
     /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        let mut waiters = self.waiters.lock().unwrap().take();
+        let mut waiters = {
+            let mut state = self.state.lock().unwrap();
+            if state.armed {
+                state.deferred = true;
+                return;
+            }
+
+            state.waiters.take()
+        };
+
         waiters.wake();
+    }
+
+    /// Hold back wakes for the duration of a poll that holds the lock on the accept
+    /// state.
+    ///
+    /// That poll drives the shared accept futures with this list's waker, and one of
+    /// them may wake it *inline* — `FuturesUnordered`, for one, notifies its parent from
+    /// a child's `wake`. Delivering that would resume an accepter underneath the accept
+    /// lock, which it takes as its first move. So it is recorded instead, and
+    /// [`disarm`](Self::disarm) hands it back once the lock is gone.
+    pub(crate) fn arm(&self) {
+        self.state.lock().unwrap().armed = true;
+    }
+
+    /// Stop holding wakes back, reporting whether one arrived while armed.
+    ///
+    /// Only ever called with the accept lock released, and the caller owes the list a
+    /// [`wake_all`](Self::wake_all) when this returns true.
+    pub(crate) fn disarm(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.armed = false;
+        std::mem::take(&mut state.deferred)
     }
 
     /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
@@ -55,7 +97,7 @@ impl AcceptWaiters {
     /// entries. Panics rather than guessing if kio's format ever changes.
     #[cfg(test)]
     fn slots(&self) -> usize {
-        let list = format!("{:?}", self.waiters.lock().unwrap());
+        let list = format!("{:?}", self.state.lock().unwrap().waiters);
         list.rsplit_once("len: ")
             .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
             .expect("WaiterList Debug should report a length")
@@ -81,6 +123,28 @@ mod tests {
     };
 
     use super::*;
+
+    /// Records whether it was woken.
+    #[derive(Default)]
+    struct Flag {
+        woken: std::sync::atomic::AtomicBool,
+    }
+
+    impl Flag {
+        fn woken(&self) -> bool {
+            self.woken.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl Wake for Flag {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.woken.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
 
     /// A waker that re-enters the list from `wake`, standing in for an executor that
     /// polls a resumed task inline: the first thing a resumed accepter does is register
@@ -154,5 +218,38 @@ mod tests {
         );
 
         drop(held);
+    }
+
+    /// A wake that lands mid-poll is held until the accept lock is gone.
+    ///
+    /// The shared accept futures are driven with this list's waker while the poll holds
+    /// that lock, and an inner future can wake it inline. Delivering it there would
+    /// resume an accepter straight into the lock it is standing on.
+    #[test]
+    fn a_wake_during_a_poll_is_deferred() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm();
+        waiters.wake_all();
+        assert!(
+            !flag.woken(),
+            "the wake was delivered while the accept lock was held"
+        );
+
+        assert!(waiters.disarm(), "the deferred wake was dropped");
+        waiters.wake_all();
+        assert!(flag.woken(), "the deferred wake never arrived");
+    }
+
+    /// Nothing owed when nothing woke.
+    #[test]
+    fn disarming_a_quiet_poll_owes_no_wake() {
+        let waiters = AcceptWaiters::default();
+        waiters.arm();
+        assert!(!waiters.disarm());
     }
 }

--- a/rs/web-transport-iroh/src/waiters.rs
+++ b/rs/web-transport-iroh/src/waiters.rs
@@ -41,8 +41,13 @@ impl AcceptWaiters {
     }
 
     /// Wake every parked accepter so it can retry.
+    ///
+    /// The list is taken under the lock and woken outside it. A waker is free to resume
+    /// its task inline, and the first thing a resumed accepter does is register here
+    /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        self.waiters.lock().unwrap().wake();
+        let mut waiters = self.waiters.lock().unwrap().take();
+        waiters.wake();
     }
 }
 
@@ -53,5 +58,60 @@ impl Wake for AcceptWaiters {
 
     fn wake_by_ref(self: &Arc<Self>) {
         self.wake_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Weak, mpsc},
+        thread,
+        time::Duration,
+    };
+
+    use super::*;
+
+    /// A waker that re-enters the list from `wake`, standing in for an executor that
+    /// polls a resumed task inline: the first thing a resumed accepter does is register
+    /// itself again.
+    struct Reentrant {
+        waiters: Weak<AcceptWaiters>,
+    }
+
+    impl Wake for Reentrant {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            if let Some(waiters) = self.waiters.upgrade() {
+                waiters.register(&Waiter::new(std::task::Waker::noop().clone()));
+            }
+        }
+    }
+
+    #[test]
+    fn waking_does_not_hold_the_lock() {
+        let waiters = Arc::new(AcceptWaiters::default());
+        let inline = Arc::new(Reentrant {
+            waiters: Arc::downgrade(&waiters),
+        });
+
+        // Kept alive for the whole test: the registration dies with it.
+        let waiter = Waiter::new(std::task::Waker::from(inline));
+        waiters.register(&waiter);
+
+        // On a deadlock this thread never finishes, so the test cannot hang.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn({
+            let waiters = waiters.clone();
+            move || {
+                waiters.wake_all();
+                let _ = tx.send(());
+            }
+        });
+
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
     }
 }

--- a/rs/web-transport-iroh/src/waiters.rs
+++ b/rs/web-transport-iroh/src/waiters.rs
@@ -1,0 +1,57 @@
+//! Who is waiting on a shared accept, and how they are woken.
+//!
+//! `H3SessionAccept` is shared by every clone of a session, so it has to fan a single
+//! arrival out to every accepter parked on it — without holding on to accepters that
+//! walk away, which is what the weak registrations in [`kio::WaiterList`] are for.
+//!
+//! [`AcceptWaiters`] is that list, plus the waker the shared accept futures are polled
+//! with. A caller holds the other end of its registration inside the future it is
+//! polling; see [`kio::wait`].
+
+use std::{
+    sync::{Arc, Mutex},
+    task::Wake,
+};
+
+use kio::{Waiter, WaiterList};
+
+/// The accepters parked on one direction, plus the waker that wakes all of them.
+///
+/// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
+/// this, not with the caller's. A caller's waker goes stale the moment it stops
+/// accepting: whoever polled last is the one the inner future holds, so if that caller
+/// drops its future the arrival wakes nobody while other accepters sit parked. This
+/// waker cannot go stale — it lives as long as the accept state — and waking it wakes
+/// everyone on the list.
+#[derive(Default)]
+pub(crate) struct AcceptWaiters {
+    // Held only to register or to wake, never across a poll of the inner futures, which
+    // take locks of their own further down.
+    waiters: Mutex<WaiterList>,
+}
+
+impl AcceptWaiters {
+    /// Park a caller until the next wake.
+    ///
+    /// Registrations are weak and owned by the caller, so an accepter that gives up — a
+    /// `timeout` around `accept_uni`, or a task that just drops the future — releases
+    /// its slot instead of leaving a waker parked here forever.
+    pub(crate) fn register(&self, waiter: &Waiter) {
+        waiter.register(&mut self.waiters.lock().unwrap());
+    }
+
+    /// Wake every parked accepter so it can retry.
+    pub(crate) fn wake_all(&self) {
+        self.waiters.lock().unwrap().wake();
+    }
+}
+
+impl Wake for AcceptWaiters {
+    fn wake(self: Arc<Self>) {
+        self.wake_all();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.wake_all();
+    }
+}

--- a/rs/web-transport-iroh/src/waiters.rs
+++ b/rs/web-transport-iroh/src/waiters.rs
@@ -19,9 +19,13 @@ use kio::{Waiter, WaiterList};
 struct AcceptState {
     waiters: WaiterList,
 
-    /// A poll is holding the lock on the accept state, so a wake arriving now is
-    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
-    armed: bool,
+    /// How many polls are holding the lock on the accept state. While this is non-zero
+    /// a wake is recorded rather than delivered. See [`AcceptWaiters::arm`].
+    ///
+    /// A count, not a flag: one poll releases the accept lock before it disarms, so
+    /// another can be armed and mid-poll by then, and a flag would let the first one
+    /// clear the second's protection.
+    armed: usize,
 
     /// A wake arrived while `armed`, and is owed to the list.
     deferred: bool,
@@ -59,7 +63,7 @@ impl AcceptWaiters {
     pub(crate) fn wake_all(&self) {
         let mut waiters = {
             let mut state = self.state.lock().unwrap();
-            if state.armed {
+            if state.armed > 0 {
                 state.deferred = true;
                 return;
             }
@@ -79,16 +83,23 @@ impl AcceptWaiters {
     /// lock, which it takes as its first move. So it is recorded instead, and
     /// [`disarm`](Self::disarm) hands it back once the lock is gone.
     pub(crate) fn arm(&self) {
-        self.state.lock().unwrap().armed = true;
+        self.state.lock().unwrap().armed += 1;
     }
 
-    /// Stop holding wakes back, reporting whether one arrived while armed.
+    /// Stop holding wakes back, reporting whether one arrived and is this caller's to
+    /// deliver.
     ///
     /// Only ever called with the accept lock released, and the caller owes the list a
-    /// [`wake_all`](Self::wake_all) when this returns true.
+    /// [`wake_all`](Self::wake_all) when this returns true. False while another poll is
+    /// still armed: a deferred wake stays owed until the last one leaves, and that one
+    /// delivers it.
     pub(crate) fn disarm(&self) -> bool {
         let mut state = self.state.lock().unwrap();
-        state.armed = false;
+        state.armed = state.armed.saturating_sub(1);
+        if state.armed > 0 {
+            return false;
+        }
+
         std::mem::take(&mut state.deferred)
     }
 
@@ -251,5 +262,31 @@ mod tests {
         let waiters = AcceptWaiters::default();
         waiters.arm();
         assert!(!waiters.disarm());
+    }
+
+    /// One poll releasing the accept lock must not drop another's protection.
+    ///
+    /// The lock is released before `disarm`, so a second poll can be armed and running
+    /// by then. With a flag instead of a count, the first one leaving would expose the
+    /// second to exactly the inline wake this is here to prevent.
+    #[test]
+    fn overlapping_polls_stay_armed_until_the_last_one_leaves() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm(); // first poll
+        waiters.arm(); // second poll, overlapping
+
+        assert!(!waiters.disarm(), "the first out does not own the wake");
+
+        waiters.wake_all();
+        assert!(!flag.woken(), "a poll is still holding the accept lock");
+
+        assert!(waiters.disarm(), "the last one out owes the deferred wake");
+        waiters.wake_all();
+        assert!(flag.woken());
     }
 }

--- a/rs/web-transport-noq/Cargo.toml
+++ b/rs/web-transport-noq/Cargo.toml
@@ -26,6 +26,7 @@ qlog = ["noq/qlog"]
 bytes = "1"
 futures = "0.3"
 http = "1"
+kio = "0.5.2"
 noq = { version = "1", default-features = false, features = [
     "tracing-log",
     "platform-verifier",
@@ -52,6 +53,7 @@ web-transport-trait = { workspace = true }
 [dev-dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+rcgen = "0.14"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rs/web-transport-noq/src/lib.rs
+++ b/rs/web-transport-noq/src/lib.rs
@@ -30,6 +30,7 @@ mod recv;
 mod send;
 mod server;
 mod session;
+mod waiters;
 
 pub use client::*;
 pub use error::*;
@@ -59,6 +60,10 @@ pub use noq;
 
 /// Re-export the http crate because it's in the public API.
 pub use http;
+
+/// Re-export kio, whose [`Waiter`](kio::Waiter) is how a caller of
+/// [`SessionAccept`]'s poll methods holds its place in the accept queue.
+pub use kio;
 
 /// Re-export the generic WebTransport implementation.
 pub use web_transport_trait as generic;

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    future::{poll_fn, Future},
+    future::Future,
     io::Cursor,
     ops::Deref,
     pin::Pin,
@@ -11,9 +11,11 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use futures::stream::{FuturesUnordered, Stream, StreamExt};
+use kio::Waiter;
 
 use crate::{
     proto::{ConnectRequest, ConnectResponse, Frame, StreamUni, VarInt},
+    waiters::AcceptWaiters,
     ClientError, Connected, RecvStream, SendStream, SessionError, Settings, WebTransportError,
 };
 
@@ -186,7 +188,9 @@ impl Session {
     /// Accept a new unidirectional stream. See [`noq::Connection::accept_uni`].
     pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_uni(cx))
+            // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
+            // expires, say — also drops its registration in `SessionAccept`.
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -202,7 +206,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`noq::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_bi(cx))
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -575,11 +579,19 @@ pub struct SessionAccept {
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
 
-    // Wakers from concurrent callers of accept_bi / accept_uni.
-    // When one caller gets a stream, all others are woken so they can retry.
-    // This fixes the lost-waker bug where the unfold stream only stores one waker.
-    bi_wakers: Vec<Waker>,
-    uni_wakers: Vec<Waker>,
+    // Waiters from concurrent callers of accept_bi / accept_uni.
+    // Every clone of the session polls this one struct, so an arrival has to be fanned
+    // out: each caller registers here and all of them are woken when a stream lands.
+    //
+    bi_waiters: Arc<AcceptWaiters>,
+    uni_waiters: Arc<AcceptWaiters>,
+
+    // `Waker::from(waiters.clone())`, cached so the inner accept futures are polled with
+    // the same waker every time. That waker outlives every caller, so an accepter that
+    // drops its future cannot take the wakeup path with it, and the layer below holds
+    // one registration rather than one per caller.
+    bi_waker: Waker,
+    uni_waker: Waker,
 }
 
 impl SessionAccept {
@@ -597,6 +609,11 @@ impl SessionAccept {
             Some((conn.accept_bi().await, conn))
         }));
 
+        let bi_waiters = Arc::new(AcceptWaiters::default());
+        let uni_waiters = Arc::new(AcceptWaiters::default());
+        let bi_waker = Waker::from(bi_waiters.clone());
+        let uni_waker = Waker::from(uni_waiters.clone());
+
         Self {
             session_id,
             error,
@@ -610,18 +627,25 @@ impl SessionAccept {
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
 
-            bi_wakers: Vec::new(),
-            uni_wakers: Vec::new(),
+            bi_waiters,
+            uni_waiters,
+            bi_waker,
+            uni_waker,
         }
     }
 
     // This is poll-based because we accept and decode streams in parallel.
     // In async land I would use tokio::JoinSet, but that requires a runtime.
     // It's better to use FuturesUnordered instead because it's agnostic.
-    pub fn poll_accept_uni(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<RecvStream, SessionError>> {
+    pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
+        // Register before polling, not on the way out: the shared waker can fire from the
+        // layer below at any point here, and a wake that lands before the caller is on
+        // the list would be lost.
+        self.uni_waiters.register(waiter);
+
+        let waker = self.uni_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next_unpin(cx) {
@@ -629,9 +653,7 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        for waker in self.uni_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -649,21 +671,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode unidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.uni_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv, self.error.clone());
-                    for waker in self.uni_wakers.drain(..) {
-                        waker.wake();
-                    }
+                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -707,8 +722,14 @@ impl SessionAccept {
 
     pub fn poll_accept_bi(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        // Register before polling; see `poll_accept_uni`.
+        self.bi_waiters.register(waiter);
+
+        let waker = self.bi_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next_unpin(cx) {
@@ -716,9 +737,7 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        for waker in self.bi_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -736,21 +755,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode bidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.bi_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send, self.error.clone());
                 let recv = RecvStream::new(recv, self.error.clone());
-                for waker in self.bi_wakers.drain(..) {
-                    waker.wake();
-                }
+                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -565,12 +565,18 @@ fn poll_accept_uni_shared(
 ) -> Poll<Result<RecvStream, SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.uni_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_uni(waiter);
-        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 
@@ -583,12 +589,18 @@ fn poll_accept_bi_shared(
 ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.bi_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_bi(waiter);
-        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -190,7 +190,7 @@ impl Session {
         if let Some(accept) = &self.accept {
             // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
             // expires, say — also drops its registration in `SessionAccept`.
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter))
+            kio::wait(|waiter| poll_accept_uni_shared(accept, waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -206,7 +206,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`noq::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter))
+            kio::wait(|waiter| poll_accept_bi_shared(accept, waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -552,6 +552,49 @@ impl PartialEq for Session {
 
 impl Eq for Session {}
 
+// Poll the shared accept state, then wake the *other* accepters once the lock is
+// released.
+//
+// `SessionAccept` does not wake them itself: a waker is free to resume its task
+// inline, and the first thing a resumed accepter does is take this same lock. An
+// arrival or a failure is exactly what the others are parked waiting to retry
+// after, so `Ready` is the signal.
+fn poll_accept_uni_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<RecvStream, SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_uni(waiter);
+        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
+fn poll_accept_bi_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_bi(waiter);
+        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
 // Type aliases just so clippy doesn't complain about the complexity.
 type AcceptUni = dyn Stream<Item = Result<noq::RecvStream, noq::ConnectionError>> + Send;
 type AcceptBi =
@@ -581,7 +624,8 @@ pub struct SessionAccept {
 
     // Waiters from concurrent callers of accept_bi / accept_uni.
     // Every clone of the session polls this one struct, so an arrival has to be fanned
-    // out: each caller registers here and all of them are woken when a stream lands.
+    // out: each caller registers here and all of them are woken when a stream lands —
+    // by the caller that saw it, once it has released the lock on this struct.
     //
     bi_waiters: Arc<AcceptWaiters>,
     uni_waiters: Arc<AcceptWaiters>,
@@ -653,7 +697,6 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -678,7 +721,6 @@ impl SessionAccept {
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv, self.error.clone());
-                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -737,7 +779,6 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -762,7 +803,6 @@ impl SessionAccept {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send, self.error.clone());
                 let recv = RecvStream::new(recv, self.error.clone());
-                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -678,9 +678,20 @@ impl SessionAccept {
         }
     }
 
-    // This is poll-based because we accept and decode streams in parallel.
-    // In async land I would use tokio::JoinSet, but that requires a runtime.
-    // It's better to use FuturesUnordered instead because it's agnostic.
+    /// Poll for the next unidirectional WebTransport stream.
+    ///
+    /// `waiter` is parked until a stream arrives, the accept fails, or the caller drops
+    /// it. The registration is weak and owned by the caller: keep the [`Waiter`] alive
+    /// until it is woken, or it will be reclaimed and nothing will wake you. Drive this
+    /// with [`kio::wait`], which holds the waiter inside the future it builds.
+    ///
+    /// A `Ready` here means every *other* parked accepter should be woken so it can
+    /// retry. This does not do that itself — see `poll_accept_uni_shared`, which wakes
+    /// them once the lock on this struct is released.
+    //
+    // Poll-based because we accept and decode streams in parallel. In async land this
+    // would be a `tokio::JoinSet`, but that needs a runtime; `FuturesUnordered` is
+    // runtime-agnostic.
     pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
         // Register before polling, not on the way out: the shared waker can fire from the
         // layer below at any point here, and a wake that lands before the caller is on
@@ -762,6 +773,11 @@ impl SessionAccept {
         Ok((typ, recv))
     }
 
+    /// Poll for the next bidirectional WebTransport stream.
+    ///
+    /// The same contract as [`poll_accept_uni`](Self::poll_accept_uni): the `waiter`
+    /// registration is weak and owned by the caller, and a `Ready` is what the other
+    /// parked accepters need to be woken for.
     pub fn poll_accept_bi(
         &mut self,
         waiter: &Waiter,

--- a/rs/web-transport-noq/src/session.rs
+++ b/rs/web-transport-noq/src/session.rs
@@ -575,7 +575,7 @@ fn poll_accept_uni_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
@@ -599,7 +599,7 @@ fn poll_accept_bi_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }

--- a/rs/web-transport-noq/src/waiters.rs
+++ b/rs/web-transport-noq/src/waiters.rs
@@ -49,6 +49,17 @@ impl AcceptWaiters {
         let mut waiters = self.waiters.lock().unwrap().take();
         waiters.wake();
     }
+
+    /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
+    /// exposes no length, and the test below has to see that repeated polls do not stack
+    /// entries. Panics rather than guessing if kio's format ever changes.
+    #[cfg(test)]
+    fn slots(&self) -> usize {
+        let list = format!("{:?}", self.waiters.lock().unwrap());
+        list.rsplit_once("len: ")
+            .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
+            .expect("WaiterList Debug should report a length")
+    }
 }
 
 impl Wake for AcceptWaiters {
@@ -113,5 +124,35 @@ mod tests {
 
         rx.recv_timeout(Duration::from_secs(5))
             .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
+    }
+
+    /// Repeated polls must not stack registrations.
+    ///
+    /// Both routes in build a fresh `Waiter` per poll and drop the previous one — kio's
+    /// `wait` for the `async` methods, the `Context` bridge for the `poll_*` ones — so
+    /// the list reclaims the dead slot instead of growing. A bridge that reused a *live*
+    /// waiter would add an entry on every re-poll, which is the trap `kio::WaiterCell`
+    /// warns about, and this is the guard for whatever ends up replacing that bridge.
+    #[test]
+    fn repeated_polls_do_not_stack_registrations() {
+        let waiters = AcceptWaiters::default();
+
+        // Retained across iterations exactly as a poll bridge retains it: assigning the
+        // next one drops the previous, killing the registration it left behind.
+        let mut held = None;
+
+        for _ in 0..100 {
+            let waiter = Waiter::new(std::task::Waker::noop().clone());
+            waiters.register(&waiter);
+            held = Some(waiter);
+        }
+
+        assert!(
+            waiters.slots() <= 2,
+            "100 polls left {} registrations behind",
+            waiters.slots()
+        );
+
+        drop(held);
     }
 }

--- a/rs/web-transport-noq/src/waiters.rs
+++ b/rs/web-transport-noq/src/waiters.rs
@@ -15,6 +15,18 @@ use std::{
 
 use kio::{Waiter, WaiterList};
 
+#[derive(Default)]
+struct AcceptState {
+    waiters: WaiterList,
+
+    /// A poll is holding the lock on the accept state, so a wake arriving now is
+    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
+    armed: bool,
+
+    /// A wake arrived while `armed`, and is owed to the list.
+    deferred: bool,
+}
+
 /// The accepters parked on one direction, plus the waker that wakes all of them.
 ///
 /// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
@@ -25,9 +37,7 @@ use kio::{Waiter, WaiterList};
 /// everyone on the list.
 #[derive(Default)]
 pub(crate) struct AcceptWaiters {
-    // Held only to register or to wake, never across a poll of the inner futures, which
-    // take locks of their own further down.
-    waiters: Mutex<WaiterList>,
+    state: Mutex<AcceptState>,
 }
 
 impl AcceptWaiters {
@@ -37,17 +47,49 @@ impl AcceptWaiters {
     /// `timeout` around `accept_uni`, or a task that just drops the future — releases
     /// its slot instead of leaving a waker parked here forever.
     pub(crate) fn register(&self, waiter: &Waiter) {
-        waiter.register(&mut self.waiters.lock().unwrap());
+        waiter.register(&mut self.state.lock().unwrap().waiters);
     }
 
-    /// Wake every parked accepter so it can retry.
+    /// Wake every parked accepter so it can retry, or record the wake while a poll is
+    /// [armed](Self::arm).
     ///
     /// The list is taken under the lock and woken outside it. A waker is free to resume
     /// its task inline, and the first thing a resumed accepter does is register here
     /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        let mut waiters = self.waiters.lock().unwrap().take();
+        let mut waiters = {
+            let mut state = self.state.lock().unwrap();
+            if state.armed {
+                state.deferred = true;
+                return;
+            }
+
+            state.waiters.take()
+        };
+
         waiters.wake();
+    }
+
+    /// Hold back wakes for the duration of a poll that holds the lock on the accept
+    /// state.
+    ///
+    /// That poll drives the shared accept futures with this list's waker, and one of
+    /// them may wake it *inline* — `FuturesUnordered`, for one, notifies its parent from
+    /// a child's `wake`. Delivering that would resume an accepter underneath the accept
+    /// lock, which it takes as its first move. So it is recorded instead, and
+    /// [`disarm`](Self::disarm) hands it back once the lock is gone.
+    pub(crate) fn arm(&self) {
+        self.state.lock().unwrap().armed = true;
+    }
+
+    /// Stop holding wakes back, reporting whether one arrived while armed.
+    ///
+    /// Only ever called with the accept lock released, and the caller owes the list a
+    /// [`wake_all`](Self::wake_all) when this returns true.
+    pub(crate) fn disarm(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.armed = false;
+        std::mem::take(&mut state.deferred)
     }
 
     /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
@@ -55,7 +97,7 @@ impl AcceptWaiters {
     /// entries. Panics rather than guessing if kio's format ever changes.
     #[cfg(test)]
     fn slots(&self) -> usize {
-        let list = format!("{:?}", self.waiters.lock().unwrap());
+        let list = format!("{:?}", self.state.lock().unwrap().waiters);
         list.rsplit_once("len: ")
             .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
             .expect("WaiterList Debug should report a length")
@@ -81,6 +123,28 @@ mod tests {
     };
 
     use super::*;
+
+    /// Records whether it was woken.
+    #[derive(Default)]
+    struct Flag {
+        woken: std::sync::atomic::AtomicBool,
+    }
+
+    impl Flag {
+        fn woken(&self) -> bool {
+            self.woken.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl Wake for Flag {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.woken.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
 
     /// A waker that re-enters the list from `wake`, standing in for an executor that
     /// polls a resumed task inline: the first thing a resumed accepter does is register
@@ -154,5 +218,38 @@ mod tests {
         );
 
         drop(held);
+    }
+
+    /// A wake that lands mid-poll is held until the accept lock is gone.
+    ///
+    /// The shared accept futures are driven with this list's waker while the poll holds
+    /// that lock, and an inner future can wake it inline. Delivering it there would
+    /// resume an accepter straight into the lock it is standing on.
+    #[test]
+    fn a_wake_during_a_poll_is_deferred() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm();
+        waiters.wake_all();
+        assert!(
+            !flag.woken(),
+            "the wake was delivered while the accept lock was held"
+        );
+
+        assert!(waiters.disarm(), "the deferred wake was dropped");
+        waiters.wake_all();
+        assert!(flag.woken(), "the deferred wake never arrived");
+    }
+
+    /// Nothing owed when nothing woke.
+    #[test]
+    fn disarming_a_quiet_poll_owes_no_wake() {
+        let waiters = AcceptWaiters::default();
+        waiters.arm();
+        assert!(!waiters.disarm());
     }
 }

--- a/rs/web-transport-noq/src/waiters.rs
+++ b/rs/web-transport-noq/src/waiters.rs
@@ -41,8 +41,13 @@ impl AcceptWaiters {
     }
 
     /// Wake every parked accepter so it can retry.
+    ///
+    /// The list is taken under the lock and woken outside it. A waker is free to resume
+    /// its task inline, and the first thing a resumed accepter does is register here
+    /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        self.waiters.lock().unwrap().wake();
+        let mut waiters = self.waiters.lock().unwrap().take();
+        waiters.wake();
     }
 }
 
@@ -53,5 +58,60 @@ impl Wake for AcceptWaiters {
 
     fn wake_by_ref(self: &Arc<Self>) {
         self.wake_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{mpsc, Weak},
+        thread,
+        time::Duration,
+    };
+
+    use super::*;
+
+    /// A waker that re-enters the list from `wake`, standing in for an executor that
+    /// polls a resumed task inline: the first thing a resumed accepter does is register
+    /// itself again.
+    struct Reentrant {
+        waiters: Weak<AcceptWaiters>,
+    }
+
+    impl Wake for Reentrant {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            if let Some(waiters) = self.waiters.upgrade() {
+                waiters.register(&Waiter::new(std::task::Waker::noop().clone()));
+            }
+        }
+    }
+
+    #[test]
+    fn waking_does_not_hold_the_lock() {
+        let waiters = Arc::new(AcceptWaiters::default());
+        let inline = Arc::new(Reentrant {
+            waiters: Arc::downgrade(&waiters),
+        });
+
+        // Kept alive for the whole test: the registration dies with it.
+        let waiter = Waiter::new(std::task::Waker::from(inline));
+        waiters.register(&waiter);
+
+        // On a deadlock this thread never finishes, so the test cannot hang.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn({
+            let waiters = waiters.clone();
+            move || {
+                waiters.wake_all();
+                let _ = tx.send(());
+            }
+        });
+
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
     }
 }

--- a/rs/web-transport-noq/src/waiters.rs
+++ b/rs/web-transport-noq/src/waiters.rs
@@ -19,9 +19,13 @@ use kio::{Waiter, WaiterList};
 struct AcceptState {
     waiters: WaiterList,
 
-    /// A poll is holding the lock on the accept state, so a wake arriving now is
-    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
-    armed: bool,
+    /// How many polls are holding the lock on the accept state. While this is non-zero
+    /// a wake is recorded rather than delivered. See [`AcceptWaiters::arm`].
+    ///
+    /// A count, not a flag: one poll releases the accept lock before it disarms, so
+    /// another can be armed and mid-poll by then, and a flag would let the first one
+    /// clear the second's protection.
+    armed: usize,
 
     /// A wake arrived while `armed`, and is owed to the list.
     deferred: bool,
@@ -59,7 +63,7 @@ impl AcceptWaiters {
     pub(crate) fn wake_all(&self) {
         let mut waiters = {
             let mut state = self.state.lock().unwrap();
-            if state.armed {
+            if state.armed > 0 {
                 state.deferred = true;
                 return;
             }
@@ -79,16 +83,23 @@ impl AcceptWaiters {
     /// lock, which it takes as its first move. So it is recorded instead, and
     /// [`disarm`](Self::disarm) hands it back once the lock is gone.
     pub(crate) fn arm(&self) {
-        self.state.lock().unwrap().armed = true;
+        self.state.lock().unwrap().armed += 1;
     }
 
-    /// Stop holding wakes back, reporting whether one arrived while armed.
+    /// Stop holding wakes back, reporting whether one arrived and is this caller's to
+    /// deliver.
     ///
     /// Only ever called with the accept lock released, and the caller owes the list a
-    /// [`wake_all`](Self::wake_all) when this returns true.
+    /// [`wake_all`](Self::wake_all) when this returns true. False while another poll is
+    /// still armed: a deferred wake stays owed until the last one leaves, and that one
+    /// delivers it.
     pub(crate) fn disarm(&self) -> bool {
         let mut state = self.state.lock().unwrap();
-        state.armed = false;
+        state.armed = state.armed.saturating_sub(1);
+        if state.armed > 0 {
+            return false;
+        }
+
         std::mem::take(&mut state.deferred)
     }
 
@@ -251,5 +262,31 @@ mod tests {
         let waiters = AcceptWaiters::default();
         waiters.arm();
         assert!(!waiters.disarm());
+    }
+
+    /// One poll releasing the accept lock must not drop another's protection.
+    ///
+    /// The lock is released before `disarm`, so a second poll can be armed and running
+    /// by then. With a flag instead of a count, the first one leaving would expose the
+    /// second to exactly the inline wake this is here to prevent.
+    #[test]
+    fn overlapping_polls_stay_armed_until_the_last_one_leaves() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm(); // first poll
+        waiters.arm(); // second poll, overlapping
+
+        assert!(!waiters.disarm(), "the first out does not own the wake");
+
+        waiters.wake_all();
+        assert!(!flag.woken(), "a poll is still holding the accept lock");
+
+        assert!(waiters.disarm(), "the last one out owes the deferred wake");
+        waiters.wake_all();
+        assert!(flag.woken());
     }
 }

--- a/rs/web-transport-noq/src/waiters.rs
+++ b/rs/web-transport-noq/src/waiters.rs
@@ -1,0 +1,57 @@
+//! Who is waiting on a shared accept, and how they are woken.
+//!
+//! `SessionAccept` is shared by every clone of a session, so it has to fan a single
+//! arrival out to every accepter parked on it — without holding on to accepters that
+//! walk away, which is what the weak registrations in [`kio::WaiterList`] are for.
+//!
+//! [`AcceptWaiters`] is that list, plus the waker the shared accept futures are polled
+//! with. A caller holds the other end of its registration inside the future it is
+//! polling; see [`kio::wait`].
+
+use std::{
+    sync::{Arc, Mutex},
+    task::Wake,
+};
+
+use kio::{Waiter, WaiterList};
+
+/// The accepters parked on one direction, plus the waker that wakes all of them.
+///
+/// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
+/// this, not with the caller's. A caller's waker goes stale the moment it stops
+/// accepting: whoever polled last is the one the inner future holds, so if that caller
+/// drops its future the arrival wakes nobody while other accepters sit parked. This
+/// waker cannot go stale — it lives as long as the accept state — and waking it wakes
+/// everyone on the list.
+#[derive(Default)]
+pub(crate) struct AcceptWaiters {
+    // Held only to register or to wake, never across a poll of the inner futures, which
+    // take locks of their own further down.
+    waiters: Mutex<WaiterList>,
+}
+
+impl AcceptWaiters {
+    /// Park a caller until the next wake.
+    ///
+    /// Registrations are weak and owned by the caller, so an accepter that gives up — a
+    /// `timeout` around `accept_uni`, or a task that just drops the future — releases
+    /// its slot instead of leaving a waker parked here forever.
+    pub(crate) fn register(&self, waiter: &Waiter) {
+        waiter.register(&mut self.waiters.lock().unwrap());
+    }
+
+    /// Wake every parked accepter so it can retry.
+    pub(crate) fn wake_all(&self) {
+        self.waiters.lock().unwrap().wake();
+    }
+}
+
+impl Wake for AcceptWaiters {
+    fn wake(self: Arc<Self>) {
+        self.wake_all();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.wake_all();
+    }
+}

--- a/rs/web-transport-noq/tests/accept_wakers.rs
+++ b/rs/web-transport-noq/tests/accept_wakers.rs
@@ -1,0 +1,227 @@
+//! Accepters come and go; the accept queue must not leak them or lose them.
+//!
+//! `SessionAccept` keeps a list of parked accepters so that every one of them is woken
+//! when a stream arrives. That list used to be a `Vec<Waker>` with no way to say "I'm
+//! gone", cleared only by a stream arriving or the connection failing, so a caller that
+//! started an accept and dropped the future — a `tokio::time::timeout` around
+//! `accept_uni()`, say — left its waker there forever. Distinct tasks doing that on a
+//! quiet connection grew the list without bound, retaining a task allocation apiece.
+//!
+//! The wake path had the mirror-image problem: the inner accept future was polled with
+//! the caller's waker, so the last caller to poll owned the only path an arrival had
+//! back into this crate. When that caller walked away, the accepters still parked here
+//! were never woken.
+
+use std::{
+    future::Future,
+    net::Ipv4Addr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Wake, Waker},
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::time::timeout;
+use web_transport_noq::{ClientBuilder, ServerBuilder};
+use web_transport_proto::ConnectRequest;
+
+/// How many accepters give up, one after another. Well past any plausible bound on
+/// concurrent accepters, so a list that keeps every registration is obvious.
+const ABANDONED: usize = 256;
+
+/// A waker that records whether it was woken. The test also watches its `Arc` count:
+/// anything still holding a clone of the waker is retaining this allocation.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl FlagWaker {
+    fn woken(&self) -> bool {
+        self.woken.load(Ordering::SeqCst)
+    }
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
+/// With both crypto features enabled — as `--all-features` does — the crate cannot
+/// pick a provider for us, so the test installs one.
+fn install_crypto_provider() {
+    #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+    {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+}
+
+/// A client and server session, already connected.
+async fn pair() -> Result<(web_transport_noq::Session, web_transport_noq::Session)> {
+    install_crypto_provider();
+
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])?;
+    let chain = vec![cert.der().clone()];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
+
+    let mut server = ServerBuilder::new()
+        .with_addr((Ipv4Addr::LOCALHOST, 0).into())
+        .with_certificate(chain.clone(), key)?;
+
+    let addr = server.local_addr()?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("no connection")?;
+        let session = request.ok().await?;
+        anyhow::Ok(session)
+    });
+
+    let url: url::Url = format!("https://127.0.0.1:{}/", addr.port()).parse()?;
+    let client = ClientBuilder::new().with_server_certificates(chain)?;
+    let client = client.connect(ConnectRequest::new(url)).await?;
+
+    let server = server_task.await??;
+    Ok((client, server))
+}
+
+/// Register an accepter, abandon it, and repeat — on a connection where no stream ever
+/// arrives, which is the case that used to grow forever. Nothing here delivers a
+/// stream: an arrival drains the list, which would hide exactly what is under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_accepters_release_their_wakers() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // Each iteration is a distinct task's worth of waker, registered by a single poll
+    // and abandoned when the future drops at the end of the scope.
+    let mut abandoned = Vec::with_capacity(ABANDONED);
+    for _ in 0..ABANDONED {
+        let flag = Arc::new(FlagWaker::default());
+        let waker = Waker::from(flag.clone());
+
+        let mut accept = std::pin::pin!(server.accept_uni());
+        assert!(
+            accept
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending(),
+            "no stream should be available yet"
+        );
+
+        abandoned.push(flag);
+    }
+
+    // Every abandoned waker should be uniquely owned by the test again: the shared
+    // accept futures are polled with the accept state's own waker, never the caller's,
+    // so there is nothing else that could still be holding one.
+    let retained = abandoned
+        .iter()
+        .filter(|flag| Arc::strong_count(flag) > 1)
+        .count();
+    assert_eq!(
+        retained, 0,
+        "{retained} of {ABANDONED} abandoned accepters are still parked in the accept list"
+    );
+
+    client.close(0, b"bye");
+    Ok(())
+}
+
+/// Reclaiming an abandoned accepter's slot must not cost a live accepter its wakeup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn churn_does_not_lose_a_live_accepter() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // One accepter that sticks around, registered before the churn.
+    let parked = Arc::new(FlagWaker::default());
+    let parked_waker = Waker::from(parked.clone());
+    let mut waiting = std::pin::pin!(server.accept_uni());
+    assert!(
+        waiting
+            .as_mut()
+            .poll(&mut Context::from_waker(&parked_waker))
+            .is_pending(),
+        "no stream should be available yet"
+    );
+
+    for _ in 0..ABANDONED {
+        let waker = Waker::from(Arc::new(FlagWaker::default()));
+        let mut accept = std::pin::pin!(server.accept_uni());
+        assert!(accept
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+            .is_pending());
+    }
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    // A second accepter takes the stream; the first should have been woken to retry.
+    let recv = timeout(Duration::from_secs(10), server.accept_uni())
+        .await
+        .context("the stream never arrived")??;
+    drop(recv);
+
+    assert!(
+        parked.woken(),
+        "the accepter that was still waiting lost its registration to the churn"
+    );
+
+    client.close(0, b"bye");
+    Ok(())
+}
+
+/// The last accepter to poll is the one the inner accept future holds a waker for. If it
+/// gives up, the arrival has to reach whoever is still waiting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_departing_accepter_does_not_strand_the_others() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // A parks first.
+    let a = Arc::new(FlagWaker::default());
+    let a_waker = Waker::from(a.clone());
+    let mut first = std::pin::pin!(server.accept_uni());
+    assert!(first
+        .as_mut()
+        .poll(&mut Context::from_waker(&a_waker))
+        .is_pending());
+
+    // B polls after A, so B's waker is the one the inner future holds, then gives up.
+    {
+        let b = Waker::from(Arc::new(FlagWaker::default()));
+        let mut second = std::pin::pin!(server.accept_uni());
+        assert!(second
+            .as_mut()
+            .poll(&mut Context::from_waker(&b))
+            .is_pending());
+    }
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    // Nothing here polls the accept path again: A has to be woken by the arrival.
+    for _ in 0..500 {
+        if a.woken() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(a.woken(), "the remaining accepter was never woken");
+
+    client.close(0, b"bye");
+    Ok(())
+}

--- a/rs/web-transport-quiche/Cargo.toml
+++ b/rs/web-transport-quiche/Cargo.toml
@@ -26,6 +26,7 @@ bytes = "1"
 flume = "0.12"
 futures = "0.3"
 http = "1"
+kio = "0.5.2"
 rustls-pki-types = "1"
 
 thiserror = "2"

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -236,7 +236,7 @@ impl Connection {
         if let Some(accept) = &self.accept {
             // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
             // expires, say — also drops its registration in `SessionAccept`.
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter)).await
+            kio::wait(|waiter| poll_accept_uni_shared(accept, waiter)).await
         } else {
             self.conn
                 .accept_uni()
@@ -252,7 +252,7 @@ impl Connection {
     /// Returns a ([SendStream], [RecvStream]) pair for sending and receiving data.
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter)).await
+            kio::wait(|waiter| poll_accept_bi_shared(accept, waiter)).await
         } else {
             self.conn
                 .accept_bi()
@@ -506,6 +506,49 @@ impl web_transport_trait::Session for Connection {
     }
 }
 
+// Poll the shared accept state, then wake the *other* accepters once the lock is
+// released.
+//
+// `SessionAccept` does not wake them itself: a waker is free to resume its task
+// inline, and the first thing a resumed accepter does is take this same lock. An
+// arrival or a failure is exactly what the others are parked waiting to retry
+// after, so `Ready` is the signal.
+fn poll_accept_uni_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<RecvStream, SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_uni(waiter);
+        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
+fn poll_accept_bi_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_bi(waiter);
+        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
 // Type aliases just so clippy doesn't complain about the complexity.
 type AcceptUni = dyn Stream<Item = Result<ez::RecvStream, ez::ConnectionError>> + Send;
 type AcceptBi =
@@ -532,7 +575,8 @@ pub struct SessionAccept {
 
     // Waiters from concurrent callers of accept_bi / accept_uni.
     // Every clone of the session polls this one struct, so an arrival has to be fanned
-    // out: each caller registers here and all of them are woken when a stream lands.
+    // out: each caller registers here and all of them are woken when a stream lands —
+    // by the caller that saw it, once it has released the lock on this struct.
     bi_waiters: Arc<AcceptWaiters>,
     uni_waiters: Arc<AcceptWaiters>,
 
@@ -596,7 +640,6 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -621,7 +664,6 @@ impl SessionAccept {
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
-                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -680,7 +722,6 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -705,7 +746,6 @@ impl SessionAccept {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
-                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 
@@ -750,7 +790,7 @@ impl web_transport_trait::poll::Session for Connection {
             // waiter list; forward to it, holding on to our registration.
             Some(accept) => self
                 .parked_accept_uni
-                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_uni(waiter)),
+                .poll(cx, |waiter| poll_accept_uni_shared(&accept, waiter)),
             None => self.parked_accept_uni.poll(cx, |waiter| {
                 let recv = ready!(self.conn.poll_accept_uni(waiter))?;
                 Poll::Ready(Ok(RecvStream::new(recv)))
@@ -765,7 +805,7 @@ impl web_transport_trait::poll::Session for Connection {
         match self.accept.clone() {
             Some(accept) => self
                 .parked_accept_bi
-                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_bi(waiter)),
+                .poll(cx, |waiter| poll_accept_bi_shared(&accept, waiter)),
             None => self.parked_accept_bi.poll(cx, |waiter| {
                 let (send, recv) = ready!(self.conn.poll_accept_bi(waiter))?;
                 Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))))

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -519,12 +519,18 @@ fn poll_accept_uni_shared(
 ) -> Poll<Result<RecvStream, SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.uni_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_uni(waiter);
-        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 
@@ -537,12 +543,18 @@ fn poll_accept_bi_shared(
 ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.bi_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_bi(waiter);
-        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -1,11 +1,16 @@
-use crate::{ez, h3, ClientError, RecvStream, SendStream, SessionError};
+use crate::{
+    ez, h3,
+    waiters::{AcceptWaiters, Parked},
+    ClientError, RecvStream, SendStream, SessionError,
+};
 
 use bytes::{Bytes, BytesMut};
 use futures::{stream::FuturesUnordered, Stream, StreamExt};
+use kio::Waiter;
 use web_transport_proto::{ConnectRequest, ConnectResponse, Frame, StreamUni, VarInt};
 
 use std::{
-    future::{poll_fn, Future},
+    future::Future,
     io::Cursor,
     pin::Pin,
     sync::{Arc, Mutex},
@@ -72,6 +77,16 @@ pub struct Connection {
     // "clone the session for concurrency".
     open_uni: OpenUni,
     open_bi: OpenBi,
+
+    // Both `SessionAccept` and `ez` hold their waiters weakly, so the handle this clone
+    // registered with has to outlive the poll that made it: one cell per operation,
+    // per-clone, like the state above.
+    parked_accept_uni: Parked,
+    parked_accept_bi: Parked,
+    parked_open_uni: Parked,
+    parked_open_bi: Parked,
+    parked_recv_datagram: Parked,
+    parked_closed: Parked,
 }
 
 /// Where an in-progress `poll_open_uni` got to.
@@ -148,6 +163,12 @@ impl Connection {
             settings: Some(Arc::new(settings)),
             open_uni: OpenUni::Idle,
             open_bi: OpenBi::Idle,
+            parked_accept_uni: Parked::default(),
+            parked_accept_bi: Parked::default(),
+            parked_open_uni: Parked::default(),
+            parked_open_bi: Parked::default(),
+            parked_recv_datagram: Parked::default(),
+            parked_closed: Parked::default(),
         };
 
         // Run a background task to check if the connect stream is closed.
@@ -213,7 +234,9 @@ impl Connection {
     /// Returns a [RecvStream] that can be used to read data from the stream.
     pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_uni(cx)).await
+            // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
+            // expires, say — also drops its registration in `SessionAccept`.
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter)).await
         } else {
             self.conn
                 .accept_uni()
@@ -229,7 +252,7 @@ impl Connection {
     /// Returns a ([SendStream], [RecvStream]) pair for sending and receiving data.
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_bi(cx)).await
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter)).await
         } else {
             self.conn
                 .accept_bi()
@@ -376,6 +399,12 @@ impl Connection {
             response: response.into(),
             open_uni: OpenUni::Idle,
             open_bi: OpenBi::Idle,
+            parked_accept_uni: Parked::default(),
+            parked_accept_bi: Parked::default(),
+            parked_open_uni: Parked::default(),
+            parked_open_bi: Parked::default(),
+            parked_recv_datagram: Parked::default(),
+            parked_closed: Parked::default(),
         }
     }
 
@@ -501,13 +530,16 @@ pub struct SessionAccept {
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
 
-    // Wakers from concurrent callers of accept_bi / accept_uni.
-    // When one caller gets a stream, all others are woken so they can retry.
-    // Every clone polls this one struct, which would otherwise keep only the most
-    // recent waker, so a second accepter would register through a waker the first
-    // had already replaced and never wake.
-    bi_wakers: Vec<Waker>,
-    uni_wakers: Vec<Waker>,
+    // Waiters from concurrent callers of accept_bi / accept_uni.
+    // Every clone of the session polls this one struct, so an arrival has to be fanned
+    // out: each caller registers here and all of them are woken when a stream lands.
+    bi_waiters: Arc<AcceptWaiters>,
+    uni_waiters: Arc<AcceptWaiters>,
+
+    // `Waker::from(waiters.clone())`, cached so the inner streams see the same waker
+    // every time — `ez` deduplicates by `will_wake`, so it parks exactly one.
+    bi_waker: Waker,
+    uni_waker: Waker,
 }
 
 impl SessionAccept {
@@ -521,6 +553,11 @@ impl SessionAccept {
             Some((conn.accept_bi().await, conn))
         }));
 
+        let bi_waiters = Arc::new(AcceptWaiters::default());
+        let uni_waiters = Arc::new(AcceptWaiters::default());
+        let bi_waker = Waker::from(bi_waiters.clone());
+        let uni_waker = Waker::from(uni_waiters.clone());
+
         Self {
             session_id,
 
@@ -533,18 +570,25 @@ impl SessionAccept {
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
 
-            bi_wakers: Vec::new(),
-            uni_wakers: Vec::new(),
+            bi_waiters,
+            uni_waiters,
+            bi_waker,
+            uni_waker,
         }
     }
 
     // This is poll-based because we accept and decode streams in parallel.
     // In async land I would use tokio::JoinSet, but that requires a runtime.
     // It's better to use FuturesUnordered instead because it's agnostic.
-    pub fn poll_accept_uni(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<RecvStream, SessionError>> {
+    pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
+        // Register before polling, not on the way out: the shared waker can fire from
+        // the `ez` driver at any point below, and a wake that lands before the caller
+        // is on the list would be lost.
+        self.uni_waiters.register(waiter);
+
+        let waker = self.uni_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next_unpin(cx) {
@@ -552,9 +596,7 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        for waker in self.uni_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -572,21 +614,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode unidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.uni_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv);
-                    for waker in self.uni_wakers.drain(..) {
-                        waker.wake();
-                    }
+                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -630,8 +665,14 @@ impl SessionAccept {
 
     pub fn poll_accept_bi(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        // Register before polling; see `poll_accept_uni`.
+        self.bi_waiters.register(waiter);
+
+        let waker = self.bi_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next_unpin(cx) {
@@ -639,9 +680,7 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        for waker in self.bi_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -659,21 +698,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode bidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.bi_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send);
                 let recv = RecvStream::new(recv);
-                for waker in self.bi_wakers.drain(..) {
-                    waker.wake();
-                }
+                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 
@@ -715,10 +747,14 @@ impl web_transport_trait::poll::Session for Connection {
     fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
         match self.accept.clone() {
             // `SessionAccept` decodes stream headers, so it keeps its own state and
-            // waker list; forward to it.
-            Some(accept) => accept.lock().unwrap().poll_accept_uni(cx),
+            // waiter list; forward to it, holding on to our registration.
+            Some(accept) => {
+                let waiter = self.parked_accept_uni.hold(cx);
+                accept.lock().unwrap().poll_accept_uni(waiter)
+            }
             None => {
-                let recv = ready!(self.conn.poll_accept_uni(cx.waker()))?;
+                let waiter = self.parked_accept_uni.hold(cx);
+                let recv = ready!(self.conn.poll_accept_uni(waiter))?;
                 Poll::Ready(Ok(RecvStream::new(recv)))
             }
         }
@@ -729,24 +765,32 @@ impl web_transport_trait::poll::Session for Connection {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
         match self.accept.clone() {
-            Some(accept) => accept.lock().unwrap().poll_accept_bi(cx),
+            Some(accept) => {
+                let waiter = self.parked_accept_bi.hold(cx);
+                accept.lock().unwrap().poll_accept_bi(waiter)
+            }
             None => {
-                let (send, recv) = ready!(self.conn.poll_accept_bi(cx.waker()))?;
+                let waiter = self.parked_accept_bi.hold(cx);
+                let (send, recv) = ready!(self.conn.poll_accept_bi(waiter))?;
                 Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))))
             }
         }
     }
 
     fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<SendStream, SessionError>> {
+        // One waiter for the whole operation: it can be registered with the connection
+        // now and the stream later, and both registrations die together.
+        let waiter = self.parked_open_uni.hold(cx);
+
         loop {
             match &mut self.open_uni {
                 OpenUni::Idle => {
-                    let send = ready!(self.conn.poll_open_uni(cx.waker()))?;
+                    let send = ready!(self.conn.poll_open_uni(waiter))?;
                     self.open_uni = OpenUni::Header { send, offset: 0 };
                 }
                 OpenUni::Header { send, offset } => {
                     while *offset < self.header_uni.len() {
-                        let size = ready!(send.poll_write(cx, &self.header_uni[*offset..]))
+                        let size = ready!(send.poll_write(waiter, &self.header_uni[*offset..]))
                             .map_err(SessionError::Header)?;
                         *offset += size;
                     }
@@ -768,10 +812,12 @@ impl web_transport_trait::poll::Session for Connection {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        let waiter = self.parked_open_bi.hold(cx);
+
         loop {
             match &mut self.open_bi {
                 OpenBi::Idle => {
-                    let (send, recv) = ready!(self.conn.poll_open_bi(cx.waker()))?;
+                    let (send, recv) = ready!(self.conn.poll_open_bi(waiter))?;
                     self.open_bi = OpenBi::Header {
                         send,
                         recv,
@@ -780,7 +826,7 @@ impl web_transport_trait::poll::Session for Connection {
                 }
                 OpenBi::Header { send, offset, .. } => {
                     while *offset < self.header_bi.len() {
-                        let size = ready!(send.poll_write(cx, &self.header_bi[*offset..]))
+                        let size = ready!(send.poll_write(waiter, &self.header_bi[*offset..]))
                             .map_err(SessionError::Header)?;
                         *offset += size;
                     }
@@ -813,7 +859,8 @@ impl web_transport_trait::poll::Session for Connection {
     }
 
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {
-        let datagram = ready!(self.conn.poll_read_datagram(cx.waker()))?;
+        let waiter = self.parked_recv_datagram.hold(cx);
+        let datagram = ready!(self.conn.poll_read_datagram(waiter))?;
         Poll::Ready(self.strip_datagram_header(datagram))
     }
 
@@ -830,7 +877,8 @@ impl web_transport_trait::poll::Session for Connection {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<SessionError> {
-        self.conn.poll_closed(cx.waker()).map(Into::into)
+        let waiter = self.parked_closed.hold(cx);
+        self.conn.poll_closed(waiter).map(Into::into)
     }
 
     #[allow(refining_impl_trait)]

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -529,7 +529,7 @@ fn poll_accept_uni_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
@@ -553,7 +553,7 @@ fn poll_accept_bi_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
@@ -592,8 +592,10 @@ pub struct SessionAccept {
     bi_waiters: Arc<AcceptWaiters>,
     uni_waiters: Arc<AcceptWaiters>,
 
-    // `Waker::from(waiters.clone())`, cached so the inner streams see the same waker
-    // every time — `ez` deduplicates by `will_wake`, so it parks exactly one.
+    // `Waker::from(waiters.clone())`, cached so `ez` is polled with the same waker every
+    // time. That waker outlives every caller, so an accepter that drops its future
+    // cannot take the wakeup path with it, and `ez` holds one registration rather than
+    // one per caller.
     bi_waker: Waker,
     uni_waker: Waker,
 }

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -748,15 +748,13 @@ impl web_transport_trait::poll::Session for Connection {
         match self.accept.clone() {
             // `SessionAccept` decodes stream headers, so it keeps its own state and
             // waiter list; forward to it, holding on to our registration.
-            Some(accept) => {
-                let waiter = self.parked_accept_uni.hold(cx);
-                accept.lock().unwrap().poll_accept_uni(waiter)
-            }
-            None => {
-                let waiter = self.parked_accept_uni.hold(cx);
+            Some(accept) => self
+                .parked_accept_uni
+                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_uni(waiter)),
+            None => self.parked_accept_uni.poll(cx, |waiter| {
                 let recv = ready!(self.conn.poll_accept_uni(waiter))?;
                 Poll::Ready(Ok(RecvStream::new(recv)))
-            }
+            }),
         }
     }
 
@@ -765,24 +763,20 @@ impl web_transport_trait::poll::Session for Connection {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
         match self.accept.clone() {
-            Some(accept) => {
-                let waiter = self.parked_accept_bi.hold(cx);
-                accept.lock().unwrap().poll_accept_bi(waiter)
-            }
-            None => {
-                let waiter = self.parked_accept_bi.hold(cx);
+            Some(accept) => self
+                .parked_accept_bi
+                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_bi(waiter)),
+            None => self.parked_accept_bi.poll(cx, |waiter| {
                 let (send, recv) = ready!(self.conn.poll_accept_bi(waiter))?;
                 Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))))
-            }
+            }),
         }
     }
 
     fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<SendStream, SessionError>> {
         // One waiter for the whole operation: it can be registered with the connection
         // now and the stream later, and both registrations die together.
-        let waiter = self.parked_open_uni.hold(cx);
-
-        loop {
+        self.parked_open_uni.poll(cx, |waiter| loop {
             match &mut self.open_uni {
                 OpenUni::Idle => {
                     let send = ready!(self.conn.poll_open_uni(waiter))?;
@@ -805,16 +799,14 @@ impl web_transport_trait::poll::Session for Connection {
                     return Poll::Ready(Ok(SendStream::new(send)));
                 }
             }
-        }
+        })
     }
 
     fn poll_open_bi(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
-        let waiter = self.parked_open_bi.hold(cx);
-
-        loop {
+        self.parked_open_bi.poll(cx, |waiter| loop {
             match &mut self.open_bi {
                 OpenBi::Idle => {
                     let (send, recv) = ready!(self.conn.poll_open_bi(waiter))?;
@@ -840,7 +832,7 @@ impl web_transport_trait::poll::Session for Connection {
                     return Poll::Ready(Ok((SendStream::new(send), RecvStream::new(recv))));
                 }
             }
-        }
+        })
     }
 
     fn poll_send_datagram(
@@ -859,8 +851,10 @@ impl web_transport_trait::poll::Session for Connection {
     }
 
     fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, SessionError>> {
-        let waiter = self.parked_recv_datagram.hold(cx);
-        let datagram = ready!(self.conn.poll_read_datagram(waiter))?;
+        let datagram = ready!(self
+            .parked_recv_datagram
+            .poll(cx, |waiter| self.conn.poll_read_datagram(waiter)))?;
+
         Poll::Ready(self.strip_datagram_header(datagram))
     }
 
@@ -877,8 +871,9 @@ impl web_transport_trait::poll::Session for Connection {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<SessionError> {
-        let waiter = self.parked_closed.hold(cx);
-        self.conn.poll_closed(waiter).map(Into::into)
+        self.parked_closed
+            .poll(cx, |waiter| self.conn.poll_closed(waiter))
+            .map(Into::into)
     }
 
     #[allow(refining_impl_trait)]

--- a/rs/web-transport-quiche/src/connection.rs
+++ b/rs/web-transport-quiche/src/connection.rs
@@ -621,9 +621,20 @@ impl SessionAccept {
         }
     }
 
-    // This is poll-based because we accept and decode streams in parallel.
-    // In async land I would use tokio::JoinSet, but that requires a runtime.
-    // It's better to use FuturesUnordered instead because it's agnostic.
+    /// Poll for the next unidirectional WebTransport stream.
+    ///
+    /// `waiter` is parked until a stream arrives, the accept fails, or the caller drops
+    /// it. The registration is weak and owned by the caller: keep the [`Waiter`] alive
+    /// until it is woken, or it will be reclaimed and nothing will wake you. Drive this
+    /// with [`kio::wait`], which holds the waiter inside the future it builds.
+    ///
+    /// A `Ready` here means every *other* parked accepter should be woken so it can
+    /// retry. This does not do that itself — see `poll_accept_uni_shared`, which wakes
+    /// them once the lock on this struct is released.
+    //
+    // Poll-based because we accept and decode streams in parallel. In async land this
+    // would be a `tokio::JoinSet`, but that needs a runtime; `FuturesUnordered` is
+    // runtime-agnostic.
     pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
         // Register before polling, not on the way out: the shared waker can fire from
         // the `ez` driver at any point below, and a wake that lands before the caller
@@ -705,6 +716,11 @@ impl SessionAccept {
         Ok((typ, recv))
     }
 
+    /// Poll for the next bidirectional WebTransport stream.
+    ///
+    /// The same contract as [`poll_accept_uni`](Self::poll_accept_uni): the `waiter`
+    /// registration is weak and owned by the caller, and a `Ready` is what the other
+    /// parked accepters need to be woken for.
     pub fn poll_accept_bi(
         &mut self,
         waiter: &Waiter,

--- a/rs/web-transport-quiche/src/ez/client.rs
+++ b/rs/web-transport-quiche/src/ez/client.rs
@@ -272,9 +272,7 @@ impl Connecting {
     /// Returns the connection once the handshake is complete, or an error if the connection
     /// is closed before the handshake finishes.
     pub async fn established(self) -> Result<Connection, ConnectionError> {
-        use std::future::poll_fn;
-
-        poll_fn(|cx| self.driver.lock().poll_handshake(cx.waker())).await?;
+        kio::wait(|waiter| self.driver.lock().poll_handshake(waiter)).await?;
 
         Ok(self.connection)
     }

--- a/rs/web-transport-quiche/src/ez/connection.rs
+++ b/rs/web-transport-quiche/src/ez/connection.rs
@@ -1,15 +1,15 @@
 use bytes::Bytes;
+use kio::{Waiter, WaiterList};
 use rustls_pki_types::CertificateDer;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{
-    future::poll_fn,
     ops::Deref,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Mutex,
     },
-    task::{ready, Poll, Waker},
+    task::{ready, Poll},
 };
 use thiserror::Error;
 use tokio_quiche::quiche;
@@ -87,7 +87,13 @@ pub enum ConnectionError {
 #[derive(Default)]
 struct ConnectionClosedState {
     err: Option<ConnectionError>,
-    wakers: Vec<Waker>,
+
+    /// Everyone waiting to hear that the connection went away.
+    ///
+    /// Every blocked read, write, accept and handshake parks here, so this is the list
+    /// that most needs weak registrations: a caller that gives up releases its slot
+    /// instead of leaving a waker parked for the life of the connection.
+    waiters: WaiterList,
 }
 
 #[derive(Clone, Default)]
@@ -96,24 +102,25 @@ pub(super) struct ConnectionClosed {
 }
 
 impl ConnectionClosed {
-    pub fn abort(&self, err: ConnectionError) -> Vec<Waker> {
+    #[must_use = "wake the waiters"]
+    pub fn abort(&self, err: ConnectionError) -> WaiterList {
         let mut state = self.state.lock().unwrap();
         if state.err.is_some() {
-            return Vec::new();
+            return WaiterList::new();
         }
 
         state.err = Some(err);
-        std::mem::take(&mut state.wakers)
+        state.waiters.take()
     }
 
     // Blocks until the connection is closed and drained.
-    pub fn poll(&self, waker: &Waker) -> Poll<ConnectionError> {
+    pub fn poll(&self, waiter: &Waiter) -> Poll<ConnectionError> {
         let mut state = self.state.lock().unwrap();
         if state.err.is_some() {
             return Poll::Ready(state.err.clone().unwrap());
         }
 
-        state.wakers.push(waker.clone());
+        waiter.register(&mut state.waiters);
 
         Poll::Pending
     }
@@ -134,22 +141,20 @@ impl ConnectionClose {
     }
 
     pub fn close(&self, err: ConnectionError) {
-        let wakers = self.driver.lock().close(err);
-
-        for waker in wakers {
-            waker.wake();
-        }
+        // Wake outside the lock, as everywhere else in this module.
+        let mut waiters = self.driver.lock().close(err);
+        waiters.wake();
     }
 
     /// Only the test below still needs this: accept and datagram reads used to race
     /// it in a `select!`, and now poll the driver's own error state directly.
     #[cfg(test)]
     pub async fn error(&self) -> ConnectionError {
-        poll_fn(|cx| self.driver.lock().error(cx.waker())).await
+        kio::wait(|waiter| self.driver.lock().error(waiter)).await
     }
 
     pub async fn wait(&self) -> ConnectionError {
-        poll_fn(|cx| self.driver.lock().closed(cx.waker())).await
+        kio::wait(|waiter| self.driver.lock().closed(waiter)).await
     }
 
     pub fn is_closed(&self) -> bool {
@@ -214,15 +219,15 @@ impl Connection {
 
     /// Accept a bidirectional stream created by the remote peer.
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), ConnectionError> {
-        poll_fn(|cx| self.poll_accept_bi(cx.waker())).await
+        kio::wait(|waiter| self.poll_accept_bi(waiter)).await
     }
 
     /// Poll for a bidirectional stream created by the remote peer.
     pub fn poll_accept_bi(
         &self,
-        waker: &Waker,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), ConnectionError>> {
-        let (id, send, recv) = ready!(self.driver.lock().poll_accept_bi(waker))?;
+        let (id, send, recv) = ready!(self.driver.lock().poll_accept_bi(waiter))?;
 
         Poll::Ready(Ok((
             SendStream::new(id, send, self.driver.clone()),
@@ -232,12 +237,12 @@ impl Connection {
 
     /// Accept a unidirectional stream created by the remote peer.
     pub async fn accept_uni(&self) -> Result<RecvStream, ConnectionError> {
-        poll_fn(|cx| self.poll_accept_uni(cx.waker())).await
+        kio::wait(|waiter| self.poll_accept_uni(waiter)).await
     }
 
     /// Poll for a unidirectional stream created by the remote peer.
-    pub fn poll_accept_uni(&self, waker: &Waker) -> Poll<Result<RecvStream, ConnectionError>> {
-        let (id, recv) = ready!(self.driver.lock().poll_accept_uni(waker))?;
+    pub fn poll_accept_uni(&self, waiter: &Waiter) -> Poll<Result<RecvStream, ConnectionError>> {
+        let (id, recv) = ready!(self.driver.lock().poll_accept_uni(waiter))?;
         Poll::Ready(Ok(RecvStream::new(id, recv, self.driver.clone())))
     }
 
@@ -245,7 +250,8 @@ impl Connection {
     ///
     /// May block while there are too many concurrent streams.
     pub async fn open_bi(&self) -> Result<(SendStream, RecvStream), ConnectionError> {
-        let (wakeup, id, send, recv) = poll_fn(|cx| self.driver.lock().open_bi(cx.waker())).await?;
+        let (wakeup, id, send, recv) =
+            kio::wait(|waiter| self.driver.lock().open_bi(waiter)).await?;
         if let Some(wakeup) = wakeup {
             wakeup.wake();
         }
@@ -260,7 +266,7 @@ impl Connection {
     ///
     /// May block while there are too many concurrent streams.
     pub async fn open_uni(&self) -> Result<SendStream, ConnectionError> {
-        let (wakeup, id, send) = poll_fn(|cx| self.driver.lock().open_uni(cx.waker())).await?;
+        let (wakeup, id, send) = kio::wait(|waiter| self.driver.lock().open_uni(waiter)).await?;
         if let Some(wakeup) = wakeup {
             wakeup.wake();
         }
@@ -270,8 +276,8 @@ impl Connection {
     }
 
     /// Poll to open a new unidirectional stream.
-    pub fn poll_open_uni(&self, waker: &Waker) -> Poll<Result<SendStream, ConnectionError>> {
-        let (wakeup, id, send) = ready!(self.driver.lock().open_uni(waker))?;
+    pub fn poll_open_uni(&self, waiter: &Waiter) -> Poll<Result<SendStream, ConnectionError>> {
+        let (wakeup, id, send) = ready!(self.driver.lock().open_uni(waiter))?;
         if let Some(wakeup) = wakeup {
             wakeup.wake();
         }
@@ -282,9 +288,9 @@ impl Connection {
     /// Poll to open a new bidirectional stream.
     pub fn poll_open_bi(
         &self,
-        waker: &Waker,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), ConnectionError>> {
-        let (wakeup, id, send, recv) = ready!(self.driver.lock().open_bi(waker))?;
+        let (wakeup, id, send, recv) = ready!(self.driver.lock().open_bi(waiter))?;
         if let Some(wakeup) = wakeup {
             wakeup.wake();
         }
@@ -296,20 +302,20 @@ impl Connection {
     }
 
     /// Poll until the connection is closed and drained.
-    pub fn poll_closed(&self, waker: &Waker) -> Poll<ConnectionError> {
-        self.driver.lock().closed(waker)
+    pub fn poll_closed(&self, waiter: &Waiter) -> Poll<ConnectionError> {
+        self.driver.lock().closed(waiter)
     }
 
     /// Receive the next application datagram from the remote peer.
     ///
     /// Waits until a datagram arrives or the connection is closed.
     pub async fn read_datagram(&self) -> Result<Bytes, ConnectionError> {
-        poll_fn(|cx| self.poll_read_datagram(cx.waker())).await
+        kio::wait(|waiter| self.poll_read_datagram(waiter)).await
     }
 
     /// Poll for the next application datagram from the remote peer.
-    pub fn poll_read_datagram(&self, waker: &Waker) -> Poll<Result<Bytes, ConnectionError>> {
-        self.driver.lock().poll_dgram_in(waker)
+    pub fn poll_read_datagram(&self, waiter: &Waiter) -> Poll<Result<Bytes, ConnectionError>> {
+        self.driver.lock().poll_dgram_in(waiter)
     }
 
     /// Queue an application datagram for the driver to send.

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -2,7 +2,6 @@ use bytes::Bytes;
 use rustls_pki_types::CertificateDer;
 use std::{
     collections::{hash_map, HashMap, HashSet, VecDeque},
-    future::poll_fn,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -10,6 +9,8 @@ use std::{
     task::{Context, Poll, Waker},
     time::Duration,
 };
+
+use kio::{Waiter, WaiterList};
 use tokio_quiche::{
     buf_factory::BufFactory,
     quic::{HandshakeInfo, QuicheConnection},
@@ -27,13 +28,6 @@ const DROP_CODE: u64 = 0x64726F70;
 
 /// How many datagrams to hold for the application before dropping the oldest.
 const DGRAM_QUEUE_CAPACITY: usize = 32;
-
-/// Register `waker` unless an equivalent one is already parked.
-fn park(wakers: &mut Vec<Waker>, waker: &Waker) {
-    if !wakers.iter().any(|w| w.will_wake(waker)) {
-        wakers.push(waker.clone());
-    }
-}
 
 type AcceptBiResult = Poll<Result<(StreamId, Lock<SendState>, Lock<RecvState>), ConnectionError>>;
 
@@ -70,8 +64,8 @@ pub(super) struct DriverState {
     /// The peer's certificate chain, set after the handshake completes.
     peer_certs: Option<Vec<CertificateDer<'static>>>,
 
-    /// Wakers waiting for the handshake to complete.
-    handshake_wakers: Vec<Waker>,
+    /// Whoever is waiting for the handshake to complete.
+    handshake_waiters: WaiterList,
 
     /// Latest connection statistics, refreshed by the driver each poll.
     stats: ConnectionStats,
@@ -85,17 +79,19 @@ pub(super) struct DriverState {
     ///
     /// A channel would be the obvious home, but its receive future owns the waker
     /// registration and drops it with the future — so an abandoned poll would never
-    /// be woken again. Parking the waker here is what makes `poll_accept_*` honest.
+    /// be woken again. Parking here is what makes `poll_accept_*` honest, and the
+    /// registrations are weak so an abandoned poll releases its slot rather than
+    /// leaving a waker parked until the connection closes.
     accept_bi: VecDeque<(StreamId, Lock<SendState>, Lock<RecvState>)>,
     accept_uni: VecDeque<(StreamId, Lock<RecvState>)>,
-    accept_bi_wakers: Vec<Waker>,
-    accept_uni_wakers: Vec<Waker>,
+    accept_bi_waiters: WaiterList,
+    accept_uni_waiters: WaiterList,
 
     /// Datagrams received from the peer. Bounded: when the application cannot keep
     /// up the *oldest* is dropped, which is the unreliable-datagram contract and
     /// keeps the freshest data, unlike a channel that rejects the newest.
     dgram_in: VecDeque<Bytes>,
-    dgram_in_wakers: Vec<Waker>,
+    dgram_in_waiters: WaiterList,
 }
 
 impl DriverState {
@@ -121,13 +117,13 @@ impl DriverState {
             alpn: None,
             server_name: None,
             peer_certs: None,
-            handshake_wakers: Vec::new(),
+            handshake_waiters: WaiterList::new(),
             accept_bi: VecDeque::new(),
             accept_uni: VecDeque::new(),
-            accept_bi_wakers: Vec::new(),
-            accept_uni_wakers: Vec::new(),
+            accept_bi_waiters: WaiterList::new(),
+            accept_uni_waiters: WaiterList::new(),
             dgram_in: VecDeque::new(),
-            dgram_in_wakers: Vec::new(),
+            dgram_in_waiters: WaiterList::new(),
             stats: ConnectionStats::default(),
         }
     }
@@ -137,28 +133,30 @@ impl DriverState {
         self.stats
     }
 
-    pub fn close(&mut self, err: ConnectionError) -> Vec<Waker> {
+    #[must_use = "wake the waiters"]
+    pub fn close(&mut self, err: ConnectionError) -> WaiterList {
         self.close_requested.abort(err)
     }
 
-    pub fn closed(&self, waker: &Waker) -> Poll<ConnectionError> {
-        self.closed.poll(waker)
+    pub fn closed(&self, waiter: &Waiter) -> Poll<ConnectionError> {
+        self.closed.poll(waiter)
     }
 
-    fn finish_close(&self, err: ConnectionError) -> Vec<Waker> {
+    #[must_use = "wake the waiters"]
+    fn finish_close(&self, err: ConnectionError) -> WaiterList {
         self.closed.abort(err)
     }
 
-    fn close_requested(&self, waker: &Waker) -> Poll<ConnectionError> {
-        self.close_requested.poll(waker)
+    fn close_requested(&self, waiter: &Waiter) -> Poll<ConnectionError> {
+        self.close_requested.poll(waiter)
     }
 
-    pub fn error(&self, waker: &Waker) -> Poll<ConnectionError> {
-        if let Poll::Ready(err) = self.close_requested.poll(waker) {
+    pub fn error(&self, waiter: &Waiter) -> Poll<ConnectionError> {
+        if let Poll::Ready(err) = self.close_requested.poll(waiter) {
             return Poll::Ready(err);
         }
 
-        self.closed.poll(waker)
+        self.closed.poll(waiter)
     }
 
     pub fn is_closed(&self) -> bool {
@@ -182,27 +180,27 @@ impl DriverState {
 
     /// Poll for handshake completion.
     /// Returns Ready once the handshake completes, or if the connection is closed.
-    pub fn poll_handshake(&mut self, waker: &Waker) -> Poll<Result<(), ConnectionError>> {
+    pub fn poll_handshake(&mut self, waiter: &Waiter) -> Poll<Result<(), ConnectionError>> {
         // Check if already established
         if self.established {
             return Poll::Ready(Ok(()));
         }
 
         // Check if connection is closed
-        if let Poll::Ready(err) = self.error(waker) {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
         // Wait for handshake
-        self.handshake_wakers.push(waker.clone());
+        waiter.register(&mut self.handshake_waiters);
         Poll::Pending
     }
 
-    /// Notify all wakers waiting for handshake completion.
-    /// Should be called when the handshake completes.
-    #[must_use = "wake the handshake wakers"]
-    pub fn complete_handshake(&mut self) -> Vec<Waker> {
-        std::mem::take(&mut self.handshake_wakers)
+    /// Take everyone waiting for handshake completion, to be woken once the caller has
+    /// released the lock. Should be called when the handshake completes.
+    #[must_use = "wake the handshake waiters"]
+    pub fn complete_handshake(&mut self) -> WaiterList {
+        self.handshake_waiters.take()
     }
 
     /// Take the driver's waker, if any. The caller is responsible for waking it.
@@ -232,13 +230,13 @@ impl DriverState {
     }
 
     // Try to create the next bidirectional stream, although it may not be possible yet.
-    pub fn open_bi(&mut self, waker: &Waker) -> OpenBiResult {
-        if let Poll::Ready(err) = self.error(waker) {
+    pub fn open_bi(&mut self, waiter: &Waiter) -> OpenBiResult {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
         if self.bi.capacity == 0 {
-            self.bi.wakers.push(waker.clone());
+            waiter.register(&mut self.bi.waiters);
             return Poll::Pending;
         }
         self.bi.capacity -= 1;
@@ -258,46 +256,48 @@ impl DriverState {
     ///
     /// The caller wakes them after releasing the lock, matching the rest of this
     /// type.
+    #[must_use = "wake the waiters"]
     pub fn push_accept_bi(
         &mut self,
         id: StreamId,
         send: Lock<SendState>,
         recv: Lock<RecvState>,
-    ) -> Vec<Waker> {
+    ) -> WaiterList {
         self.accept_bi.push_back((id, send, recv));
-        std::mem::take(&mut self.accept_bi_wakers)
+        self.accept_bi_waiters.take()
     }
 
-    pub fn push_accept_uni(&mut self, id: StreamId, recv: Lock<RecvState>) -> Vec<Waker> {
+    #[must_use = "wake the waiters"]
+    pub fn push_accept_uni(&mut self, id: StreamId, recv: Lock<RecvState>) -> WaiterList {
         self.accept_uni.push_back((id, recv));
-        std::mem::take(&mut self.accept_uni_wakers)
+        self.accept_uni_waiters.take()
     }
 
-    pub fn poll_accept_bi(&mut self, waker: &Waker) -> AcceptBiResult {
+    pub fn poll_accept_bi(&mut self, waiter: &Waiter) -> AcceptBiResult {
         // Drain what already arrived before reporting a close: streams the peer
         // opened are finite and the application is entitled to them.
         if let Some(parts) = self.accept_bi.pop_front() {
             return Poll::Ready(Ok(parts));
         }
 
-        if let Poll::Ready(err) = self.error(waker) {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
-        park(&mut self.accept_bi_wakers, waker);
+        waiter.register(&mut self.accept_bi_waiters);
         Poll::Pending
     }
 
-    pub fn poll_accept_uni(&mut self, waker: &Waker) -> AcceptUniResult {
+    pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> AcceptUniResult {
         if let Some(parts) = self.accept_uni.pop_front() {
             return Poll::Ready(Ok(parts));
         }
 
-        if let Poll::Ready(err) = self.error(waker) {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
-        park(&mut self.accept_uni_wakers, waker);
+        waiter.register(&mut self.accept_uni_waiters);
         Poll::Pending
     }
 
@@ -305,36 +305,37 @@ impl DriverState {
     ///
     /// Drops the oldest when full rather than the new arrival: for unreliable
     /// datagrams the freshest data is the useful data.
-    pub fn push_dgram_in(&mut self, datagram: Bytes) -> Vec<Waker> {
+    #[must_use = "wake the waiters"]
+    pub fn push_dgram_in(&mut self, datagram: Bytes) -> WaiterList {
         while self.dgram_in.len() >= DGRAM_QUEUE_CAPACITY {
             tracing::trace!("dropping oldest incoming datagram: queue full");
             self.dgram_in.pop_front();
         }
 
         self.dgram_in.push_back(datagram);
-        std::mem::take(&mut self.dgram_in_wakers)
+        self.dgram_in_waiters.take()
     }
 
-    pub fn poll_dgram_in(&mut self, waker: &Waker) -> Poll<Result<Bytes, ConnectionError>> {
+    pub fn poll_dgram_in(&mut self, waiter: &Waiter) -> Poll<Result<Bytes, ConnectionError>> {
         if let Some(datagram) = self.dgram_in.pop_front() {
             return Poll::Ready(Ok(datagram));
         }
 
-        if let Poll::Ready(err) = self.error(waker) {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
-        park(&mut self.dgram_in_wakers, waker);
+        waiter.register(&mut self.dgram_in_waiters);
         Poll::Pending
     }
 
-    pub fn open_uni(&mut self, waker: &Waker) -> OpenUniResult {
-        if let Poll::Ready(err) = self.error(waker) {
+    pub fn open_uni(&mut self, waiter: &Waiter) -> OpenUniResult {
+        if let Poll::Ready(err) = self.error(waiter) {
             return Poll::Ready(Err(err));
         }
 
         if self.uni.capacity == 0 {
-            self.uni.wakers.push(waker.clone());
+            waiter.register(&mut self.uni.waiters);
             return Poll::Pending;
         }
 
@@ -453,7 +454,7 @@ impl Driver {
             Ordering::Relaxed,
         );
 
-        let wakers = {
+        let mut waiters = {
             let mut state = self.state.lock();
             state.alpn = (!alpn.is_empty()).then(|| alpn.to_vec());
             state.server_name = server_name;
@@ -465,12 +466,10 @@ impl Driver {
         };
 
         // Wake all tasks waiting for handshake completion.
-        for waker in wakers {
-            waker.wake();
-        }
+        waiters.wake();
 
         // Run poll once to advance any pending operations.
-        match self.poll(Waker::noop(), qconn) {
+        match self.poll(&Waiter::noop(), qconn) {
             Poll::Ready(Err(e)) => Err(e),
             _ => Ok(()),
         }
@@ -533,14 +532,12 @@ impl Driver {
         let state = Lock::new(state);
         self.send.insert(stream_id, state.clone());
 
-        let wakers = self
+        let mut waiters = self
             .state
             .lock()
             .push_accept_bi(stream_id, state.clone(), recv_state);
 
-        for waker in wakers {
-            waker.wake();
-        }
+        waiters.wake();
 
         Ok(())
     }
@@ -558,11 +555,9 @@ impl Driver {
         let state = Lock::new(state);
         self.recv.insert(stream_id, state.clone());
 
-        let wakers = self.state.lock().push_accept_uni(stream_id, state);
+        let mut waiters = self.state.lock().push_accept_uni(stream_id, state);
 
-        for waker in wakers {
-            waker.wake();
-        }
+        waiters.wake();
 
         Ok(())
     }
@@ -598,17 +593,17 @@ impl Driver {
     }
 
     async fn wait(&mut self, qconn: &mut QuicheConnection) -> Result<(), ConnectionError> {
-        poll_fn(|cx| self.poll(cx.waker(), qconn)).await
+        kio::wait(|waiter| self.poll(waiter, qconn)).await
     }
 
     fn poll(
         &mut self,
-        waker: &Waker,
+        waiter: &Waiter,
         qconn: &mut QuicheConnection,
     ) -> Poll<Result<(), ConnectionError>> {
         if !qconn.is_draining() {
             // Check if the application wants to close the connection.
-            if let Poll::Ready(err) = self.state.lock().close_requested(waker) {
+            if let Poll::Ready(err) = self.state.lock().close_requested(waiter) {
                 // Close the connection and return the error.
                 return Poll::Ready(
                     match err {
@@ -641,7 +636,7 @@ impl Driver {
         // ack-eliciting, so a tick on a busy connection costs nothing.
         let mut keep_alive = false;
         if let Some(k) = self.keep_alive.as_mut() {
-            if k.poll(&mut Context::from_waker(waker)) {
+            if k.poll(&mut Context::from_waker(waiter.waker())) {
                 qconn.send_ack_eliciting()?;
                 keep_alive = true;
             }
@@ -650,7 +645,7 @@ impl Driver {
         // Snapshot stats while we hold an immutable view; stored under the lock below.
         let stats = ConnectionStats::from_quiche(qconn);
 
-        let (sleep, send, recv, bi_wakers, uni_wakers) = {
+        let (sleep, send, recv, bi_waiters, uni_waiters) = {
             let mut driver = self.state.lock();
             driver.stats = stats;
             // Park the waker before checking for work. `send_datagram` pushes
@@ -658,7 +653,10 @@ impl Driver {
             // queue after we publish the waker means any racing producer is
             // guaranteed to either (a) see our waker and wake us, or (b) have
             // already enqueued an item we will see here.
-            driver.waker = Some(waker.clone());
+            //
+            // A plain `Waker`, not a registration: this slot has one owner, the driver
+            // task, and whoever takes it wakes it exactly once.
+            driver.waker = Some(waiter.waker().clone());
 
             let dgram_work = !self.dgram_out.is_empty();
 
@@ -681,26 +679,21 @@ impl Driver {
 
             // If we have spare capacity, wake up any blocked wakers.
             driver.bi.capacity = qconn.peer_streams_left_bidi();
-            let bi_wakers = (driver.bi.capacity > 0).then(|| std::mem::take(&mut driver.bi.wakers));
+            let bi_waiters = (driver.bi.capacity > 0).then(|| driver.bi.waiters.take());
 
             // If we have spare capacity, wake up any blocked wakers.
             driver.uni.capacity = qconn.peer_streams_left_uni();
-            let uni_wakers =
-                (driver.uni.capacity > 0).then(|| std::mem::take(&mut driver.uni.wakers));
+            let uni_waiters = (driver.uni.capacity > 0).then(|| driver.uni.waiters.take());
 
             let send = std::mem::take(&mut driver.send);
             let recv = std::mem::take(&mut driver.recv);
 
-            (sleep, send, recv, bi_wakers, uni_wakers)
+            (sleep, send, recv, bi_waiters, uni_waiters)
         };
 
-        for waker in bi_wakers.unwrap_or_default() {
-            waker.wake();
-        }
+        bi_waiters.unwrap_or_default().wake();
 
-        for waker in uni_wakers.unwrap_or_default() {
-            waker.wake();
-        }
+        uni_waiters.unwrap_or_default().wake();
 
         for stream_id in recv {
             self.flush_recv(qconn, stream_id)?;
@@ -774,10 +767,8 @@ impl Driver {
     }
 
     fn abort(&mut self, err: ConnectionError) {
-        let wakers = self.state.lock().close_requested.abort(err);
-        for waker in wakers {
-            waker.wake();
-        }
+        let mut waiters = self.state.lock().close_requested.abort(err);
+        waiters.wake();
     }
 }
 
@@ -827,11 +818,9 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
             match qconn.dgram_recv(&mut self.buf) {
                 Ok(len) => {
                     let buf = Bytes::copy_from_slice(&self.buf[..len]);
-                    let wakers = self.state.lock().push_dgram_in(buf);
+                    let mut waiters = self.state.lock().push_dgram_in(buf);
 
-                    for waker in wakers {
-                        waker.wake();
-                    }
+                    waiters.wake();
                 }
                 Err(quiche::Error::Done) => break,
                 Err(err) => {
@@ -873,7 +862,7 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
     ) {
         let state = self.state.lock();
 
-        let err = if let Poll::Ready(err) = state.close_requested.poll(Waker::noop()) {
+        let err = if let Poll::Ready(err) = state.close_requested.poll(&Waiter::noop()) {
             err
         } else if let Some(local) = qconn.local_error() {
             let reason = String::from_utf8_lossy(&local.reason).to_string();
@@ -890,16 +879,12 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
         // Mark the connection closed only after the driver is done. In particular,
         // a local close request must not make Connection::closed resolve before
         // quiche has had an opportunity to emit CONNECTION_CLOSE.
-        let wakers = state.finish_close(err.clone());
-        for waker in wakers {
-            waker.wake();
-        }
+        let mut waiters = state.finish_close(err.clone());
+        waiters.wake();
 
-        // Also wake up any local wakers if the peer closed.
-        let wakers = state.close_requested.abort(err);
-        for waker in wakers {
-            waker.wake();
-        }
+        // Also wake up anyone waiting locally if the peer closed.
+        let mut waiters = state.close_requested.abort(err);
+        waiters.wake();
     }
 }
 
@@ -907,7 +892,7 @@ struct DriverOpen<T> {
     next: StreamId,
     capacity: u64,
     create: Vec<(StreamId, T)>,
-    wakers: Vec<Waker>,
+    waiters: WaiterList,
 }
 
 impl<T> DriverOpen<T> {
@@ -916,7 +901,7 @@ impl<T> DriverOpen<T> {
             next,
             capacity: 0,
             create: Vec::new(),
-            wakers: Vec::new(),
+            waiters: WaiterList::new(),
         }
     }
 }
@@ -931,32 +916,32 @@ mod tests {
         // connection that negotiates no ALPN must still hand back a Connection
         // rather than wait forever.
         let mut state = DriverState::new(false);
-        let waker = Waker::noop();
+        let waiter = Waiter::noop();
 
-        assert!(state.poll_handshake(waker).is_pending());
+        assert!(state.poll_handshake(&waiter).is_pending());
 
         state.established = true;
         let _ = state.complete_handshake();
 
         assert!(state.alpn().is_none());
-        assert!(matches!(state.poll_handshake(waker), Poll::Ready(Ok(()))));
+        assert!(matches!(state.poll_handshake(&waiter), Poll::Ready(Ok(()))));
     }
 
     #[test]
     fn closed_waits_for_driver_completion() {
         let mut state = DriverState::new(false);
-        let waker = Waker::noop();
+        let waiter = Waiter::noop();
         let err = ConnectionError::Local(42, "done".to_string());
 
-        assert!(state.closed(waker).is_pending());
+        assert!(state.closed(&waiter).is_pending());
 
-        state.close(err.clone());
+        let _ = state.close(err.clone());
 
-        assert!(state.close_requested(waker).is_ready());
-        assert!(state.closed(waker).is_pending());
+        assert!(state.close_requested(&waiter).is_ready());
+        assert!(state.closed(&waiter).is_pending());
 
-        state.finish_close(err);
+        let _ = state.finish_close(err);
 
-        assert!(state.closed(waker).is_ready());
+        assert!(state.closed(&waiter).is_ready());
     }
 }

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -879,12 +879,19 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
         // Mark the connection closed only after the driver is done. In particular,
         // a local close request must not make Connection::closed resolve before
         // quiche has had an opportunity to emit CONNECTION_CLOSE.
-        let mut waiters = state.finish_close(err.clone());
-        waiters.wake();
+        let mut closed = state.finish_close(err.clone());
 
         // Also wake up anyone waiting locally if the peer closed.
-        let mut waiters = state.close_requested.abort(err);
-        waiters.wake();
+        let mut requested = state.close_requested.abort(err);
+
+        // Both lists are woken *after* the guard goes, unlike everywhere else in this
+        // file where the guard is a temporary that drops with the statement. A resumed
+        // task's first move is to take this same lock, and this is the teardown path:
+        // deadlocking here would strand the close and everything waiting on it.
+        drop(state);
+
+        closed.wake();
+        requested.wake();
     }
 }
 

--- a/rs/web-transport-quiche/src/ez/mod.rs
+++ b/rs/web-transport-quiche/src/ez/mod.rs
@@ -3,6 +3,14 @@
 //! This module provides a simplified interface for working with raw QUIC connections
 //! using the quiche implementation. It handles the low-level details of connection
 //! management, stream creation, and I/O operations.
+//!
+//! Every operation is available both as an `async` method and as a `poll_*` method. The
+//! latter take a [`kio::Waiter`] rather than a [`Waker`](std::task::Waker), because a
+//! connection parks many callers on the same state and has no way to deregister them: a
+//! waiter's registrations are weak and die with it, so a caller that gives up — a
+//! `timeout` that expires, a dropped future — releases its slot. Drive one with
+//! [`kio::wait`], or hold a waiter across polls yourself when implementing a
+//! `Context`-based `poll_*` on top.
 
 mod client;
 mod connection;

--- a/rs/web-transport-quiche/src/ez/recv.rs
+++ b/rs/web-transport-quiche/src/ez/recv.rs
@@ -405,7 +405,7 @@ impl AsyncRead for RecvStream {
     ) -> Poll<Result<(), io::Error>> {
         let waiter = Waiter::new(cx.waker().clone());
         let res = self.poll_read_chunk(&waiter, buf.remaining());
-        self.parked.park(waiter);
+        self.parked.park(waiter, &res);
 
         match ready!(res) {
             Ok(Some(chunk)) => buf.put_slice(&chunk),

--- a/rs/web-transport-quiche/src/ez/recv.rs
+++ b/rs/web-transport-quiche/src/ez/recv.rs
@@ -1,7 +1,7 @@
 use futures::ready;
+use kio::Waiter;
 use std::{
     collections::VecDeque,
-    future::poll_fn,
     io,
     pin::Pin,
     task::{Context, Poll, Waker},
@@ -11,7 +11,7 @@ use tokio_quiche::quiche;
 use bytes::{BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, ReadBuf};
 
-use crate::ez::DriverState;
+use crate::{ez::DriverState, waiters::Parked};
 
 use super::{Lock, StreamError, StreamId};
 
@@ -69,7 +69,7 @@ impl RecvState {
 
     pub fn poll_read_chunk(
         &mut self,
-        waker: &Waker,
+        waiter: &Waiter,
         max: usize,
     ) -> Poll<Result<Option<Bytes>, StreamError>> {
         if let Some(reset) = self.reset {
@@ -98,12 +98,14 @@ impl RecvState {
         }
 
         self.max = max;
-        self.blocked = Some(waker.clone());
+        // A stream has a single reader, so one slot is enough here — unlike the
+        // connection-wide lists, which every stream and accepter parks on.
+        self.blocked = Some(waiter.waker().clone());
 
         Poll::Pending
     }
 
-    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+    pub fn poll_closed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
         if self.fin && self.queued.is_empty() {
             Poll::Ready(Ok(()))
         } else if let Some(reset) = self.reset {
@@ -111,7 +113,7 @@ impl RecvState {
         } else if let Some(stop) = self.stop {
             Poll::Ready(Err(StreamError::Stop(stop)))
         } else {
-            self.blocked = Some(waker.clone());
+            self.blocked = Some(waiter.waker().clone());
             Poll::Pending
         }
     }
@@ -222,11 +224,19 @@ pub struct RecvStream {
     id: StreamId,
     state: Lock<RecvState>,
     driver: Lock<DriverState>,
+
+    // For the `AsyncRead` impl, which is handed a `Context` rather than a waiter.
+    parked: Parked,
 }
 
 impl RecvStream {
     pub(super) fn new(id: StreamId, state: Lock<RecvState>, driver: Lock<DriverState>) -> Self {
-        Self { id, state, driver }
+        Self {
+            id,
+            state,
+            driver,
+            parked: Parked::default(),
+        }
     }
 
     /// Returns the QUIC stream ID.
@@ -248,7 +258,7 @@ impl RecvStream {
     ///
     /// Returns [None] if the stream has been finished by the remote.
     pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, StreamError> {
-        poll_fn(|cx| self.poll_read_chunk(cx.waker(), max)).await
+        kio::wait(|waiter| self.poll_read_chunk(waiter, max)).await
     }
 
     /// Poll to read some data into the buffer, returning the amount read.
@@ -256,10 +266,10 @@ impl RecvStream {
     /// Returns `None` if the stream has been finished by the remote.
     pub fn poll_read(
         &mut self,
-        waker: &Waker,
+        waiter: &Waiter,
         buf: &mut [u8],
     ) -> Poll<Result<Option<usize>, StreamError>> {
-        let chunk = ready!(self.poll_read_chunk(waker, buf.len()))?;
+        let chunk = ready!(self.poll_read_chunk(waiter, buf.len()))?;
 
         Poll::Ready(Ok(chunk.map(|chunk| {
             buf[..chunk.len()].copy_from_slice(&chunk);
@@ -272,17 +282,17 @@ impl RecvStream {
     /// Returns `None` if the stream has been finished by the remote.
     pub fn poll_read_chunk(
         &mut self,
-        waker: &Waker,
+        waiter: &Waiter,
         max: usize,
     ) -> Poll<Result<Option<Bytes>, StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_read_chunk(waker, max) {
+        if let Poll::Ready(res) = self.state.lock().poll_read_chunk(waiter, max) {
             return Poll::Ready(res);
         }
 
         let mut driver = self.driver.lock();
 
         // Check if the connection is closed.
-        if let Poll::Ready(res) = driver.error(waker) {
+        if let Poll::Ready(res) = driver.error(waiter) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -345,12 +355,12 @@ impl RecvStream {
     }
 
     /// Poll until the stream is closed by either side.
-    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_closed(waker) {
+    pub fn poll_closed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
+        if let Poll::Ready(res) = self.state.lock().poll_closed(waiter) {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().error(waker) {
+        if let Poll::Ready(res) = self.driver.lock().error(waiter) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -366,7 +376,7 @@ impl RecvStream {
     ///
     /// **NOTE**: This takes `&mut` to match quiche and slightly simplify the implementation.
     pub async fn closed(&mut self) -> Result<(), StreamError> {
-        poll_fn(|cx| self.poll_closed(cx.waker())).await
+        kio::wait(|waiter| self.poll_closed(waiter)).await
     }
 }
 
@@ -393,7 +403,11 @@ impl AsyncRead for RecvStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        match ready!(self.poll_read_chunk(cx.waker(), buf.remaining())) {
+        let waiter = Waiter::new(cx.waker().clone());
+        let res = self.poll_read_chunk(&waiter, buf.remaining());
+        self.parked.park(waiter);
+
+        match ready!(res) {
             Ok(Some(chunk)) => buf.put_slice(&chunk),
             Ok(None) => {}
             Err(e) => return Poll::Ready(Err(io::Error::other(e.to_string()))),

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -445,7 +445,7 @@ impl AsyncWrite for SendStream {
         let mut buf = io::Cursor::new(buf);
         let waiter = Waiter::new(cx.waker().clone());
         let res = self.poll_write_buf(&waiter, &mut buf);
-        self.parked.park(waiter);
+        self.parked.park(waiter, &res);
 
         match ready!(res) {
             Ok(n) => Poll::Ready(Ok(n)),
@@ -456,7 +456,7 @@ impl AsyncWrite for SendStream {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         let waiter = Waiter::new(cx.waker().clone());
         let res = self.poll_flushed(&waiter);
-        self.parked.park(waiter);
+        self.parked.park(waiter, &res);
 
         res.map_err(|e| io::Error::other(e.to_string()))
     }
@@ -477,7 +477,7 @@ impl AsyncWrite for SendStream {
 
         let waiter = Waiter::new(cx.waker().clone());
         let res = self.poll_closed(&waiter);
-        self.parked.park(waiter);
+        self.parked.park(waiter, &res);
 
         res.map_err(|e| io::Error::other(e.to_string()))
     }

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -1,6 +1,6 @@
+use kio::Waiter;
 use std::{
     collections::VecDeque,
-    future::poll_fn,
     io,
     pin::Pin,
     task::{ready, Context, Poll, Waker},
@@ -12,7 +12,7 @@ use tokio::io::AsyncWrite;
 
 use tokio_quiche::quic::QuicheConnection;
 
-use crate::ez::DriverState;
+use crate::{ez::DriverState, waiters::Parked};
 
 use super::{Lock, StreamError, StreamId};
 
@@ -67,7 +67,7 @@ impl SendState {
     // Returns the number of bytes written for convenience.
     fn poll_write_buf<B: Buf>(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
         buf: &mut B,
     ) -> Poll<Result<usize, StreamError>> {
         if let Some(reset) = self.reset {
@@ -79,7 +79,9 @@ impl SendState {
         }
 
         if self.capacity == 0 {
-            self.blocked = Some(cx.waker().clone());
+            // A stream has a single writer, so one slot is enough here — unlike the
+            // connection-wide lists, which every stream and accepter parks on.
+            self.blocked = Some(waiter.waker().clone());
             return Poll::Pending;
         }
 
@@ -94,7 +96,7 @@ impl SendState {
         Poll::Ready(Ok(n))
     }
 
-    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+    pub fn poll_closed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
         if let Some(reset) = self.reset {
             return Poll::Ready(Err(StreamError::Reset(reset)));
         } else if let Some(stop) = self.stop {
@@ -105,12 +107,12 @@ impl SendState {
             return Poll::Ready(Ok(()));
         }
 
-        self.blocked = Some(waker.clone());
+        self.blocked = Some(waiter.waker().clone());
 
         Poll::Pending
     }
 
-    pub fn poll_flushed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
+    pub fn poll_flushed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
         if let Some(reset) = self.reset {
             return Poll::Ready(Err(StreamError::Reset(reset)));
         } else if let Some(stop) = self.stop {
@@ -119,7 +121,7 @@ impl SendState {
             return Poll::Ready(Ok(()));
         }
 
-        self.blocked = Some(waker.clone());
+        self.blocked = Some(waiter.waker().clone());
 
         Poll::Pending
     }
@@ -231,11 +233,19 @@ pub struct SendStream {
     id: StreamId,
     state: Lock<SendState>,
     driver: Lock<DriverState>,
+
+    // For the `AsyncWrite` impl, which is handed a `Context` rather than a waiter.
+    parked: Parked,
 }
 
 impl SendStream {
     pub(super) fn new(id: StreamId, state: Lock<SendState>, driver: Lock<DriverState>) -> Self {
-        Self { id, state, driver }
+        Self {
+            id,
+            state,
+            driver,
+            parked: Parked::default(),
+        }
     }
 
     /// Returns the QUIC stream ID.
@@ -246,17 +256,13 @@ impl SendStream {
     /// Write some data to the stream, returning the size written.
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, StreamError> {
         let mut buf = io::Cursor::new(buf);
-        poll_fn(|cx| self.poll_write_buf(cx, &mut buf)).await
+        kio::wait(|waiter| self.poll_write_buf(waiter, &mut buf)).await
     }
 
     /// Poll to write some data to the stream, returning the size written.
-    pub fn poll_write(
-        &mut self,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, StreamError>> {
+    pub fn poll_write(&mut self, waiter: &Waiter, buf: &[u8]) -> Poll<Result<usize, StreamError>> {
         let mut buf = io::Cursor::new(buf);
-        self.poll_write_buf(cx, &mut buf)
+        self.poll_write_buf(waiter, &mut buf)
     }
 
     /// Poll to write some of the buffer to the stream, advancing the internal
@@ -265,10 +271,10 @@ impl SendStream {
     /// Returns the number of bytes written for convenience.
     pub fn poll_write_buf<B: Buf>(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
         buf: &mut B,
     ) -> Poll<Result<usize, StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_write_buf(cx, buf) {
+        if let Poll::Ready(res) = self.state.lock().poll_write_buf(waiter, buf) {
             // Tell the driver that the stream has data to send.
             let waker = self.driver.lock().send(self.id);
             if let Some(waker) = waker {
@@ -278,7 +284,7 @@ impl SendStream {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().error(cx.waker()) {
+        if let Poll::Ready(res) = self.driver.lock().error(waiter) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -298,7 +304,7 @@ impl SendStream {
     ///
     /// Returns the number of bytes written for convenience.
     pub async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<usize, StreamError> {
-        poll_fn(|cx| self.poll_write_buf(cx, buf)).await
+        kio::wait(|waiter| self.poll_write_buf(waiter, buf)).await
     }
 
     /// Write the entire buffer to the stream, advancing the internal position.
@@ -364,24 +370,24 @@ impl SendStream {
     }
 
     /// Poll until the stream is closed by either side.
-    pub fn poll_closed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_closed(waker) {
+    pub fn poll_closed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
+        if let Poll::Ready(res) = self.state.lock().poll_closed(waiter) {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().error(waker) {
+        if let Poll::Ready(res) = self.driver.lock().error(waiter) {
             return Poll::Ready(Err(res.into()));
         }
 
         Poll::Pending
     }
 
-    fn poll_flushed(&mut self, waker: &Waker) -> Poll<Result<(), StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_flushed(waker) {
+    fn poll_flushed(&mut self, waiter: &Waiter) -> Poll<Result<(), StreamError>> {
+        if let Poll::Ready(res) = self.state.lock().poll_flushed(waiter) {
             return Poll::Ready(res);
         }
 
-        if let Poll::Ready(res) = self.driver.lock().closed(waker) {
+        if let Poll::Ready(res) = self.driver.lock().closed(waiter) {
             return Poll::Ready(Err(res.into()));
         }
 
@@ -397,7 +403,7 @@ impl SendStream {
     ///
     /// Note: This takes `&mut` to match quiche and to simplify the implementation.
     pub async fn closed(&mut self) -> Result<(), StreamError> {
-        poll_fn(|cx| self.poll_closed(cx.waker())).await
+        kio::wait(|waiter| self.poll_closed(waiter)).await
     }
 
     /// Set the priority of this stream.
@@ -437,15 +443,22 @@ impl AsyncWrite for SendStream {
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
         let mut buf = io::Cursor::new(buf);
-        match ready!(self.poll_write_buf(cx, &mut buf)) {
+        let waiter = Waiter::new(cx.waker().clone());
+        let res = self.poll_write_buf(&waiter, &mut buf);
+        self.parked.park(waiter);
+
+        match ready!(res) {
             Ok(n) => Poll::Ready(Ok(n)),
             Err(e) => Poll::Ready(Err(io::Error::other(e.to_string()))),
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.poll_flushed(cx.waker())
-            .map_err(|e| io::Error::other(e.to_string()))
+        let waiter = Waiter::new(cx.waker().clone());
+        let res = self.poll_flushed(&waiter);
+        self.parked.park(waiter);
+
+        res.map_err(|e| io::Error::other(e.to_string()))
     }
 
     fn poll_shutdown(
@@ -462,7 +475,10 @@ impl AsyncWrite for SendStream {
             Err(e) => return Poll::Ready(Err(io::Error::other(e.to_string()))),
         }
 
-        self.poll_closed(cx.waker())
-            .map_err(|e| io::Error::other(e.to_string()))
+        let waiter = Waiter::new(cx.waker().clone());
+        let res = self.poll_closed(&waiter);
+        self.parked.park(waiter);
+
+        res.map_err(|e| io::Error::other(e.to_string()))
     }
 }

--- a/rs/web-transport-quiche/src/ez/server.rs
+++ b/rs/web-transport-quiche/src/ez/server.rs
@@ -327,10 +327,8 @@ impl Incoming {
     /// Returns the connection once the handshake is complete, or an error if the connection
     /// is closed before the handshake finishes.
     pub async fn accept(self) -> Result<Connection, ConnectionError> {
-        use std::future::poll_fn;
-
         // Wait for handshake to complete
-        poll_fn(|cx| self.driver.lock().poll_handshake(cx.waker())).await?;
+        kio::wait(|waiter| self.driver.lock().poll_handshake(waiter)).await?;
 
         Ok(self.connection)
     }

--- a/rs/web-transport-quiche/src/lib.rs
+++ b/rs/web-transport-quiche/src/lib.rs
@@ -32,6 +32,7 @@ mod error;
 mod recv;
 mod send;
 mod server;
+mod waiters;
 
 pub use client::*;
 pub use connection::*;
@@ -47,6 +48,10 @@ pub use ez::{
 
 pub use http;
 pub use web_transport_proto as proto;
+
+/// Re-export kio, whose [`Waiter`](kio::Waiter) is how a caller of [`SessionAccept`]'s
+/// poll methods holds its place in the accept queue.
+pub use kio;
 
 /// The ALPN used for WebTransport over HTTP/3.
 pub const ALPN: &str = "h3";

--- a/rs/web-transport-quiche/src/recv.rs
+++ b/rs/web-transport-quiche/src/recv.rs
@@ -6,7 +6,7 @@ use std::{
 use bytes::{BufMut, Bytes};
 use tokio::io::{AsyncRead, ReadBuf};
 
-use crate::{ez, StreamError};
+use crate::{ez, waiters::Parked, StreamError};
 
 // "recv" in ascii; if you see this then read everything or close(code)
 // hex: 0x44454356, or 0x52E4EA9B7F80 as an HTTP error code
@@ -16,11 +16,20 @@ const DROP_CODE: u64 = web_transport_proto::error_to_http3(0x44454356);
 /// A stream that can be used to receive bytes.
 pub struct RecvStream {
     inner: ez::RecvStream,
+
+    // For the poll traits, which are handed a `Context` rather than a waiter. One cell
+    // covers both read methods: they are the same operation.
+    parked_read: Parked,
+    parked_closed: Parked,
 }
 
 impl RecvStream {
     pub(super) fn new(inner: ez::RecvStream) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            parked_read: Parked::default(),
+            parked_closed: Parked::default(),
+        }
     }
 
     /// Read some data into the buffer and return the amount read.
@@ -111,7 +120,8 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
         cx: &mut Context<'_>,
         dst: &mut [u8],
     ) -> Poll<Result<Option<usize>, Self::Error>> {
-        self.inner.poll_read(cx.waker(), dst).map_err(Into::into)
+        let waiter = self.parked_read.hold(cx);
+        self.inner.poll_read(waiter, dst).map_err(Into::into)
     }
 
     fn poll_read_chunk(
@@ -120,9 +130,8 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
         max: usize,
     ) -> Poll<Result<Option<Bytes>, Self::Error>> {
         // ez already owns the bytes, so this hands them over instead of copying.
-        self.inner
-            .poll_read_chunk(cx.waker(), max)
-            .map_err(Into::into)
+        let waiter = self.parked_read.hold(cx);
+        self.inner.poll_read_chunk(waiter, max).map_err(Into::into)
     }
 
     fn stop(&mut self, code: u32) {
@@ -130,6 +139,7 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_closed(cx.waker()).map_err(Into::into)
+        let waiter = self.parked_closed.hold(cx);
+        self.inner.poll_closed(waiter).map_err(Into::into)
     }
 }

--- a/rs/web-transport-quiche/src/recv.rs
+++ b/rs/web-transport-quiche/src/recv.rs
@@ -120,8 +120,9 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
         cx: &mut Context<'_>,
         dst: &mut [u8],
     ) -> Poll<Result<Option<usize>, Self::Error>> {
-        let waiter = self.parked_read.hold(cx);
-        self.inner.poll_read(waiter, dst).map_err(Into::into)
+        self.parked_read
+            .poll(cx, |waiter| self.inner.poll_read(waiter, dst))
+            .map_err(Into::into)
     }
 
     fn poll_read_chunk(
@@ -130,8 +131,9 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
         max: usize,
     ) -> Poll<Result<Option<Bytes>, Self::Error>> {
         // ez already owns the bytes, so this hands them over instead of copying.
-        let waiter = self.parked_read.hold(cx);
-        self.inner.poll_read_chunk(waiter, max).map_err(Into::into)
+        self.parked_read
+            .poll(cx, |waiter| self.inner.poll_read_chunk(waiter, max))
+            .map_err(Into::into)
     }
 
     fn stop(&mut self, code: u32) {
@@ -139,7 +141,8 @@ impl web_transport_trait::poll::RecvStream for RecvStream {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let waiter = self.parked_closed.hold(cx);
-        self.inner.poll_closed(waiter).map_err(Into::into)
+        self.parked_closed
+            .poll(cx, |waiter| self.inner.poll_closed(waiter))
+            .map_err(Into::into)
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -144,8 +144,9 @@ impl web_transport_trait::poll::SendStream for SendStream {
     type Error = StreamError;
 
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
-        let waiter = self.parked_write.hold(cx);
-        self.inner.poll_write(waiter, buf).map_err(Into::into)
+        self.parked_write
+            .poll(cx, |waiter| self.inner.poll_write(waiter, buf))
+            .map_err(Into::into)
     }
 
     fn poll_write_buf<B: Buf>(
@@ -155,8 +156,9 @@ impl web_transport_trait::poll::SendStream for SendStream {
     ) -> Poll<Result<usize, Self::Error>> {
         // ez advances `buf` by exactly what it accepted, so this keeps the
         // partial-write contract while skipping the default's extra copy.
-        let waiter = self.parked_write.hold(cx);
-        self.inner.poll_write_buf(waiter, buf).map_err(Into::into)
+        self.parked_write
+            .poll(cx, |waiter| self.inner.poll_write_buf(waiter, buf))
+            .map_err(Into::into)
     }
 
     fn set_priority(&mut self, order: u8) {
@@ -172,7 +174,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let waiter = self.parked_closed.hold(cx);
-        self.inner.poll_closed(waiter).map_err(Into::into)
+        self.parked_closed
+            .poll(cx, |waiter| self.inner.poll_closed(waiter))
+            .map_err(Into::into)
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -7,7 +7,7 @@ use std::{
 use bytes::Buf;
 use tokio::io::AsyncWrite;
 
-use crate::{ez, StreamError};
+use crate::{ez, waiters::Parked, StreamError};
 
 // "send" in ascii; if you see this then call finish().await or close(code)
 // hex: 0x73656E64, or 0x52E51B4DCE20 as an HTTP error code
@@ -20,11 +20,20 @@ const DROP_CODE: u64 = web_transport_proto::error_to_http3(0x73656E64);
 /// WebTransport uses u32 error codes and they're mapped in a reserved HTTP/3 error space.
 pub struct SendStream {
     inner: ez::SendStream,
+
+    // For the poll traits, which are handed a `Context` rather than a waiter. One cell
+    // covers both write methods: they are the same operation.
+    parked_write: Parked,
+    parked_closed: Parked,
 }
 
 impl SendStream {
     pub(super) fn new(inner: ez::SendStream) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            parked_write: Parked::default(),
+            parked_closed: Parked::default(),
+        }
     }
 
     /// Write some data to the stream, returning the size written.
@@ -135,7 +144,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
     type Error = StreamError;
 
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
-        self.inner.poll_write(cx, buf).map_err(Into::into)
+        let waiter = self.parked_write.hold(cx);
+        self.inner.poll_write(waiter, buf).map_err(Into::into)
     }
 
     fn poll_write_buf<B: Buf>(
@@ -145,7 +155,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
     ) -> Poll<Result<usize, Self::Error>> {
         // ez advances `buf` by exactly what it accepted, so this keeps the
         // partial-write contract while skipping the default's extra copy.
-        self.inner.poll_write_buf(cx, buf).map_err(Into::into)
+        let waiter = self.parked_write.hold(cx);
+        self.inner.poll_write_buf(waiter, buf).map_err(Into::into)
     }
 
     fn set_priority(&mut self, order: u8) {
@@ -161,6 +172,7 @@ impl web_transport_trait::poll::SendStream for SendStream {
     }
 
     fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_closed(cx.waker()).map_err(Into::into)
+        let waiter = self.parked_closed.hold(cx);
+        self.inner.poll_closed(waiter).map_err(Into::into)
     }
 }

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -52,6 +52,17 @@ impl AcceptWaiters {
         let mut waiters = self.waiters.lock().unwrap().take();
         waiters.wake();
     }
+
+    /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
+    /// exposes no length, and the test below has to see that repeated polls do not stack
+    /// entries. Panics rather than guessing if kio's format ever changes.
+    #[cfg(test)]
+    fn slots(&self) -> usize {
+        let list = format!("{:?}", self.waiters.lock().unwrap());
+        list.rsplit_once("len: ")
+            .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
+            .expect("WaiterList Debug should report a length")
+    }
 }
 
 impl Wake for AcceptWaiters {
@@ -178,5 +189,35 @@ mod tests {
 
         rx.recv_timeout(Duration::from_secs(5))
             .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
+    }
+
+    /// Repeated polls must not stack registrations.
+    ///
+    /// Both routes in build a fresh `Waiter` per poll and drop the previous one — kio's
+    /// `wait` for the `async` methods, the `Context` bridge for the `poll_*` ones — so
+    /// the list reclaims the dead slot instead of growing. A bridge that reused a *live*
+    /// waiter would add an entry on every re-poll, which is the trap `kio::WaiterCell`
+    /// warns about, and this is the guard for whatever ends up replacing that bridge.
+    #[test]
+    fn repeated_polls_do_not_stack_registrations() {
+        let waiters = AcceptWaiters::default();
+
+        // Retained across iterations exactly as a poll bridge retains it: assigning the
+        // next one drops the previous, killing the registration it left behind.
+        let mut held = None;
+
+        for _ in 0..100 {
+            let waiter = Waiter::new(std::task::Waker::noop().clone());
+            waiters.register(&waiter);
+            held = Some(waiter);
+        }
+
+        assert!(
+            waiters.slots() <= 2,
+            "100 polls left {} registrations behind",
+            waiters.slots()
+        );
+
+        drop(held);
     }
 }

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -1,0 +1,119 @@
+//! Who is waiting on shared connection state, and how they are woken.
+//!
+//! Both this crate and [`ez`](crate::ez) park callers on state they share — the accept
+//! queues, the connection-closed error, a stream's flow-control credit — and none of it
+//! may hold on to a caller that walks away. That is what the weak registrations in
+//! [`kio::WaiterList`] are for: a slot lives only as long as the [`kio::Waiter`] that
+//! made it.
+//!
+//! [`Parked`] is the caller's end of such a registration, for a caller that has only a
+//! `Context` to work with. [`AcceptWaiters`] is the other end for
+//! [`SessionAccept`](crate::SessionAccept), which is shared by every clone of a session
+//! and has to fan one arrival out to every accepter parked on it.
+
+use std::{
+    sync::{Arc, Mutex},
+    task::{Context, Wake},
+};
+
+use kio::{Waiter, WaiterList};
+
+/// The accepters parked on one direction, plus the waker that wakes all of them.
+///
+/// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
+/// this, not with the caller's. A caller's waker goes stale the moment it stops
+/// accepting: whoever polled last is the one the inner future holds, so if that caller
+/// drops its future the arrival wakes nobody while other accepters sit parked. This
+/// waker cannot go stale — it lives as long as the accept state — and waking it wakes
+/// everyone on the list.
+#[derive(Default)]
+pub(crate) struct AcceptWaiters {
+    // Held only to register or to wake, never across a poll of the inner futures, which
+    // take locks of their own further down.
+    waiters: Mutex<WaiterList>,
+}
+
+impl AcceptWaiters {
+    /// Park a caller until the next wake.
+    ///
+    /// Registrations are weak and owned by the caller, so an accepter that gives up — a
+    /// `timeout` around `accept_uni`, or a task that just drops the future — releases
+    /// its slot instead of leaving a waker parked here forever.
+    pub(crate) fn register(&self, waiter: &Waiter) {
+        waiter.register(&mut self.waiters.lock().unwrap());
+    }
+
+    /// Wake every parked accepter so it can retry.
+    pub(crate) fn wake_all(&self) {
+        self.waiters.lock().unwrap().wake();
+    }
+}
+
+impl Wake for AcceptWaiters {
+    fn wake(self: Arc<Self>) {
+        self.wake_all();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.wake_all();
+    }
+}
+
+/// A [`Waiter`] retained across `poll` calls.
+///
+/// A registration in [`AcceptWaiters`] stays live only while the caller holds the
+/// [`Waiter`] it registered, which is what lets a caller that walks away release its
+/// slot. So the handle has to live somewhere the *caller* owns, and a `poll_*` method is
+/// handed nothing but a `Context`. This is that somewhere: one cell per operation, held
+/// by whoever polls.
+///
+/// The `async` methods have no need for it — [`kio::wait`] keeps the waiter inside the
+/// future it builds, so dropping the future drops the registration.
+///
+/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); replace this
+/// with it once that releases. Its `hold` also *reuses* the waiter when the task is
+/// unchanged and every registration was already drained, which saves the allocation this
+/// one makes on each poll.
+#[derive(Default)]
+pub(crate) struct Parked {
+    waiter: Option<Waiter>,
+}
+
+impl Parked {
+    /// Adopt `cx`'s waker for this poll, retiring the previous handle and with it the
+    /// registration it left behind.
+    ///
+    /// Always replaces rather than reusing: [`WaiterList`] reclaims a slot only when the
+    /// `Waiter` that registered it dies, so re-registering a live one would stack a
+    /// duplicate entry on every spurious re-poll.
+    pub(crate) fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
+        self.waiter.insert(Waiter::new(cx.waker().clone()))
+    }
+}
+
+impl Parked {
+    /// Park a waiter built for this poll, retiring the previous one.
+    ///
+    /// The two-step alternative to [`hold`](Self::hold), for a poll that needs `&mut
+    /// self` of the struct holding this cell while the waiter is alive — the borrow
+    /// checker allows only one of those at a time. Build the waiter from the `Context`,
+    /// poll with it, then park it here so its registrations outlive the poll.
+    pub(crate) fn park(&mut self, waiter: Waiter) {
+        // Retiring the old one *after* the poll matters: the new waiter is already
+        // registered by then, so there is no window with nothing registered.
+        self.waiter = Some(waiter);
+    }
+}
+
+impl Clone for Parked {
+    /// A clone starts unregistered: a registration belongs to the handle that parked it.
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl std::fmt::Debug for Parked {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("Parked").finish_non_exhaustive()
+    }
+}

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -44,8 +44,13 @@ impl AcceptWaiters {
     }
 
     /// Wake every parked accepter so it can retry.
+    ///
+    /// The list is taken under the lock and woken outside it. A waker is free to resume
+    /// its task inline, and the first thing a resumed accepter does is register here
+    /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        self.waiters.lock().unwrap().wake();
+        let mut waiters = self.waiters.lock().unwrap().take();
+        waiters.wake();
     }
 }
 
@@ -118,5 +123,60 @@ impl Clone for Parked {
 impl std::fmt::Debug for Parked {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.debug_struct("Parked").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{mpsc, Weak},
+        thread,
+        time::Duration,
+    };
+
+    use super::*;
+
+    /// A waker that re-enters the list from `wake`, standing in for an executor that
+    /// polls a resumed task inline: the first thing a resumed accepter does is register
+    /// itself again.
+    struct Reentrant {
+        waiters: Weak<AcceptWaiters>,
+    }
+
+    impl Wake for Reentrant {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            if let Some(waiters) = self.waiters.upgrade() {
+                waiters.register(&Waiter::new(std::task::Waker::noop().clone()));
+            }
+        }
+    }
+
+    #[test]
+    fn waking_does_not_hold_the_lock() {
+        let waiters = Arc::new(AcceptWaiters::default());
+        let inline = Arc::new(Reentrant {
+            waiters: Arc::downgrade(&waiters),
+        });
+
+        // Kept alive for the whole test: the registration dies with it.
+        let waiter = Waiter::new(std::task::Waker::from(inline));
+        waiters.register(&waiter);
+
+        // On a deadlock this thread never finishes, so the test cannot hang.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn({
+            let waiters = waiters.clone();
+            move || {
+                waiters.wake_all();
+                let _ = tx.send(());
+            }
+        });
+
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
     }
 }

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -13,7 +13,7 @@
 
 use std::{
     sync::{Arc, Mutex},
-    task::{Context, Wake},
+    task::{Context, Poll, Wake},
 };
 
 use kio::{Waiter, WaiterList};
@@ -70,38 +70,41 @@ impl Wake for AcceptWaiters {
 /// The `async` methods have no need for it — [`kio::wait`] keeps the waiter inside the
 /// future it builds, so dropping the future drops the registration.
 ///
-/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); replace this
-/// with it once that releases. Its `hold` also *reuses* the waiter when the task is
-/// unchanged and every registration was already drained, which saves the allocation this
-/// one makes on each poll.
+/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); this can go
+/// once that releases. Its `hold` also *reuses* the waiter when the task is unchanged and
+/// every registration was already drained, which saves the allocation this one makes on
+/// each poll — though it holds the waiter across a `Ready`, so keep retiring it here.
 #[derive(Default)]
 pub(crate) struct Parked {
     waiter: Option<Waiter>,
 }
 
 impl Parked {
-    /// Adopt `cx`'s waker for this poll, retiring the previous handle and with it the
-    /// registration it left behind.
+    /// Run one poll with a retained waiter.
     ///
-    /// Always replaces rather than reusing: [`WaiterList`] reclaims a slot only when the
-    /// `Waiter` that registered it dies, so re-registering a live one would stack a
-    /// duplicate entry on every spurious re-poll.
-    pub(crate) fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
-        self.waiter.insert(Waiter::new(cx.waker().clone()))
+    /// The waiter is kept only while the poll is `Pending`. On `Ready` there is nothing
+    /// left to wake, and holding the waker would pin the polling task's allocation until
+    /// something polled this cell again — for a stream that finished its last read and
+    /// then sat idle, that is the rest of the connection.
+    pub(crate) fn poll<T>(
+        &mut self,
+        cx: &mut Context<'_>,
+        poll: impl FnOnce(&Waiter) -> Poll<T>,
+    ) -> Poll<T> {
+        let waiter = Waiter::new(cx.waker().clone());
+        let result = poll(&waiter);
+        self.park(waiter, &result);
+        result
     }
-}
 
-impl Parked {
-    /// Park a waiter built for this poll, retiring the previous one.
-    ///
-    /// The two-step alternative to [`hold`](Self::hold), for a poll that needs `&mut
-    /// self` of the struct holding this cell while the waiter is alive — the borrow
-    /// checker allows only one of those at a time. Build the waiter from the `Context`,
-    /// poll with it, then park it here so its registrations outlive the poll.
-    pub(crate) fn park(&mut self, waiter: Waiter) {
-        // Retiring the old one *after* the poll matters: the new waiter is already
+    /// The two-step form of [`poll`](Self::poll), for a poll that needs `&mut self` of
+    /// the struct holding this cell while the waiter is alive — the borrow checker allows
+    /// only one of those at a time, so the closure form will not compile there. Build the
+    /// waiter from the `Context`, poll with it, then hand it here with the result.
+    pub(crate) fn park<T>(&mut self, waiter: Waiter, result: &Poll<T>) {
+        // Retiring the previous waiter *after* the poll matters: the new one is already
         // registered by then, so there is no window with nothing registered.
-        self.waiter = Some(waiter);
+        self.waiter = result.is_pending().then_some(waiter);
     }
 }
 

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -22,9 +22,13 @@ use kio::{Waiter, WaiterList};
 struct AcceptState {
     waiters: WaiterList,
 
-    /// A poll is holding the lock on the accept state, so a wake arriving now is
-    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
-    armed: bool,
+    /// How many polls are holding the lock on the accept state. While this is non-zero
+    /// a wake is recorded rather than delivered. See [`AcceptWaiters::arm`].
+    ///
+    /// A count, not a flag: one poll releases the accept lock before it disarms, so
+    /// another can be armed and mid-poll by then, and a flag would let the first one
+    /// clear the second's protection.
+    armed: usize,
 
     /// A wake arrived while `armed`, and is owed to the list.
     deferred: bool,
@@ -62,7 +66,7 @@ impl AcceptWaiters {
     pub(crate) fn wake_all(&self) {
         let mut waiters = {
             let mut state = self.state.lock().unwrap();
-            if state.armed {
+            if state.armed > 0 {
                 state.deferred = true;
                 return;
             }
@@ -82,16 +86,23 @@ impl AcceptWaiters {
     /// lock, which it takes as its first move. So it is recorded instead, and
     /// [`disarm`](Self::disarm) hands it back once the lock is gone.
     pub(crate) fn arm(&self) {
-        self.state.lock().unwrap().armed = true;
+        self.state.lock().unwrap().armed += 1;
     }
 
-    /// Stop holding wakes back, reporting whether one arrived while armed.
+    /// Stop holding wakes back, reporting whether one arrived and is this caller's to
+    /// deliver.
     ///
     /// Only ever called with the accept lock released, and the caller owes the list a
-    /// [`wake_all`](Self::wake_all) when this returns true.
+    /// [`wake_all`](Self::wake_all) when this returns true. False while another poll is
+    /// still armed: a deferred wake stays owed until the last one leaves, and that one
+    /// delivers it.
     pub(crate) fn disarm(&self) -> bool {
         let mut state = self.state.lock().unwrap();
-        state.armed = false;
+        state.armed = state.armed.saturating_sub(1);
+        if state.armed > 0 {
+            return false;
+        }
+
         std::mem::take(&mut state.deferred)
     }
 
@@ -316,5 +327,31 @@ mod tests {
         let waiters = AcceptWaiters::default();
         waiters.arm();
         assert!(!waiters.disarm());
+    }
+
+    /// One poll releasing the accept lock must not drop another's protection.
+    ///
+    /// The lock is released before `disarm`, so a second poll can be armed and running
+    /// by then. With a flag instead of a count, the first one leaving would expose the
+    /// second to exactly the inline wake this is here to prevent.
+    #[test]
+    fn overlapping_polls_stay_armed_until_the_last_one_leaves() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm(); // first poll
+        waiters.arm(); // second poll, overlapping
+
+        assert!(!waiters.disarm(), "the first out does not own the wake");
+
+        waiters.wake_all();
+        assert!(!flag.woken(), "a poll is still holding the accept lock");
+
+        assert!(waiters.disarm(), "the last one out owes the deferred wake");
+        waiters.wake_all();
+        assert!(flag.woken());
     }
 }

--- a/rs/web-transport-quiche/src/waiters.rs
+++ b/rs/web-transport-quiche/src/waiters.rs
@@ -18,6 +18,18 @@ use std::{
 
 use kio::{Waiter, WaiterList};
 
+#[derive(Default)]
+struct AcceptState {
+    waiters: WaiterList,
+
+    /// A poll is holding the lock on the accept state, so a wake arriving now is
+    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
+    armed: bool,
+
+    /// A wake arrived while `armed`, and is owed to the list.
+    deferred: bool,
+}
+
 /// The accepters parked on one direction, plus the waker that wakes all of them.
 ///
 /// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
@@ -28,9 +40,7 @@ use kio::{Waiter, WaiterList};
 /// everyone on the list.
 #[derive(Default)]
 pub(crate) struct AcceptWaiters {
-    // Held only to register or to wake, never across a poll of the inner futures, which
-    // take locks of their own further down.
-    waiters: Mutex<WaiterList>,
+    state: Mutex<AcceptState>,
 }
 
 impl AcceptWaiters {
@@ -40,17 +50,49 @@ impl AcceptWaiters {
     /// `timeout` around `accept_uni`, or a task that just drops the future — releases
     /// its slot instead of leaving a waker parked here forever.
     pub(crate) fn register(&self, waiter: &Waiter) {
-        waiter.register(&mut self.waiters.lock().unwrap());
+        waiter.register(&mut self.state.lock().unwrap().waiters);
     }
 
-    /// Wake every parked accepter so it can retry.
+    /// Wake every parked accepter so it can retry, or record the wake while a poll is
+    /// [armed](Self::arm).
     ///
     /// The list is taken under the lock and woken outside it. A waker is free to resume
     /// its task inline, and the first thing a resumed accepter does is register here
     /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        let mut waiters = self.waiters.lock().unwrap().take();
+        let mut waiters = {
+            let mut state = self.state.lock().unwrap();
+            if state.armed {
+                state.deferred = true;
+                return;
+            }
+
+            state.waiters.take()
+        };
+
         waiters.wake();
+    }
+
+    /// Hold back wakes for the duration of a poll that holds the lock on the accept
+    /// state.
+    ///
+    /// That poll drives the shared accept futures with this list's waker, and one of
+    /// them may wake it *inline* — `FuturesUnordered`, for one, notifies its parent from
+    /// a child's `wake`. Delivering that would resume an accepter underneath the accept
+    /// lock, which it takes as its first move. So it is recorded instead, and
+    /// [`disarm`](Self::disarm) hands it back once the lock is gone.
+    pub(crate) fn arm(&self) {
+        self.state.lock().unwrap().armed = true;
+    }
+
+    /// Stop holding wakes back, reporting whether one arrived while armed.
+    ///
+    /// Only ever called with the accept lock released, and the caller owes the list a
+    /// [`wake_all`](Self::wake_all) when this returns true.
+    pub(crate) fn disarm(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.armed = false;
+        std::mem::take(&mut state.deferred)
     }
 
     /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
@@ -58,7 +100,7 @@ impl AcceptWaiters {
     /// entries. Panics rather than guessing if kio's format ever changes.
     #[cfg(test)]
     fn slots(&self) -> usize {
-        let list = format!("{:?}", self.waiters.lock().unwrap());
+        let list = format!("{:?}", self.state.lock().unwrap().waiters);
         list.rsplit_once("len: ")
             .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
             .expect("WaiterList Debug should report a length")
@@ -147,6 +189,28 @@ mod tests {
 
     use super::*;
 
+    /// Records whether it was woken.
+    #[derive(Default)]
+    struct Flag {
+        woken: std::sync::atomic::AtomicBool,
+    }
+
+    impl Flag {
+        fn woken(&self) -> bool {
+            self.woken.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl Wake for Flag {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.woken.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     /// A waker that re-enters the list from `wake`, standing in for an executor that
     /// polls a resumed task inline: the first thing a resumed accepter does is register
     /// itself again.
@@ -219,5 +283,38 @@ mod tests {
         );
 
         drop(held);
+    }
+
+    /// A wake that lands mid-poll is held until the accept lock is gone.
+    ///
+    /// The shared accept futures are driven with this list's waker while the poll holds
+    /// that lock, and an inner future can wake it inline. Delivering it there would
+    /// resume an accepter straight into the lock it is standing on.
+    #[test]
+    fn a_wake_during_a_poll_is_deferred() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm();
+        waiters.wake_all();
+        assert!(
+            !flag.woken(),
+            "the wake was delivered while the accept lock was held"
+        );
+
+        assert!(waiters.disarm(), "the deferred wake was dropped");
+        waiters.wake_all();
+        assert!(flag.woken(), "the deferred wake never arrived");
+    }
+
+    /// Nothing owed when nothing woke.
+    #[test]
+    fn disarming_a_quiet_poll_owes_no_wake() {
+        let waiters = AcceptWaiters::default();
+        waiters.arm();
+        assert!(!waiters.disarm());
     }
 }

--- a/rs/web-transport-quiche/tests/accept_wakers.rs
+++ b/rs/web-transport-quiche/tests/accept_wakers.rs
@@ -1,9 +1,14 @@
-//! Concurrent accepters must all be woken.
+//! Concurrent accepters must all be woken, and must not pile up.
 //!
-//! Every clone of a `Session` polls the same `SessionAccept`, and it kept no wakers
+//! Every clone of a `Connection` polls the same `SessionAccept`, and it kept no wakers
 //! of its own — each poll registered with the inner accept stream, which stores
 //! exactly one. A second accepter registered through a waker that replaced the
 //! first's, so the first never woke again even as streams arrived.
+//!
+//! The list that fixed that had no deregistration path, so an accepter that dropped its
+//! future left its waker parked forever. Callers now register weakly and the inner
+//! accept streams are polled with the accept state's own waker, which is what keeps both
+//! this list and `ez`'s bounded.
 
 use std::{
     future::Future,
@@ -61,6 +66,82 @@ fn client() -> ClientBuilder {
     let mut settings = Settings::default();
     settings.verify_peer = false;
     ClientBuilder::default().with_settings(settings)
+}
+
+/// Register an accepter, abandon it, and repeat — on a connection where no stream ever
+/// arrives, which is the case that used to grow forever. Nothing here delivers a
+/// stream: an arrival drains the list, which would hide exactly what is under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_accepters_release_their_wakers() -> Result<()> {
+    /// Well past any plausible bound on concurrent accepters.
+    const ABANDONED: usize = 256;
+
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Vec<Arc<FlagWaker>>>();
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.expect("a connection");
+        let session = request.ok().await.expect("an established session");
+
+        // Each iteration is a distinct task's worth of waker, registered by a single
+        // poll and abandoned when the future drops at the end of the scope.
+        let mut abandoned = Vec::with_capacity(ABANDONED);
+        for _ in 0..ABANDONED {
+            let flag = Arc::new(FlagWaker::default());
+            let waker = Waker::from(flag.clone());
+
+            let mut accept = std::pin::pin!(session.accept_uni());
+            assert!(
+                accept
+                    .as_mut()
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending(),
+                "no stream should be available yet"
+            );
+
+            abandoned.push(flag);
+        }
+
+        done_tx.send(abandoned).ok().expect("client is listening");
+    });
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let session = client()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(url)
+        .await?
+        .established()
+        .await?;
+
+    let abandoned = timeout(Duration::from_secs(10), done_rx)
+        .await
+        .context("the server never finished registering")??;
+
+    // Every abandoned waker should be uniquely owned by the test again: the shared
+    // accept futures are polled with the accept state's own waker, never the caller's,
+    // so there is nothing else that could still be holding one.
+    let retained = abandoned
+        .iter()
+        .filter(|flag| Arc::strong_count(flag) > 1)
+        .count();
+    assert_eq!(
+        retained, 0,
+        "{retained} of {ABANDONED} abandoned accepters are still parked"
+    );
+
+    session.close(0, "bye");
+    server_task.abort();
+    Ok(())
 }
 
 /// Register an accepter, let a second one resolve, and assert the first was woken so
@@ -198,6 +279,85 @@ async fn two_tasks_can_accept_concurrently() -> Result<()> {
     timeout(Duration::from_secs(10), done_rx)
         .await
         .context("an accepter was never woken")??;
+
+    session.close(0, "bye");
+    server_task.abort();
+    Ok(())
+}
+
+/// The last accepter to poll is the one the inner accept path holds a waker for. If it
+/// gives up, the arrival still has to reach whoever is left waiting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_departing_accepter_does_not_strand_the_others() -> Result<()> {
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    // Held until both accepters have registered, so the stream cannot arrive early.
+    let (registered_tx, registered_rx) = tokio::sync::oneshot::channel::<()>();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.expect("a connection");
+        let session = request.ok().await.expect("an established session");
+
+        // A parks first.
+        let a = Arc::new(FlagWaker::default());
+        let a_waker = Waker::from(a.clone());
+        let mut first = std::pin::pin!(session.accept_uni());
+        assert!(first
+            .as_mut()
+            .poll(&mut Context::from_waker(&a_waker))
+            .is_pending());
+
+        // B polls after A, then gives up.
+        {
+            let b = Waker::from(Arc::new(FlagWaker::default()));
+            let mut second = std::pin::pin!(session.accept_uni());
+            assert!(second
+                .as_mut()
+                .poll(&mut Context::from_waker(&b))
+                .is_pending());
+        }
+
+        registered_tx.send(()).expect("client is listening");
+
+        // Nothing here polls the accept path again: A has to be woken by the arrival.
+        for _ in 0..500 {
+            if a.woken() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(a.woken(), "the remaining accepter was never woken");
+
+        done_tx.send(()).expect("client is listening");
+    });
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let session = client()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(url)
+        .await?
+        .established()
+        .await?;
+
+    registered_rx.await?;
+
+    let mut send = session.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    timeout(Duration::from_secs(10), done_rx)
+        .await
+        .context("the remaining accepter was never woken")??;
 
     session.close(0, "bye");
     server_task.abort();

--- a/rs/web-transport-quiche/tests/ez_wakers.rs
+++ b/rs/web-transport-quiche/tests/ez_wakers.rs
@@ -1,0 +1,191 @@
+//! A caller that gives up must not leave its waker inside `ez`.
+//!
+//! Every `ez` poll that parks registers with the connection: an accept joins the accept
+//! queue's list, and *any* blocked operation — read, write, accept, handshake — also
+//! registers with the connection-closed list so a teardown wakes it. Those were plain
+//! `Vec<Waker>`s cleared only when the thing they waited for happened, and the
+//! connection-closed one did not even deduplicate, so it grew by a waker clone on every
+//! pending poll and held them all until the connection went away.
+//!
+//! Nothing here lets the operations complete: the point is what the connection retains
+//! while they are pending, and an arrival or a close drains the lists.
+
+use std::{
+    future::Future,
+    net::{Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Wake, Waker},
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::time::timeout;
+use web_transport_quiche::ez;
+
+/// How many callers give up, one after another. Well past any plausible bound on
+/// concurrent callers, so a list that keeps every registration is obvious.
+const ABANDONED: usize = 256;
+
+/// A waker whose `Arc` count the test watches: anything still holding a clone is
+/// retaining this allocation.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+/// A connected client and server, raw QUIC with no WebTransport on top.
+async fn pair() -> Result<(ez::Connection, ez::Connection)> {
+    let (chain, key) = make_self_signed()?;
+
+    let mut server = ez::ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain.clone(), key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let server_task = tokio::spawn(async move {
+        let incoming = server.accept().await.context("no connection")?;
+        let conn = incoming.accept().await?;
+        anyhow::Ok(conn)
+    });
+
+    let hashes = chain
+        .iter()
+        .map(|cert| {
+            use sha2::Digest;
+            let digest = sha2::Sha256::digest(cert.as_ref());
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&digest);
+            hash
+        })
+        .collect();
+
+    let client = ez::ClientBuilder::new()
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .with_server_certificate_hashes(hashes)
+        .connect("127.0.0.1", addr.port())
+        .await?
+        .established()
+        .await?;
+
+    let server = timeout(Duration::from_secs(10), server_task)
+        .await
+        .context("the server never accepted")???;
+
+    Ok((client, server))
+}
+
+/// Poll an operation once per iteration with a fresh waker, dropping the future each
+/// time, and report how many of those wakers something still holds.
+///
+/// A macro rather than a function taking a closure: each iteration needs its own mutable
+/// borrow of the stream being polled, which an `FnMut` cannot hand out.
+///
+/// The last poll's waker is excluded. Single-owner state — a stream's blocked reader, the
+/// driver's own wakeup — legitimately keeps a plain waker for the most recent poller;
+/// what must not happen is the *other* 256 piling up.
+macro_rules! abandon {
+    ($op:expr) => {{
+        let mut flags = Vec::with_capacity(ABANDONED);
+
+        for _ in 0..=ABANDONED {
+            let flag = Arc::new(FlagWaker::default());
+            let waker = Waker::from(flag.clone());
+
+            let mut fut = std::pin::pin!($op);
+            assert!(
+                fut.as_mut()
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending(),
+                "the operation should not be able to complete"
+            );
+
+            flags.push(flag);
+        }
+
+        flags.pop();
+        flags
+            .iter()
+            .filter(|flag| Arc::strong_count(flag) > 1)
+            .count()
+    }};
+}
+
+/// A blocked read is the common case: it registers with the connection-closed list on
+/// every pending poll, so this is the list that grew fastest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_reads_release_their_wakers() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hi").await?;
+
+    let mut recv = server.accept_uni().await?;
+    let mut buf = [0u8; 2];
+    assert_eq!(recv.read(&mut buf).await?, Some(2));
+
+    // The peer sends nothing more and never finishes the stream, so every read parks.
+    let retained = abandon!(recv.read(&mut buf));
+    assert_eq!(retained, 0, "{retained} abandoned reads are still parked");
+
+    client.close(0, "bye");
+    Ok(())
+}
+
+/// The accept queue's own list, on a connection where no stream ever arrives.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_accepts_release_their_wakers() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    let retained = abandon!(server.accept_uni());
+    assert_eq!(retained, 0, "{retained} abandoned accepts are still parked");
+
+    client.close(0, "bye");
+    Ok(())
+}
+
+/// Waiting on the connection registers with the same list, and a caller that stops
+/// waiting must release its slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_datagram_reads_release_their_wakers() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    let retained = abandon!(server.read_datagram());
+    assert_eq!(
+        retained, 0,
+        "{retained} abandoned datagram reads are still parked"
+    );
+
+    client.close(0, "bye");
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/ez_wakers.rs
+++ b/rs/web-transport-quiche/tests/ez_wakers.rs
@@ -17,14 +17,17 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    task::{Context, Wake, Waker},
+    task::{Context, Poll, Wake, Waker},
     time::Duration,
 };
 
 use anyhow::{Context as _, Result};
 use rcgen::{CertifiedKey, KeyPair};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-use tokio::time::timeout;
+use tokio::{
+    io::{AsyncRead, ReadBuf},
+    time::timeout,
+};
 use web_transport_quiche::ez;
 
 /// How many callers give up, one after another. Well past any plausible bound on
@@ -184,6 +187,52 @@ async fn abandoned_datagram_reads_release_their_wakers() -> Result<()> {
     assert_eq!(
         retained, 0,
         "{retained} abandoned datagram reads are still parked"
+    );
+
+    client.close(0, "bye");
+    Ok(())
+}
+
+/// The other half of the rule: a poll that *finishes* must not keep the poller's waker
+/// either. The bridge retains a waiter so its registrations survive a `Pending`; holding
+/// it past a `Ready` would pin the polling task's allocation to the stream until
+/// something polled it again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_finished_read_releases_the_poller() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"done").await?;
+
+    let mut recv = server.accept_uni().await?;
+
+    // Read through `AsyncRead`, which is the surface that has to bridge a `Context`.
+    let flag = Arc::new(FlagWaker::default());
+    let waker = Waker::from(flag.clone());
+    let mut dst = [0u8; 16];
+    let mut buf = ReadBuf::new(&mut dst);
+
+    loop {
+        let read =
+            std::pin::Pin::new(&mut recv).poll_read(&mut Context::from_waker(&waker), &mut buf);
+        match read {
+            Poll::Ready(res) => {
+                res?;
+                break;
+            }
+            // Not arrived yet: yield and retry, so the tracked waker is the one that
+            // completes the read rather than one left parked.
+            Poll::Pending => tokio::task::yield_now().await,
+        }
+    }
+    assert_eq!(buf.filled(), b"done");
+
+    // The test's own `Waker` counts too, so it goes first.
+    drop(waker);
+    assert_eq!(
+        Arc::strong_count(&flag),
+        1,
+        "the finished read is still holding the poller's waker"
     );
 
     client.close(0, "bye");

--- a/rs/web-transport-quiche/tests/ez_wakers.rs
+++ b/rs/web-transport-quiche/tests/ez_wakers.rs
@@ -201,16 +201,29 @@ async fn abandoned_datagram_reads_release_their_wakers() -> Result<()> {
 async fn a_finished_read_releases_the_poller() -> Result<()> {
     let (client, server) = pair().await?;
 
+    // An opening byte, so the stream reaches the peer and can be accepted.
     let mut send = client.open_uni().await?;
-    send.write_all(b"done").await?;
+    send.write_all(b"hi").await?;
 
     let mut recv = server.accept_uni().await?;
+    let mut drained = [0u8; 2];
+    assert_eq!(recv.read(&mut drained).await?, Some(2));
 
     // Read through `AsyncRead`, which is the surface that has to bridge a `Context`.
     let flag = Arc::new(FlagWaker::default());
     let waker = Waker::from(flag.clone());
     let mut dst = [0u8; 16];
     let mut buf = ReadBuf::new(&mut dst);
+
+    // Park first, so the waiter this poll retains is the one the `Ready` below has to
+    // let go of. Nothing more has been sent and the stream is open, so this cannot be
+    // ready yet.
+    assert!(std::pin::Pin::new(&mut recv)
+        .poll_read(&mut Context::from_waker(&waker), &mut buf)
+        .is_pending());
+    assert!(buf.filled().is_empty());
+
+    send.write_all(b"done").await?;
 
     loop {
         let read =

--- a/rs/web-transport-quiche/tests/ez_wakers.rs
+++ b/rs/web-transport-quiche/tests/ez_wakers.rs
@@ -238,3 +238,78 @@ async fn a_finished_read_releases_the_poller() -> Result<()> {
     client.close(0, "bye");
     Ok(())
 }
+
+/// Teardown must wake outside the driver lock.
+///
+/// The driver settles the connection error under the state lock, and the same lock is
+/// the first thing a resumed task reaches for. Waking underneath it deadlocks the driver
+/// mid-teardown, which strands the close and everything parked on it.
+///
+/// The probe never blocks the driver: it hands the lock attempt to a scratch thread and
+/// gives up after a moment, so a regression fails this test instead of wedging the
+/// runtime — a worker stuck on a `std` mutex would outlive any timeout, because dropping
+/// the runtime waits for it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn teardown_wakes_outside_the_driver_lock() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    struct Probe {
+        conn: ez::Connection,
+        woken: AtomicBool,
+        locked_out: AtomicBool,
+    }
+
+    impl Wake for Probe {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            // What a resumed task does first, on a thread of its own so that a driver
+            // still holding the lock stalls the probe rather than itself.
+            let conn = self.conn.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let _ = conn.is_closed();
+                let _ = tx.send(());
+            });
+
+            let held = rx.recv_timeout(Duration::from_secs(2)).is_err();
+            self.locked_out.store(held, Ordering::SeqCst);
+            self.woken.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let probe = Arc::new(Probe {
+        conn: server.clone(),
+        woken: AtomicBool::new(false),
+        locked_out: AtomicBool::new(false),
+    });
+    let waker = Waker::from(probe.clone());
+
+    // Parks on the datagram queue and, through it, on the connection-closed lists that
+    // teardown wakes. Held for the rest of the test: the registration is weak.
+    let mut parked = std::pin::pin!(server.read_datagram());
+    assert!(parked
+        .as_mut()
+        .poll(&mut Context::from_waker(&waker))
+        .is_pending());
+
+    // The peer goes away, so the driver runs its teardown and wakes what is parked.
+    client.close(0, "bye");
+
+    timeout(Duration::from_secs(10), async {
+        while !probe.woken.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("teardown never woke the parked reader")?;
+
+    assert!(
+        !probe.locked_out.load(Ordering::SeqCst),
+        "teardown woke a parked reader while still holding the driver lock"
+    );
+
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/poll.rs
+++ b/rs/web-transport-quiche/tests/poll.rs
@@ -8,6 +8,11 @@
 use std::{
     future::poll_fn,
     net::{Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll, Wake, Waker},
 };
 
 use anyhow::{Context as _, Result};
@@ -120,6 +125,69 @@ async fn datagrams_round_trip_through_the_poll_surface() -> Result<()> {
 
     let received = poll_fn(|cx| server.poll_recv_datagram(cx)).await?;
     assert_eq!(&received[..], b"dgram");
+
+    Ok(())
+}
+
+/// A waker whose `Arc` count the test watches: anything still holding a clone is
+/// retaining this allocation. Not `Waker::noop`, which is a static and so cannot be
+/// counted.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
+/// A poll that finishes must not keep the poller's waker.
+///
+/// The bridge from `Context` to a `kio::Waiter` has to retain the waiter while a poll is
+/// pending, or the registration it made dies with the poll. Retaining it past a `Ready`
+/// is a different thing entirely: the stream is done with that caller, but goes on
+/// holding its waker — and so the polling task's allocation — until something polls it
+/// again. A stream whose last read completed and then sat idle would hold one for the
+/// rest of the connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_finished_poll_releases_the_poller() -> Result<()> {
+    let (mut client, mut server) = pair().await?;
+
+    let mut send = poll_fn(|cx| client.poll_open_uni(cx)).await?;
+    poll_fn(|cx| send.poll_write(cx, b"done")).await?;
+
+    let mut recv = poll_fn(|cx| server.poll_accept_uni(cx)).await?;
+
+    // Poll until the read is ready, tracking only the waker that sees it through.
+    let mut dst = [0u8; 16];
+    let flag = Arc::new(FlagWaker::default());
+    let waker = Waker::from(flag.clone());
+
+    loop {
+        match recv.poll_read(&mut Context::from_waker(&waker), &mut dst) {
+            Poll::Ready(res) => {
+                assert_eq!(res?.context("stream ended early")?, 4);
+                break;
+            }
+            // Not arrived yet: yield and retry, so the tracked waker is the one that
+            // completes the read rather than one left parked.
+            Poll::Pending => tokio::task::yield_now().await,
+        }
+    }
+
+    // The test's own `Waker` counts too, so it goes first.
+    drop(waker);
+    assert_eq!(
+        Arc::strong_count(&flag),
+        1,
+        "the finished read is still holding the poller's waker"
+    );
 
     Ok(())
 }

--- a/rs/web-transport-quiche/tests/poll.rs
+++ b/rs/web-transport-quiche/tests/poll.rs
@@ -159,15 +159,32 @@ impl Wake for FlagWaker {
 async fn a_finished_poll_releases_the_poller() -> Result<()> {
     let (mut client, mut server) = pair().await?;
 
+    // An opening byte, so the stream reaches the peer and can be accepted.
     let mut send = poll_fn(|cx| client.poll_open_uni(cx)).await?;
-    poll_fn(|cx| send.poll_write(cx, b"done")).await?;
+    poll_fn(|cx| send.poll_write(cx, b"hi")).await?;
 
     let mut recv = poll_fn(|cx| server.poll_accept_uni(cx)).await?;
+    let mut drained = [0u8; 2];
+    assert_eq!(
+        poll_fn(|cx| recv.poll_read(cx, &mut drained))
+            .await?
+            .context("stream ended early")?,
+        2
+    );
 
     // Poll until the read is ready, tracking only the waker that sees it through.
     let mut dst = [0u8; 16];
     let flag = Arc::new(FlagWaker::default());
     let waker = Waker::from(flag.clone());
+
+    // Park first, so the waiter this poll retains is the one the `Ready` below has to
+    // let go of. Nothing more has been sent and the stream is open, so this cannot be
+    // ready yet.
+    assert!(recv
+        .poll_read(&mut Context::from_waker(&waker), &mut dst)
+        .is_pending());
+
+    poll_fn(|cx| send.poll_write(cx, b"done")).await?;
 
     loop {
         match recv.poll_read(&mut Context::from_waker(&waker), &mut dst) {

--- a/rs/web-transport-quinn/Cargo.toml
+++ b/rs/web-transport-quinn/Cargo.toml
@@ -26,6 +26,7 @@ qlog = ["quinn/qlog"]
 bytes = "1"
 futures = "0.3"
 http = "1"
+kio = "0.5.2"
 
 quinn = { version = "0.11", default-features = false, features = [
     "platform-verifier",

--- a/rs/web-transport-quinn/src/lib.rs
+++ b/rs/web-transport-quinn/src/lib.rs
@@ -31,6 +31,7 @@ mod recv;
 mod send;
 mod server;
 mod session;
+mod waiters;
 
 pub use client::*;
 pub use error::*;
@@ -60,6 +61,10 @@ pub use quinn;
 
 /// Re-export the http crate because it's in the public API.
 pub use http;
+
+/// Re-export kio, whose [`Waiter`](kio::Waiter) is how a caller of
+/// [`SessionAccept`]'s poll methods holds its place in the accept queue.
+pub use kio;
 
 /// Re-export the generic WebTransport implementation.
 pub use web_transport_trait as generic;

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    future::{poll_fn, Future},
+    future::Future,
     io::Cursor,
     ops::Deref,
     pin::Pin,
@@ -11,9 +11,11 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use futures::stream::{FuturesUnordered, Stream, StreamExt};
+use kio::Waiter;
 
 use crate::{
     proto::{ConnectRequest, ConnectResponse, Frame, StreamUni, VarInt},
+    waiters::{AcceptWaiters, Parked},
     ClientError, Connected, RecvStream, SendStream, SessionError, Settings, WebTransportError,
 };
 
@@ -74,6 +76,12 @@ pub struct Session {
     op_send_datagram: crate::op::Op<Result<(), SessionError>>,
     op_recv_datagram: crate::op::Op<Result<Bytes, SessionError>>,
     op_closed: crate::op::Op<SessionError>,
+
+    // `SessionAccept` holds its waiters weakly, so the handle this clone registered
+    // with has to outlive the poll that made it. Per-clone, for the same reason as the
+    // ops above.
+    parked_accept_uni: Parked,
+    parked_accept_bi: Parked,
 }
 
 impl Session {
@@ -117,6 +125,8 @@ impl Session {
             op_send_datagram: Default::default(),
             op_recv_datagram: Default::default(),
             op_closed: Default::default(),
+            parked_accept_uni: Default::default(),
+            parked_accept_bi: Default::default(),
         };
 
         // Run a background task to read capsules from the CONNECT recv stream.
@@ -208,7 +218,9 @@ impl Session {
     /// Accept a new unidirectional stream. See [`quinn::Connection::accept_uni`].
     pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_uni(cx))
+            // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
+            // expires, say — also drops its registration in `SessionAccept`.
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -224,7 +236,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`quinn::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            poll_fn(|cx| accept.lock().unwrap().poll_accept_bi(cx))
+            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -510,6 +522,8 @@ impl Session {
             op_send_datagram: Default::default(),
             op_recv_datagram: Default::default(),
             op_closed: Default::default(),
+            parked_accept_uni: Default::default(),
+            parked_accept_bi: Default::default(),
             settings: None,
             connect_send: Arc::new(Mutex::new(None)),
             error: Arc::new(OnceLock::new()),
@@ -584,11 +598,18 @@ pub struct SessionAccept {
     pending_uni: FuturesUnordered<Pin<Box<PendingUni>>>,
     pending_bi: FuturesUnordered<Pin<Box<PendingBi>>>,
 
-    // Wakers from concurrent callers of accept_bi / accept_uni.
-    // When one caller gets a stream, all others are woken so they can retry.
-    // This fixes the lost-waker bug where the unfold stream only stores one waker.
-    bi_wakers: Vec<Waker>,
-    uni_wakers: Vec<Waker>,
+    // Waiters from concurrent callers of accept_bi / accept_uni.
+    // Every clone of the session polls this one struct, so an arrival has to be fanned
+    // out: each caller registers here and all of them are woken when a stream lands.
+    bi_waiters: Arc<AcceptWaiters>,
+    uni_waiters: Arc<AcceptWaiters>,
+
+    // `Waker::from(waiters.clone())`, cached so Quinn's accept futures are polled with
+    // the same waker every time. That waker outlives every caller, so an accepter that
+    // drops its future cannot take the wakeup path with it, and Quinn holds one
+    // registration rather than one per caller.
+    bi_waker: Waker,
+    uni_waker: Waker,
 }
 
 impl SessionAccept {
@@ -606,6 +627,11 @@ impl SessionAccept {
             Some((conn.accept_bi().await, conn))
         }));
 
+        let bi_waiters = Arc::new(AcceptWaiters::default());
+        let uni_waiters = Arc::new(AcceptWaiters::default());
+        let bi_waker = Waker::from(bi_waiters.clone());
+        let uni_waker = Waker::from(uni_waiters.clone());
+
         Self {
             session_id,
             error,
@@ -619,18 +645,25 @@ impl SessionAccept {
             pending_uni: FuturesUnordered::new(),
             pending_bi: FuturesUnordered::new(),
 
-            bi_wakers: Vec::new(),
-            uni_wakers: Vec::new(),
+            bi_waiters,
+            uni_waiters,
+            bi_waker,
+            uni_waker,
         }
     }
 
     // This is poll-based because we accept and decode streams in parallel.
     // In async land I would use tokio::JoinSet, but that requires a runtime.
     // It's better to use FuturesUnordered instead because it's agnostic.
-    pub fn poll_accept_uni(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<RecvStream, SessionError>> {
+    pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
+        // Register before polling, not on the way out: the shared waker can fire from
+        // Quinn's driver at any point below, and a wake that lands before the caller is
+        // on the list would be lost.
+        self.uni_waiters.register(waiter);
+
+        let waker = self.uni_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_uni.poll_next_unpin(cx) {
@@ -638,9 +671,7 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        for waker in self.uni_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -658,21 +689,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode unidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.uni_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.uni_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             // Decide if we keep looping based on the type.
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv, self.error.clone());
-                    for waker in self.uni_wakers.drain(..) {
-                        waker.wake();
-                    }
+                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -716,8 +740,14 @@ impl SessionAccept {
 
     pub fn poll_accept_bi(
         &mut self,
-        cx: &mut Context<'_>,
+        waiter: &Waiter,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+        // Register before polling; see `poll_accept_uni`.
+        self.bi_waiters.register(waiter);
+
+        let waker = self.bi_waker.clone();
+        let cx = &mut Context::from_waker(&waker);
+
         loop {
             // Accept any new streams.
             if let Poll::Ready(Some(res)) = self.accept_bi.poll_next_unpin(cx) {
@@ -725,9 +755,7 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        for waker in self.bi_wakers.drain(..) {
-                            waker.wake();
-                        }
+                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -745,21 +773,14 @@ impl SessionAccept {
                     tracing::warn!(?err, "failed to decode bidirectional stream");
                     continue;
                 }
-                Poll::Ready(None) | Poll::Pending => {
-                    if !self.bi_wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                        self.bi_wakers.push(cx.waker().clone());
-                    }
-                    return Poll::Pending;
-                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Pending,
             };
 
             if let Some((send, recv)) = res {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send, self.error.clone());
                 let recv = RecvStream::new(recv, self.error.clone());
-                for waker in self.bi_wakers.drain(..) {
-                    waker.wake();
-                }
+                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 
@@ -1005,11 +1026,12 @@ impl web_transport_trait::poll::Session for Session {
     type RecvStream = RecvStream;
     type Error = SessionError;
 
-    // Accept forwards natively: `SessionAccept` already drives a persistent stream
-    // and keeps a waker list, so there is nothing to retain here.
+    // Accept forwards natively: `SessionAccept` already drives a persistent stream and
+    // keeps a waiter list, so the only thing to retain is our registration in it.
     fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
         if let Some(accept) = self.accept.clone() {
-            return accept.lock().unwrap().poll_accept_uni(cx);
+            let waiter = self.parked_accept_uni.hold(cx);
+            return accept.lock().unwrap().poll_accept_uni(waiter);
         }
 
         let conn = self.conn.clone();
@@ -1029,7 +1051,8 @@ impl web_transport_trait::poll::Session for Session {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
         if let Some(accept) = self.accept.clone() {
-            return accept.lock().unwrap().poll_accept_bi(cx);
+            let waiter = self.parked_accept_bi.hold(cx);
+            return accept.lock().unwrap().poll_accept_bi(waiter);
         }
 
         let conn = self.conn.clone();

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -696,9 +696,20 @@ impl SessionAccept {
         }
     }
 
-    // This is poll-based because we accept and decode streams in parallel.
-    // In async land I would use tokio::JoinSet, but that requires a runtime.
-    // It's better to use FuturesUnordered instead because it's agnostic.
+    /// Poll for the next unidirectional WebTransport stream.
+    ///
+    /// `waiter` is parked until a stream arrives, the accept fails, or the caller drops
+    /// it. The registration is weak and owned by the caller: keep the [`Waiter`] alive
+    /// until it is woken, or it will be reclaimed and nothing will wake you. Drive this
+    /// with [`kio::wait`], which holds the waiter inside the future it builds.
+    ///
+    /// A `Ready` here means every *other* parked accepter should be woken so it can
+    /// retry. This does not do that itself — see `poll_accept_uni_shared`, which wakes
+    /// them once the lock on this struct is released.
+    //
+    // Poll-based because we accept and decode streams in parallel. In async land this
+    // would be a `tokio::JoinSet`, but that needs a runtime; `FuturesUnordered` is
+    // runtime-agnostic.
     pub fn poll_accept_uni(&mut self, waiter: &Waiter) -> Poll<Result<RecvStream, SessionError>> {
         // Register before polling, not on the way out: the shared waker can fire from
         // Quinn's driver at any point below, and a wake that lands before the caller is
@@ -780,6 +791,11 @@ impl SessionAccept {
         Ok((typ, recv))
     }
 
+    /// Poll for the next bidirectional WebTransport stream.
+    ///
+    /// The same contract as [`poll_accept_uni`](Self::poll_accept_uni): the `waiter`
+    /// registration is weak and owned by the caller, and a `Ready` is what the other
+    /// parked accepters need to be woken for.
     pub fn poll_accept_bi(
         &mut self,
         waiter: &Waiter,

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -220,7 +220,7 @@ impl Session {
         if let Some(accept) = &self.accept {
             // `kio::wait` owns the waiter, so dropping this future — a `timeout` that
             // expires, say — also drops its registration in `SessionAccept`.
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_uni(waiter))
+            kio::wait(|waiter| poll_accept_uni_shared(accept, waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -236,7 +236,7 @@ impl Session {
     /// Accept a new bidirectional stream. See [`quinn::Connection::accept_bi`].
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), SessionError> {
         if let Some(accept) = &self.accept {
-            kio::wait(|waiter| accept.lock().unwrap().poll_accept_bi(waiter))
+            kio::wait(|waiter| poll_accept_bi_shared(accept, waiter))
                 .await
                 .map_err(|e| self.map_error(e))
         } else {
@@ -571,6 +571,49 @@ impl PartialEq for Session {
 
 impl Eq for Session {}
 
+// Poll the shared accept state, then wake the *other* accepters once the lock is
+// released.
+//
+// `SessionAccept` does not wake them itself: a waker is free to resume its task
+// inline, and the first thing a resumed accepter does is take this same lock. An
+// arrival or a failure is exactly what the others are parked waiting to retry
+// after, so `Ready` is the signal.
+fn poll_accept_uni_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<RecvStream, SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_uni(waiter);
+        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
+fn poll_accept_bi_shared(
+    accept: &Mutex<SessionAccept>,
+    waiter: &Waiter,
+) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
+    let (result, waiters) = {
+        let mut accept = accept.lock().unwrap();
+        let result = accept.poll_accept_bi(waiter);
+        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+        (result, waiters)
+    };
+
+    if let Some(waiters) = waiters {
+        waiters.wake_all();
+    }
+
+    result
+}
+
 // Type aliases just so clippy doesn't complain about the complexity.
 type AcceptUni = dyn Stream<Item = Result<quinn::RecvStream, quinn::ConnectionError>> + Send;
 type AcceptBi = dyn Stream<Item = Result<(quinn::SendStream, quinn::RecvStream), quinn::ConnectionError>>
@@ -600,7 +643,8 @@ pub struct SessionAccept {
 
     // Waiters from concurrent callers of accept_bi / accept_uni.
     // Every clone of the session polls this one struct, so an arrival has to be fanned
-    // out: each caller registers here and all of them are woken when a stream lands.
+    // out: each caller registers here and all of them are woken when a stream lands —
+    // by the caller that saw it, once it has released the lock on this struct.
     bi_waiters: Arc<AcceptWaiters>,
     uni_waiters: Arc<AcceptWaiters>,
 
@@ -671,7 +715,6 @@ impl SessionAccept {
                 let recv = match res {
                     Ok(recv) => recv,
                     Err(e) => {
-                        self.uni_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -696,7 +739,6 @@ impl SessionAccept {
             match typ {
                 StreamUni::WEBTRANSPORT => {
                     let recv = RecvStream::new(recv, self.error.clone());
-                    self.uni_waiters.wake_all();
                     return Poll::Ready(Ok(recv));
                 }
                 StreamUni::QPACK_DECODER => {
@@ -755,7 +797,6 @@ impl SessionAccept {
                 let (send, recv) = match res {
                     Ok(pair) => pair,
                     Err(e) => {
-                        self.bi_waiters.wake_all();
                         return Poll::Ready(Err(e.into()));
                     }
                 };
@@ -780,7 +821,6 @@ impl SessionAccept {
                 // Wrap the streams in our own types for correct error codes.
                 let send = SendStream::new(send, self.error.clone());
                 let recv = RecvStream::new(recv, self.error.clone());
-                self.bi_waiters.wake_all();
                 return Poll::Ready(Ok((send, recv)));
             }
 
@@ -1032,7 +1072,7 @@ impl web_transport_trait::poll::Session for Session {
         if let Some(accept) = self.accept.clone() {
             return self
                 .parked_accept_uni
-                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_uni(waiter));
+                .poll(cx, |waiter| poll_accept_uni_shared(&accept, waiter));
         }
 
         let conn = self.conn.clone();
@@ -1054,7 +1094,7 @@ impl web_transport_trait::poll::Session for Session {
         if let Some(accept) = self.accept.clone() {
             return self
                 .parked_accept_bi
-                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_bi(waiter));
+                .poll(cx, |waiter| poll_accept_bi_shared(&accept, waiter));
         }
 
         let conn = self.conn.clone();

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -584,12 +584,18 @@ fn poll_accept_uni_shared(
 ) -> Poll<Result<RecvStream, SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.uni_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_uni(waiter);
-        let waiters = result.is_ready().then(|| accept.uni_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 
@@ -602,12 +608,18 @@ fn poll_accept_bi_shared(
 ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
     let (result, waiters) = {
         let mut accept = accept.lock().unwrap();
+        let waiters = accept.bi_waiters.clone();
+
+        // The poll below drives the shared accept futures with this list's waker, and
+        // one of them may wake it inline. Hold those back until the lock is gone.
+        waiters.arm();
         let result = accept.poll_accept_bi(waiter);
-        let waiters = result.is_ready().then(|| accept.bi_waiters.clone());
+
         (result, waiters)
     };
 
-    if let Some(waiters) = waiters {
+    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
 

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -594,7 +594,7 @@ fn poll_accept_uni_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }
@@ -618,7 +618,7 @@ fn poll_accept_bi_shared(
         (result, waiters)
     };
 
-    // `disarm` runs first either way: it has to clear the flag even on a `Ready`.
+    // `disarm` runs first either way: the count has to come down even on a `Ready`.
     if waiters.disarm() || result.is_ready() {
         waiters.wake_all();
     }

--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -1030,8 +1030,9 @@ impl web_transport_trait::poll::Session for Session {
     // keeps a waiter list, so the only thing to retain is our registration in it.
     fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
         if let Some(accept) = self.accept.clone() {
-            let waiter = self.parked_accept_uni.hold(cx);
-            return accept.lock().unwrap().poll_accept_uni(waiter);
+            return self
+                .parked_accept_uni
+                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_uni(waiter));
         }
 
         let conn = self.conn.clone();
@@ -1051,8 +1052,9 @@ impl web_transport_trait::poll::Session for Session {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), SessionError>> {
         if let Some(accept) = self.accept.clone() {
-            let waiter = self.parked_accept_bi.hold(cx);
-            return accept.lock().unwrap().poll_accept_bi(waiter);
+            return self
+                .parked_accept_bi
+                .poll(cx, |waiter| accept.lock().unwrap().poll_accept_bi(waiter));
         }
 
         let conn = self.conn.clone();

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -1,0 +1,103 @@
+//! Who is waiting on a shared accept, and how they are woken.
+//!
+//! [`SessionAccept`](crate::SessionAccept) is shared by every clone of a session, so it
+//! has to fan a single arrival out to every accepter parked on it — without holding on
+//! to accepters that walk away, which is what the weak registrations in
+//! [`kio::WaiterList`] are for.
+//!
+//! [`AcceptWaiters`] is the list, plus the waker the shared accept futures are polled
+//! with. [`Parked`] is the caller's end of a registration in that list, for a caller
+//! that only has a `Context` to work with.
+
+use std::{
+    sync::{Arc, Mutex},
+    task::{Context, Wake},
+};
+
+use kio::{Waiter, WaiterList};
+
+/// The accepters parked on one direction, plus the waker that wakes all of them.
+///
+/// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
+/// this, not with the caller's. A caller's waker goes stale the moment it stops
+/// accepting: whoever polled last is the one the inner future holds, so if that caller
+/// drops its future the arrival wakes nobody while other accepters sit parked. This
+/// waker cannot go stale — it lives as long as the accept state — and waking it wakes
+/// everyone on the list.
+#[derive(Default)]
+pub(crate) struct AcceptWaiters {
+    // Held only to register or to wake, never across a poll of the inner futures, which
+    // take locks of their own further down.
+    waiters: Mutex<WaiterList>,
+}
+
+impl AcceptWaiters {
+    /// Park a caller until the next wake.
+    ///
+    /// Registrations are weak and owned by the caller, so an accepter that gives up — a
+    /// `timeout` around `accept_uni`, or a task that just drops the future — releases
+    /// its slot instead of leaving a waker parked here forever.
+    pub(crate) fn register(&self, waiter: &Waiter) {
+        waiter.register(&mut self.waiters.lock().unwrap());
+    }
+
+    /// Wake every parked accepter so it can retry.
+    pub(crate) fn wake_all(&self) {
+        self.waiters.lock().unwrap().wake();
+    }
+}
+
+impl Wake for AcceptWaiters {
+    fn wake(self: Arc<Self>) {
+        self.wake_all();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.wake_all();
+    }
+}
+
+/// A [`Waiter`] retained across `poll` calls.
+///
+/// A registration in [`AcceptWaiters`] stays live only while the caller holds the
+/// [`Waiter`] it registered, which is what lets a caller that walks away release its
+/// slot. So the handle has to live somewhere the *caller* owns, and a `poll_*` method is
+/// handed nothing but a `Context`. This is that somewhere: one cell per operation, held
+/// by whoever polls.
+///
+/// The `async` methods have no need for it — [`kio::wait`] keeps the waiter inside the
+/// future it builds, so dropping the future drops the registration.
+///
+/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); replace this
+/// with it once that releases. Its `hold` also *reuses* the waiter when the task is
+/// unchanged and every registration was already drained, which saves the allocation this
+/// one makes on each poll.
+#[derive(Default)]
+pub(crate) struct Parked {
+    waiter: Option<Waiter>,
+}
+
+impl Parked {
+    /// Adopt `cx`'s waker for this poll, retiring the previous handle and with it the
+    /// registration it left behind.
+    ///
+    /// Always replaces rather than reusing: [`WaiterList`] reclaims a slot only when the
+    /// `Waiter` that registered it dies, so re-registering a live one would stack a
+    /// duplicate entry on every spurious re-poll.
+    pub(crate) fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
+        self.waiter.insert(Waiter::new(cx.waker().clone()))
+    }
+}
+
+impl Clone for Parked {
+    /// A clone starts unregistered: a registration belongs to the handle that parked it.
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl std::fmt::Debug for Parked {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("Parked").finish_non_exhaustive()
+    }
+}

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -16,6 +16,18 @@ use std::{
 
 use kio::{Waiter, WaiterList};
 
+#[derive(Default)]
+struct AcceptState {
+    waiters: WaiterList,
+
+    /// A poll is holding the lock on the accept state, so a wake arriving now is
+    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
+    armed: bool,
+
+    /// A wake arrived while `armed`, and is owed to the list.
+    deferred: bool,
+}
+
 /// The accepters parked on one direction, plus the waker that wakes all of them.
 ///
 /// The shared accept futures are polled with a [`Waker`](std::task::Waker) made from
@@ -26,9 +38,7 @@ use kio::{Waiter, WaiterList};
 /// everyone on the list.
 #[derive(Default)]
 pub(crate) struct AcceptWaiters {
-    // Held only to register or to wake, never across a poll of the inner futures, which
-    // take locks of their own further down.
-    waiters: Mutex<WaiterList>,
+    state: Mutex<AcceptState>,
 }
 
 impl AcceptWaiters {
@@ -38,17 +48,49 @@ impl AcceptWaiters {
     /// `timeout` around `accept_uni`, or a task that just drops the future — releases
     /// its slot instead of leaving a waker parked here forever.
     pub(crate) fn register(&self, waiter: &Waiter) {
-        waiter.register(&mut self.waiters.lock().unwrap());
+        waiter.register(&mut self.state.lock().unwrap().waiters);
     }
 
-    /// Wake every parked accepter so it can retry.
+    /// Wake every parked accepter so it can retry, or record the wake while a poll is
+    /// [armed](Self::arm).
     ///
     /// The list is taken under the lock and woken outside it. A waker is free to resume
     /// its task inline, and the first thing a resumed accepter does is register here
     /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        let mut waiters = self.waiters.lock().unwrap().take();
+        let mut waiters = {
+            let mut state = self.state.lock().unwrap();
+            if state.armed {
+                state.deferred = true;
+                return;
+            }
+
+            state.waiters.take()
+        };
+
         waiters.wake();
+    }
+
+    /// Hold back wakes for the duration of a poll that holds the lock on the accept
+    /// state.
+    ///
+    /// That poll drives the shared accept futures with this list's waker, and one of
+    /// them may wake it *inline* — `FuturesUnordered`, for one, notifies its parent from
+    /// a child's `wake`. Delivering that would resume an accepter underneath the accept
+    /// lock, which it takes as its first move. So it is recorded instead, and
+    /// [`disarm`](Self::disarm) hands it back once the lock is gone.
+    pub(crate) fn arm(&self) {
+        self.state.lock().unwrap().armed = true;
+    }
+
+    /// Stop holding wakes back, reporting whether one arrived while armed.
+    ///
+    /// Only ever called with the accept lock released, and the caller owes the list a
+    /// [`wake_all`](Self::wake_all) when this returns true.
+    pub(crate) fn disarm(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.armed = false;
+        std::mem::take(&mut state.deferred)
     }
 
     /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
@@ -56,7 +98,7 @@ impl AcceptWaiters {
     /// entries. Panics rather than guessing if kio's format ever changes.
     #[cfg(test)]
     fn slots(&self) -> usize {
-        let list = format!("{:?}", self.waiters.lock().unwrap());
+        let list = format!("{:?}", self.state.lock().unwrap().waiters);
         list.rsplit_once("len: ")
             .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
             .expect("WaiterList Debug should report a length")
@@ -145,6 +187,28 @@ mod tests {
 
     use super::*;
 
+    /// Records whether it was woken.
+    #[derive(Default)]
+    struct Flag {
+        woken: std::sync::atomic::AtomicBool,
+    }
+
+    impl Flag {
+        fn woken(&self) -> bool {
+            self.woken.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl Wake for Flag {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.woken.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     /// A waker that re-enters the list from `wake`, standing in for an executor that
     /// polls a resumed task inline: the first thing a resumed accepter does is register
     /// itself again.
@@ -217,5 +281,38 @@ mod tests {
         );
 
         drop(held);
+    }
+
+    /// A wake that lands mid-poll is held until the accept lock is gone.
+    ///
+    /// The shared accept futures are driven with this list's waker while the poll holds
+    /// that lock, and an inner future can wake it inline. Delivering it there would
+    /// resume an accepter straight into the lock it is standing on.
+    #[test]
+    fn a_wake_during_a_poll_is_deferred() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm();
+        waiters.wake_all();
+        assert!(
+            !flag.woken(),
+            "the wake was delivered while the accept lock was held"
+        );
+
+        assert!(waiters.disarm(), "the deferred wake was dropped");
+        waiters.wake_all();
+        assert!(flag.woken(), "the deferred wake never arrived");
+    }
+
+    /// Nothing owed when nothing woke.
+    #[test]
+    fn disarming_a_quiet_poll_owes_no_wake() {
+        let waiters = AcceptWaiters::default();
+        waiters.arm();
+        assert!(!waiters.disarm());
     }
 }

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -11,7 +11,7 @@
 
 use std::{
     sync::{Arc, Mutex},
-    task::{Context, Wake},
+    task::{Context, Poll, Wake},
 };
 
 use kio::{Waiter, WaiterList};
@@ -68,24 +68,41 @@ impl Wake for AcceptWaiters {
 /// The `async` methods have no need for it — [`kio::wait`] keeps the waiter inside the
 /// future it builds, so dropping the future drops the registration.
 ///
-/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); replace this
-/// with it once that releases. Its `hold` also *reuses* the waiter when the task is
-/// unchanged and every registration was already drained, which saves the allocation this
-/// one makes on each poll.
+/// kio grew a `WaiterCell` for exactly this after 0.5.2 (moq-dev/moq#2560); this can go
+/// once that releases. Its `hold` also *reuses* the waiter when the task is unchanged and
+/// every registration was already drained, which saves the allocation this one makes on
+/// each poll — though it holds the waiter across a `Ready`, so keep retiring it here.
 #[derive(Default)]
 pub(crate) struct Parked {
     waiter: Option<Waiter>,
 }
 
 impl Parked {
-    /// Adopt `cx`'s waker for this poll, retiring the previous handle and with it the
-    /// registration it left behind.
+    /// Run one poll with a retained waiter.
     ///
-    /// Always replaces rather than reusing: [`WaiterList`] reclaims a slot only when the
-    /// `Waiter` that registered it dies, so re-registering a live one would stack a
-    /// duplicate entry on every spurious re-poll.
-    pub(crate) fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
-        self.waiter.insert(Waiter::new(cx.waker().clone()))
+    /// The waiter is kept only while the poll is `Pending`. On `Ready` there is nothing
+    /// left to wake, and holding the waker would pin the polling task's allocation until
+    /// something polled this cell again — for a stream that finished its last read and
+    /// then sat idle, that is the rest of the connection.
+    pub(crate) fn poll<T>(
+        &mut self,
+        cx: &mut Context<'_>,
+        poll: impl FnOnce(&Waiter) -> Poll<T>,
+    ) -> Poll<T> {
+        let waiter = Waiter::new(cx.waker().clone());
+        let result = poll(&waiter);
+        self.park(waiter, &result);
+        result
+    }
+
+    /// The two-step form of [`poll`](Self::poll), for a poll that needs `&mut self` of
+    /// the struct holding this cell while the waiter is alive — the borrow checker allows
+    /// only one of those at a time, so the closure form will not compile there. Build the
+    /// waiter from the `Context`, poll with it, then hand it here with the result.
+    pub(crate) fn park<T>(&mut self, waiter: Waiter, result: &Poll<T>) {
+        // Retiring the previous waiter *after* the poll matters: the new one is already
+        // registered by then, so there is no window with nothing registered.
+        self.waiter = result.is_pending().then_some(waiter);
     }
 }
 

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -42,8 +42,13 @@ impl AcceptWaiters {
     }
 
     /// Wake every parked accepter so it can retry.
+    ///
+    /// The list is taken under the lock and woken outside it. A waker is free to resume
+    /// its task inline, and the first thing a resumed accepter does is register here
+    /// again — waking underneath the lock would deadlock on this very mutex.
     pub(crate) fn wake_all(&self) {
-        self.waiters.lock().unwrap().wake();
+        let mut waiters = self.waiters.lock().unwrap().take();
+        waiters.wake();
     }
 }
 
@@ -116,5 +121,60 @@ impl Clone for Parked {
 impl std::fmt::Debug for Parked {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.debug_struct("Parked").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{mpsc, Weak},
+        thread,
+        time::Duration,
+    };
+
+    use super::*;
+
+    /// A waker that re-enters the list from `wake`, standing in for an executor that
+    /// polls a resumed task inline: the first thing a resumed accepter does is register
+    /// itself again.
+    struct Reentrant {
+        waiters: Weak<AcceptWaiters>,
+    }
+
+    impl Wake for Reentrant {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            if let Some(waiters) = self.waiters.upgrade() {
+                waiters.register(&Waiter::new(std::task::Waker::noop().clone()));
+            }
+        }
+    }
+
+    #[test]
+    fn waking_does_not_hold_the_lock() {
+        let waiters = Arc::new(AcceptWaiters::default());
+        let inline = Arc::new(Reentrant {
+            waiters: Arc::downgrade(&waiters),
+        });
+
+        // Kept alive for the whole test: the registration dies with it.
+        let waiter = Waiter::new(std::task::Waker::from(inline));
+        waiters.register(&waiter);
+
+        // On a deadlock this thread never finishes, so the test cannot hang.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn({
+            let waiters = waiters.clone();
+            move || {
+                waiters.wake_all();
+                let _ = tx.send(());
+            }
+        });
+
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
     }
 }

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -20,9 +20,13 @@ use kio::{Waiter, WaiterList};
 struct AcceptState {
     waiters: WaiterList,
 
-    /// A poll is holding the lock on the accept state, so a wake arriving now is
-    /// recorded rather than delivered. See [`AcceptWaiters::arm`].
-    armed: bool,
+    /// How many polls are holding the lock on the accept state. While this is non-zero
+    /// a wake is recorded rather than delivered. See [`AcceptWaiters::arm`].
+    ///
+    /// A count, not a flag: one poll releases the accept lock before it disarms, so
+    /// another can be armed and mid-poll by then, and a flag would let the first one
+    /// clear the second's protection.
+    armed: usize,
 
     /// A wake arrived while `armed`, and is owed to the list.
     deferred: bool,
@@ -60,7 +64,7 @@ impl AcceptWaiters {
     pub(crate) fn wake_all(&self) {
         let mut waiters = {
             let mut state = self.state.lock().unwrap();
-            if state.armed {
+            if state.armed > 0 {
                 state.deferred = true;
                 return;
             }
@@ -80,16 +84,23 @@ impl AcceptWaiters {
     /// lock, which it takes as its first move. So it is recorded instead, and
     /// [`disarm`](Self::disarm) hands it back once the lock is gone.
     pub(crate) fn arm(&self) {
-        self.state.lock().unwrap().armed = true;
+        self.state.lock().unwrap().armed += 1;
     }
 
-    /// Stop holding wakes back, reporting whether one arrived while armed.
+    /// Stop holding wakes back, reporting whether one arrived and is this caller's to
+    /// deliver.
     ///
     /// Only ever called with the accept lock released, and the caller owes the list a
-    /// [`wake_all`](Self::wake_all) when this returns true.
+    /// [`wake_all`](Self::wake_all) when this returns true. False while another poll is
+    /// still armed: a deferred wake stays owed until the last one leaves, and that one
+    /// delivers it.
     pub(crate) fn disarm(&self) -> bool {
         let mut state = self.state.lock().unwrap();
-        state.armed = false;
+        state.armed = state.armed.saturating_sub(1);
+        if state.armed > 0 {
+            return false;
+        }
+
         std::mem::take(&mut state.deferred)
     }
 
@@ -314,5 +325,31 @@ mod tests {
         let waiters = AcceptWaiters::default();
         waiters.arm();
         assert!(!waiters.disarm());
+    }
+
+    /// One poll releasing the accept lock must not drop another's protection.
+    ///
+    /// The lock is released before `disarm`, so a second poll can be armed and running
+    /// by then. With a flag instead of a count, the first one leaving would expose the
+    /// second to exactly the inline wake this is here to prevent.
+    #[test]
+    fn overlapping_polls_stay_armed_until_the_last_one_leaves() {
+        let waiters = AcceptWaiters::default();
+
+        let flag = Arc::new(Flag::default());
+        let waiter = Waiter::new(std::task::Waker::from(flag.clone()));
+        waiters.register(&waiter);
+
+        waiters.arm(); // first poll
+        waiters.arm(); // second poll, overlapping
+
+        assert!(!waiters.disarm(), "the first out does not own the wake");
+
+        waiters.wake_all();
+        assert!(!flag.woken(), "a poll is still holding the accept lock");
+
+        assert!(waiters.disarm(), "the last one out owes the deferred wake");
+        waiters.wake_all();
+        assert!(flag.woken());
     }
 }

--- a/rs/web-transport-quinn/src/waiters.rs
+++ b/rs/web-transport-quinn/src/waiters.rs
@@ -50,6 +50,17 @@ impl AcceptWaiters {
         let mut waiters = self.waiters.lock().unwrap().take();
         waiters.wake();
     }
+
+    /// How many slots the list is holding, read out of its `Debug` — [`WaiterList`]
+    /// exposes no length, and the test below has to see that repeated polls do not stack
+    /// entries. Panics rather than guessing if kio's format ever changes.
+    #[cfg(test)]
+    fn slots(&self) -> usize {
+        let list = format!("{:?}", self.waiters.lock().unwrap());
+        list.rsplit_once("len: ")
+            .and_then(|(_, len)| len.trim_end_matches(&[' ', '}'][..]).parse().ok())
+            .expect("WaiterList Debug should report a length")
+    }
 }
 
 impl Wake for AcceptWaiters {
@@ -176,5 +187,35 @@ mod tests {
 
         rx.recv_timeout(Duration::from_secs(5))
             .expect("wake_all woke a waker while holding the lock, and the wake re-entered it");
+    }
+
+    /// Repeated polls must not stack registrations.
+    ///
+    /// Both routes in build a fresh `Waiter` per poll and drop the previous one — kio's
+    /// `wait` for the `async` methods, the `Context` bridge for the `poll_*` ones — so
+    /// the list reclaims the dead slot instead of growing. A bridge that reused a *live*
+    /// waiter would add an entry on every re-poll, which is the trap `kio::WaiterCell`
+    /// warns about, and this is the guard for whatever ends up replacing that bridge.
+    #[test]
+    fn repeated_polls_do_not_stack_registrations() {
+        let waiters = AcceptWaiters::default();
+
+        // Retained across iterations exactly as a poll bridge retains it: assigning the
+        // next one drops the previous, killing the registration it left behind.
+        let mut held = None;
+
+        for _ in 0..100 {
+            let waiter = Waiter::new(std::task::Waker::noop().clone());
+            waiters.register(&waiter);
+            held = Some(waiter);
+        }
+
+        assert!(
+            waiters.slots() <= 2,
+            "100 polls left {} registrations behind",
+            waiters.slots()
+        );
+
+        drop(held);
     }
 }

--- a/rs/web-transport-quinn/tests/accept_wakers.rs
+++ b/rs/web-transport-quinn/tests/accept_wakers.rs
@@ -1,0 +1,228 @@
+//! Accepters come and go; the accept queue must not leak them or lose them.
+//!
+//! `SessionAccept` keeps a list of parked accepters so that every one of them is woken
+//! when a stream arrives. That list used to be a `Vec<Waker>` with no way to say "I'm
+//! gone", cleared only by a stream arriving or the connection failing, so a caller that
+//! started an accept and dropped the future — a `tokio::time::timeout` around
+//! `accept_uni()`, say — left its waker there forever. Distinct tasks doing that on a
+//! quiet connection grew the list without bound, retaining a task allocation apiece.
+//!
+//! The wake path had the mirror-image problem: the inner accept future was polled with
+//! the caller's waker, so the last caller to poll owned the only path an arrival had
+//! back into this crate. When that caller walked away, the accepters still parked here
+//! were never woken.
+
+use std::{
+    future::Future,
+    net::Ipv4Addr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Wake, Waker},
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use tokio::time::timeout;
+use web_transport_proto::ConnectRequest;
+use web_transport_quinn::quinn::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+use web_transport_quinn::{ClientBuilder, ServerBuilder};
+
+/// How many accepters give up, one after another. Well past any plausible bound on
+/// concurrent accepters, so a list that keeps every registration is obvious.
+const ABANDONED: usize = 256;
+
+/// A waker that records whether it was woken. The test also watches its `Arc` count:
+/// anything still holding a clone of the waker is retaining this allocation.
+#[derive(Default)]
+struct FlagWaker {
+    woken: AtomicBool,
+}
+
+impl FlagWaker {
+    fn woken(&self) -> bool {
+        self.woken.load(Ordering::SeqCst)
+    }
+}
+
+impl Wake for FlagWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
+/// With both crypto features enabled — as `--all-features` does — the crate cannot
+/// pick a provider for us, so the test installs one.
+fn install_crypto_provider() {
+    #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+    {
+        let _ = web_transport_quinn::quinn::rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
+    }
+}
+
+/// A client and server session, already connected.
+async fn pair() -> Result<(web_transport_quinn::Session, web_transport_quinn::Session)> {
+    install_crypto_provider();
+
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])?;
+    let chain = vec![cert.der().clone()];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
+
+    let mut server = ServerBuilder::new()
+        .with_addr((Ipv4Addr::LOCALHOST, 0).into())
+        .with_certificate(chain.clone(), key)?;
+
+    let addr = server.local_addr()?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("no connection")?;
+        let session = request.ok().await?;
+        anyhow::Ok(session)
+    });
+
+    let url: url::Url = format!("https://127.0.0.1:{}/", addr.port()).parse()?;
+    let client = ClientBuilder::new().with_server_certificates(chain)?;
+    let client = client.connect(ConnectRequest::new(url)).await?;
+
+    let server = server_task.await??;
+    Ok((client, server))
+}
+
+/// Register an accepter, abandon it, and repeat — on a connection where no stream ever
+/// arrives, which is the case that used to grow forever. Nothing here delivers a
+/// stream: an arrival drains the list, which would hide exactly what is under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abandoned_accepters_release_their_wakers() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // Each iteration is a distinct task's worth of waker, registered by a single poll
+    // and abandoned when the future drops at the end of the scope.
+    let mut abandoned = Vec::with_capacity(ABANDONED);
+    for _ in 0..ABANDONED {
+        let flag = Arc::new(FlagWaker::default());
+        let waker = Waker::from(flag.clone());
+
+        let mut accept = std::pin::pin!(server.accept_uni());
+        assert!(
+            accept
+                .as_mut()
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending(),
+            "no stream should be available yet"
+        );
+
+        abandoned.push(flag);
+    }
+
+    // Every abandoned waker should be uniquely owned by the test again: the shared
+    // accept futures are polled with the accept state's own waker, never the caller's,
+    // so there is nothing else that could still be holding one.
+    let retained = abandoned
+        .iter()
+        .filter(|flag| Arc::strong_count(flag) > 1)
+        .count();
+    assert_eq!(
+        retained, 0,
+        "{retained} of {ABANDONED} abandoned accepters are still parked in the accept list"
+    );
+
+    client.close(0, b"bye");
+    Ok(())
+}
+
+/// Reclaiming an abandoned accepter's slot must not cost a live accepter its wakeup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn churn_does_not_lose_a_live_accepter() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // One accepter that sticks around, registered before the churn.
+    let parked = Arc::new(FlagWaker::default());
+    let parked_waker = Waker::from(parked.clone());
+    let mut waiting = std::pin::pin!(server.accept_uni());
+    assert!(
+        waiting
+            .as_mut()
+            .poll(&mut Context::from_waker(&parked_waker))
+            .is_pending(),
+        "no stream should be available yet"
+    );
+
+    for _ in 0..ABANDONED {
+        let waker = Waker::from(Arc::new(FlagWaker::default()));
+        let mut accept = std::pin::pin!(server.accept_uni());
+        assert!(accept
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+            .is_pending());
+    }
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    // A second accepter takes the stream; the first should have been woken to retry.
+    let recv = timeout(Duration::from_secs(10), server.accept_uni())
+        .await
+        .context("the stream never arrived")??;
+    drop(recv);
+
+    assert!(
+        parked.woken(),
+        "the accepter that was still waiting lost its registration to the churn"
+    );
+
+    client.close(0, b"bye");
+    Ok(())
+}
+
+/// The last accepter to poll is the one the inner accept future holds a waker for. If it
+/// gives up, the arrival has to reach whoever is still waiting.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_departing_accepter_does_not_strand_the_others() -> Result<()> {
+    let (client, server) = pair().await?;
+
+    // A parks first.
+    let a = Arc::new(FlagWaker::default());
+    let a_waker = Waker::from(a.clone());
+    let mut first = std::pin::pin!(server.accept_uni());
+    assert!(first
+        .as_mut()
+        .poll(&mut Context::from_waker(&a_waker))
+        .is_pending());
+
+    // B polls after A, so B's waker is the one the inner future holds, then gives up.
+    {
+        let b = Waker::from(Arc::new(FlagWaker::default()));
+        let mut second = std::pin::pin!(server.accept_uni());
+        assert!(second
+            .as_mut()
+            .poll(&mut Context::from_waker(&b))
+            .is_pending());
+    }
+
+    let mut send = client.open_uni().await?;
+    send.write_all(b"hi").await?;
+    send.finish()?;
+
+    // Nothing here polls the accept path again: A has to be woken by the arrival.
+    for _ in 0..500 {
+        if a.woken() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(a.woken(), "the remaining accepter was never woken");
+
+    client.close(0, b"bye");
+    Ok(())
+}


### PR DESCRIPTION
## The bug

The stream-accept paths kept pending accepters in a plain `Vec<Waker>` with no way to deregister. Entries were cleared only when a stream arrived or the accept failed, so a caller that started an accept and then dropped the future — a `tokio::time::timeout` around `accept_uni()`, say — left its waker there for the life of the connection. The `will_wake` dedup only helps a task that re-polls; distinct tasks doing this on a quiet, long-lived connection grow the list without bound, retaining a task allocation each.

This predates the poll-traits work (`git blame` points at #120 and #179), so it is not a regression from any current branch.

`web-transport-quiche`'s `ez` layer had the same bug one level down, in more places: the driver's accept, datagram, handshake and open-capacity lists, and `ConnectionClosed`. That last one is the worst of them — every blocked read, write, accept and handshake parks on it, and it pushed a waker clone on **every** pending poll with no dedup at all, so it grew per-poll rather than per-task. Fixing only the `SessionAccept` layer would have left quiche still leaking underneath.

## The fix

Every one of those lists is now a `kio::WaiterList`, whose entries are `Weak<Waker>` owned by the caller's `kio::Waiter`. A caller that walks away drops its waiter, its slot goes dead, and the next registration reclaims it — no explicit deregistration, so nothing has to run on the abandoning path.

Consequences worth knowing about:

- **`ez`'s `poll_*` surface takes `&kio::Waiter` instead of `&Waker`**, and its `async` methods go through `kio::wait`. This is what makes the registration outlive the poll that created it. `SessionAccept::poll_accept_*` changes the same way. Both are breaking; `kio` is re-exported from each crate root.
- **A waiter is retained only while its poll is `Pending`.** Holding it past a `Ready` would pin the polling task's allocation to the stream until something polled it again.
- **Nothing wakes while holding a lock a resumed task will take.** That covers three paths: `AcceptWaiters::wake_all` (takes the list, wakes outside its own mutex), the accept fan-out (moved out of `poll_accept_*` to a helper that runs after the guard drops), and the `ez` teardown in `on_conn_close` (drops the driver guard first). `AcceptWaiters` additionally *holds back* wakes for the duration of a poll — an inner future can wake the list inline, `FuturesUnordered` notifies its parent from a child's `wake` — and hands them back on `disarm`. That is a count, not a flag: a poll releases the accept lock before it disarms, so another can be armed by then.
- **Per-stream `blocked: Option<Waker>` slots stay plain wakers.** A stream has a single reader and a single writer, so those have one owner and cannot accumulate.
- **`AcceptWaiters`** (new `waiters.rs` in each backend) exists because `SessionAccept` is shared by every clone of a session: the shared accept futures are polled with a waker made from the list rather than with whichever caller polled last, since a caller's waker goes stale the moment it stops accepting. **`Parked`** in the same module is the bridge a `Context`-based `poll_*` needs to keep its registration alive across polls.

## On `kio`

`Parked` mirrors `kio::WaiterCell`, which landed in kio *after* 0.5.2 (moq-dev/moq#2560). These crates are published, so they take `kio = "0.5.2"` from crates.io rather than a git pin. Once #2560 releases, both copies of `Parked` can be deleted for `kio::WaiterCell`, along with the two-step make/park dance in `ez`'s `AsyncRead`/`AsyncWrite` impls — that only exists because `Waiter` is not `Clone` in 0.5.2.

Still open: `AcceptWaiters` is duplicated across the four backends. It is nothing but a `WaiterList` plus an `impl Wake`, so kio looks like its natural home.

## Tests

Every new test was confirmed failing against the code it guards:

- `web-transport-{quinn,noq}/tests/accept_wakers.rs`, `web-transport-iroh/src/tests.rs`, and additions to `web-transport-quiche/tests/accept_wakers.rs` — abandoned accepters release their wakers (256 retained before the fix).
- `web-transport-quiche/tests/ez_wakers.rs` — the same over a raw `ez` pair for reads, accepts and datagram reads; that a finished poll releases the poller; and that teardown wakes outside the driver lock. The last one probes the lock from a scratch thread rather than taking it, so a regression fails in about four seconds instead of wedging a runtime worker on a `std` mutex, which no timeout can rescue.
- `waiters.rs` unit tests in all four crates — waking never happens under the list's own lock, registrations do not stack across re-polls, a wake during a poll is deferred, and overlapping polls stay armed until the last one leaves.
- `web-transport-quiche/tests/poll.rs` — a finished read through the poll traits releases the poller.

Also verified: `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `cargo doc`, the `wasm32-unknown-unknown` checks, and the full test suites for quinn, noq, iroh and quiche.

## Breaking change

`ez`'s `poll_*` methods and `SessionAccept::poll_accept_*` take `&kio::Waiter` instead of `&std::task::Waker`. A `Waker` cannot express deregistration — the caller has to own something whose drop releases the registration — so the leak this PR fixes is not addressable without it. Callers move to `kio::wait` for the async path, or hold a waiter across polls. The title is `fix!:` so the squashed commit carries the marker for release-plz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)
