### PR TITLE
refactor(qmux)!: keep transport types behind their module path

### DIFF
--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]
 categories = ["network-programming"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["tls", "wss"]
 tcp = ["tokio/net", "tokio/io-util"]

--- a/rs/qmux/README.md
+++ b/rs/qmux/README.md
@@ -10,17 +10,48 @@ The protocol reuses QUIC frame types and semantics while adapting them for strea
 
 ```toml
 [dependencies]
-qmux = "0.0.1"
+qmux = "0.4"
 ```
 
 ### Features
 
 - **`tcp`** - QMux over raw TCP streams
+- **`uds`** - QMux over Unix domain sockets (Unix only)
 - **`tls`** - QMux over TLS (via `tokio-rustls`)
 - **`ws`** - QMux over WebSockets (via `tokio-tungstenite`)
 - **`wss`** - QMux over secure WebSockets (WebSocket + TLS)
 
 Default features: `tls`, `wss`
+
+## Usage
+
+The crate root holds the transport-independent session API — `Session`,
+`SendStream`, `RecvStream`, `Config`, `Version`, and `Error`. Each transport
+keeps its own entry point in its own module, so the shared names don't collide:
+
+| Module | Entry point | Feature |
+| --- | --- | --- |
+| `qmux::tcp` | `tcp::Config` | `tcp` |
+| `qmux::uds` | `uds::Config` | `uds` |
+| `qmux::tls` | `tls::Client`, `tls::Server` | `tls` |
+| `qmux::ws` | `ws::Client`, `ws::Server`, `ws::Upgraded` | `ws` |
+| `qmux::transport` | `transport::Stream` | `tcp` or `uds` |
+
+```rust
+use qmux::{tcp, Error, Session, Version};
+
+async fn connect(addr: std::net::SocketAddr) -> Result<Session, Error> {
+    tcp::Config::new(Version::QMux02)
+        .protocols(["moq-lite-04"])
+        .connect(addr)
+        .await
+}
+```
+
+To run QMux over something the built-in modules don't cover, wrap any
+`AsyncRead + AsyncWrite` byte stream in `transport::Stream`, or implement
+`transport::Transport` yourself, then pass it to `Session::connect` /
+`Session::accept`.
 
 ## License
 

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -3,6 +3,29 @@
 //! Provides QUIC-style multiplexed streams over TCP, TLS, and WebSocket.
 //! Speaks draft-02 by default, negotiating down to draft-01 or draft-00, with
 //! backwards compatibility for the legacy `webtransport` wire format.
+//!
+//! # Layout
+//!
+//! The crate root holds the transport-independent session API: [`Session`] and
+//! its [`SendStream`] / [`RecvStream`] halves, plus the [`Config`], [`Version`],
+//! and [`Error`] types they share.
+//!
+//! Everything tied to a specific transport lives in that transport's module, so
+//! the generic names stay unambiguous when several are in scope at once:
+//!
+//! | Module | Entry point | Feature |
+//! | --- | --- | --- |
+//! | `tcp` | `tcp::Config` | `tcp` |
+//! | `uds` | `uds::Config` | `uds` (Unix only) |
+//! | `tls` | `tls::Client`, `tls::Server` | `tls` |
+//! | `ws` | `ws::Client`, `ws::Server`, `ws::Upgraded` | `ws` |
+//! | [`transport`] | [`transport::Stream`] | `tcp` or `uds` |
+//!
+//! For anything the built-in modules don't cover, wrap an
+//! [`AsyncRead`](tokio::io::AsyncRead) + [`AsyncWrite`](tokio::io::AsyncWrite)
+//! byte stream in [`transport::Stream`], or implement
+//! [`transport::Transport`] yourself, and pass it to [`Session::connect`] /
+//! [`Session::accept`].
 
 // ALPN/subprotocol negotiation is only used by the TLS and WebSocket transports.
 #[cfg(any(feature = "tls", feature = "ws"))]
@@ -36,17 +59,6 @@ pub mod tls;
 #[cfg(feature = "ws")]
 pub mod ws;
 
-// Re-export the WebSocket dependencies so downstream integrations can use the
-// exact versions compatible with QMux's public WebSocket types.
-#[cfg(feature = "ws")]
-pub use tokio_tungstenite;
-
-#[cfg(feature = "ws")]
-pub use tokio_tungstenite::tungstenite;
-
-#[cfg(feature = "ws")]
-pub use ws::{Client, KeepAlive, Server};
-
 use proto::*;
 
 pub use config::{Config, Protocol};
@@ -54,11 +66,9 @@ pub use error::Error;
 pub use proto::Version;
 pub use session::{RecvStream, SendStream, Session};
 pub use stream::{StreamDir, StreamId};
-pub use transport::Transport;
-// The transport half-traits live at `transport::{Reader, Writer}` and the concrete
-// byte-stream transport at `transport::Stream`, rather than the crate root — the
-// bare `Reader`/`Writer`/`Stream` names would be too generic (and `Stream` would
-// collide with the STREAM-frame `Stream` type) alongside the rest of the API.
+// Transport-specific types are deliberately *not* re-exported here; they stay
+// behind their module path (`transport::Transport`, `ws::Client`, `tls::Client`,
+// ...) so that names shared across transports don't collide at the crate root.
 
 /// All supported ALPN identifiers, in preference order.
 ///

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -24,7 +24,7 @@ use crate::{Error, Protocol, Session, Version};
 /// ```
 ///
 /// For flow-control tuning beyond version + protocols, build a [`crate::Config`]
-/// and drive [`crate::Stream`] + [`Session::connect`] yourself.
+/// and drive [`crate::transport::Stream`] + [`Session::connect`] yourself.
 #[derive(Debug, Clone)]
 pub struct Config {
     inner: crate::Config,

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -6,10 +6,19 @@ use crate::protocol::validate_protocol;
 use crate::transport::WsTransport;
 use crate::{alpn, Config, Error, Session, Version};
 
-// Re-exported so downstream integrations can depend on the exact versions
-// compatible with the public WebSocket types below, rather than pinning their
-// own and hitting a type mismatch.
+/// The `tokio-tungstenite` version this crate is built against.
+///
+/// [`Client::with_connector`] and [`Upgraded`] take `tokio-tungstenite` types
+/// directly, so use this re-export rather than a separately pinned dependency —
+/// a different minor version is a distinct crate to the compiler and fails to
+/// typecheck against these APIs.
 pub use tokio_tungstenite;
+
+/// The `tungstenite` version this crate is built against, matching
+/// [`tokio_tungstenite`].
+///
+/// [`Client::with_config`] and [`Upgraded`] name `tungstenite` types, and
+/// [`Error::WebSocket`] wraps a `tungstenite::Error`.
 pub use tokio_tungstenite::tungstenite;
 
 /// Keep-alive configuration for WebSocket transports.

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -1,11 +1,16 @@
 use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_tungstenite::tungstenite;
 
 use crate::protocol::validate_protocol;
 use crate::transport::WsTransport;
 use crate::{alpn, Config, Error, Session, Version};
+
+// Re-exported so downstream integrations can depend on the exact versions
+// compatible with the public WebSocket types below, rather than pinning their
+// own and hitting a type mismatch.
+pub use tokio_tungstenite;
+pub use tokio_tungstenite::tungstenite;
 
 /// Keep-alive configuration for WebSocket transports.
 ///

--- a/rs/qmux/tests/backpressure.rs
+++ b/rs/qmux/tests/backpressure.rs
@@ -10,8 +10,8 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use qmux::transport::{Reader, Writer};
-use qmux::{Config, Error, Session, Transport, Version};
+use qmux::transport::{Reader, Transport, Writer};
+use qmux::{Config, Error, Session, Version};
 use tokio::sync::{mpsc, watch};
 use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
 

--- a/rs/qmux/tests/priority.rs
+++ b/rs/qmux/tests/priority.rs
@@ -8,8 +8,8 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use qmux::transport::{Reader, Writer};
-use qmux::{Config, Error, Session, Transport, Version};
+use qmux::transport::{Reader, Transport, Writer};
+use qmux::{Config, Error, Session, Version};
 use tokio::sync::mpsc;
 use web_transport_trait::{RecvStream as _, SendStream as _, Session as _};
 


### PR DESCRIPTION
## Problem

The crate root re-exported transport-specific items, so `qmux::Client`, `qmux::Server`, `qmux::Transport`, `qmux::KeepAlive`, `qmux::tungstenite`, and `qmux::tokio_tungstenite` sat alongside the session API even though each belongs to exactly one transport.

That makes the root ambiguous — `qmux::Client` is the WebSocket one, but `tls::Client` is just as much a "client" and never got a root alias — and the collisions only get worse as transports are added. It also meant the WebSocket dependency re-exports were visible to callers who never enabled `ws`-adjacent code paths in their heads.

## Change

The crate root now exports only the transport-independent session API:

`Session`, `SendStream`, `RecvStream`, `Config`, `Protocol`, `Version`, `Error`, `StreamId`, `StreamDir`, `ALPNS`.

Everything transport-specific stays behind its module path:

| Before | After |
| --- | --- |
| `qmux::Transport` | `qmux::transport::Transport` |
| `qmux::Client` / `qmux::Server` | `qmux::ws::Client` / `qmux::ws::Server` |
| `qmux::KeepAlive` | `qmux::ws::KeepAlive` |
| `qmux::tungstenite` | `qmux::ws::tungstenite` |
| `qmux::tokio_tungstenite` | `qmux::ws::tokio_tungstenite` |

The tungstenite re-exports move next to the public WebSocket types whose versions they exist to pin, which is the only place they're meaningful.

Docs and packaging cleanups that fall out of this:

- Crate-level docs and the README now describe the module layout (which entry point lives where, and under which feature).
- `[package.metadata.docs.rs] all-features = true`, so the `uds` module actually renders on docs.rs — it was invisible before, since `uds` is not a default feature.
- README: stale `qmux = "0.0.1"` install line (crate is at 0.4.1), missing `uds` feature in the feature list.
- Fixed the broken `[crate::Stream]` intra-doc link in `tcp` (the type is `crate::transport::Stream`).

No behavior changes — this is import paths and documentation only.

## Breaking change

`qmux::{Client, Server, KeepAlive, Transport, tungstenite, tokio_tungstenite}` are removed. Callers move to the module paths in the table above. Nothing in this workspace depended on the removed names; the two tests that used `qmux::Transport` are updated in this PR.

## Testing

- `cargo test -p qmux --all-features --all-targets` — 129 unit + all integration tests pass
- `cargo test -p qmux --all-features --doc` — 3 doctests pass
- `cargo clippy -p qmux --all-features --all-targets` — clean
- `cargo doc -p qmux --all-features --no-deps` — no warnings
- `cargo check -p qmux` across each feature combination (`[]`, `tcp`, `uds`, `ws`, `tls`, `wss`, `tcp,ws`, `uds,wss`) — clean
- `cargo check --workspace --all-targets --all-features` and `cargo fmt --all --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MveiWUXQZ52iAugQJwYgHR)_