### PR TITLE
Restore Error send and sync bounds

### DIFF
--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -59,12 +59,8 @@ impl Stats for StatsUnavailable {}
 
 /// Error trait for WebTransport operations.
 ///
-/// Deliberately *not* `Send + Sync`. Those are required by the async traits below,
-/// whose futures must be spawnable, and are declared there. The [`poll`] traits need
-/// neither, so a transport pinned to one thread can use an error type that is
-/// neither — one holding an [`std::rc::Rc`] to shared connection state, say.
-/// (Still `'static`, so an error cannot *borrow* that state.)
-pub trait Error: std::error::Error + 'static {
+/// Implementations must be Send + Sync + 'static for use across async boundaries.
+pub trait Error: std::error::Error + MaybeSend + MaybeSync + 'static {
     /// Returns the error code and reason if this was an application error.
     ///
     /// NOTE: Reason reasons are technically bytes on the wire, but we convert to a String for convenience.
@@ -83,9 +79,7 @@ pub trait Error: std::error::Error + 'static {
 pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
     type SendStream: SendStream;
     type RecvStream: RecvStream;
-    // `Send` so a spawned future can carry it out; `Sync` so it boxes into
-    // `Box<dyn Error + Send + Sync>` and `anyhow::Error` like any other error.
-    type Error: Error + MaybeSend + MaybeSync;
+    type Error: Error;
 
     /// Block until the peer creates a new unidirectional stream.
     fn accept_uni(&self)
@@ -143,7 +137,7 @@ pub trait Session: Clone + MaybeSend + MaybeSync + 'static {
 /// QUIC streams have flow control, which means the send rate is limited by the peer's receive window.
 /// The stream will be closed with a graceful FIN when dropped.
 pub trait SendStream: MaybeSend {
-    type Error: Error + MaybeSend + MaybeSync;
+    type Error: Error;
 
     /// Write some of the buffer to the stream, returning how many bytes were
     /// written. See [`write_buf`](Self::write_buf) for the cancel-safety contract,
@@ -259,7 +253,7 @@ pub trait SendStream: MaybeSend {
 /// All bytes are flushed in order and the stream is flow controlled.
 /// The stream will be closed with STOP_SENDING code=0 when dropped.
 pub trait RecvStream: MaybeSend {
-    type Error: Error + MaybeSend + MaybeSync;
+    type Error: Error;
 
     /// Read the next chunk of data, up to the max size.
     ///

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -7,12 +7,14 @@
 //! Two properties are deliberate, and both are constraints on what an implementation
 //! is *allowed* to be rather than features it gets:
 //!
-//! - **No `Send` or `Sync` bound.** A transport pinned to one thread — a
-//!   thread-per-core `io_uring` runtime, say — can implement these. The async traits
-//!   in the crate root add `MaybeSend` on top, because their futures need it; the
-//!   poll traits do not, so a `!Send` stack stays expressible all the way down.
-//!   [`Session`]'s associated stream types only require the poll halves, so the
-//!   bound cannot leak back in through them.
+//! - **No `Send` or `Sync` bound on sessions or streams.** A transport pinned to one
+//!   thread — a thread-per-core `io_uring` runtime, say — can implement these. The
+//!   async traits in the crate root add `MaybeSend` on top, because their futures
+//!   need it; the poll traits do not, so a `!Send` stack stays expressible all the
+//!   way down. [`Session`]'s associated stream types only require the poll halves,
+//!   so the bound cannot leak back in through them. Error types still implement the
+//!   shared crate-level [`crate::Error`] trait and retain its `MaybeSend + MaybeSync`
+//!   bounds.
 //!
 //! - **`&mut self` throughout, and no `Clone`.** A sans-I/O state machine owns its
 //!   state and mutates it in place. A `&self` surface would force every


### PR DESCRIPTION
Restores the MaybeSend and MaybeSync supertraits on web_transport_trait::Error to preserve the existing 0.3 API guarantee. Updates the new poll API documentation to clarify that sessions and streams may remain non-Send while shared error types retain those bounds.\n\nVerification:\n- cargo check -p web-transport-trait --all-targets --all-features\n- cargo semver-checks check-release -p web-transport-trait (196 passed)\n- just check passed workspace, Clippy, formatting, WASM, and 72/86 feature combinations before the local disk filled; remote CI will provide the complete repository gate.