### PR TITLE
add cmake to nix development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
           pkgs.pkg-config
           pkgs.glib
           pkgs.gtk3
+          pkgs.cmake
           # Required to compile boringssl (via bindgen loading libclang)
           pkgs.llvmPackages.libclang.lib
           # Only for NPM publishing


### PR DESCRIPTION
## Summary

Add CMake to the Nix development shell so `boring-sys` can build BoringSSL without relying on a host-installed `cmake` binary.

## Root cause

The shell already provided libclang for `boring-sys` bindgen support, but omitted the CMake executable used by the dependency's build script. CI masked the omission because GitHub-hosted runners provide CMake outside the Nix shell.

## Impact

Contributors can run `nix develop --command just check` and `nix develop --command just test` on machines without a system CMake installation.

Fixes #352.

## Validation

- `nix-instantiate --parse flake.nix`
- `git diff --check`
- `nix develop --command cmake --version` (cold-cache shell build started successfully; still building the Rust toolchain during publication)