### PR TITLE
fix(qmux): silence application abort warnings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "js/qmux": {
       "name": "@moq/qmux",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@moq/web-socket-stream": "workspace:*",
       },

--- a/js/qmux/package.json
+++ b/js/qmux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/qmux",
 	"author": "Luke Curley <kixelated@gmail.com>",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "QMux protocol (draft-ietf-quic-qmux-02) over WebSockets",
 	"type": "module",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/qmux/src/session.test.ts
+++ b/js/qmux/src/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { WebSocketLike, WebSocketStreamLike } from "@moq/web-socket-stream";
 import { SessionError, StreamError } from "./error.ts";
 import * as Frame from "./frame.ts";
@@ -306,6 +306,38 @@ describe("Session integration (scripted peer)", () => {
 		const reset = peer.received().find((f) => f.type === "reset_stream") as Frame.ResetStream;
 		expect(reset.code.value).toBe(0n);
 		session.close();
+	});
+
+	test("application aborts do not log warnings", async () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const { session, peer } = connect();
+
+		try {
+			await session.ready;
+			peer.send({ type: "transport_parameters", params: peerParams() });
+
+			const uni = await session.createUnidirectionalStream();
+			await uni.abort(new Error("application closed uni stream"));
+
+			const bidi = await session.createBidirectionalStream();
+			await bidi.writable.abort(new Error("application closed local bidi stream"));
+
+			peer.send({
+				type: "stream",
+				id: Stream.Id.create(0n, Stream.Dir.Bi, true),
+				data: new Uint8Array([1]),
+				fin: false,
+			});
+			const incoming = await session.incomingBidirectionalStreams.getReader().read();
+			if (!incoming.value) throw new Error("expected an incoming bidirectional stream");
+			await incoming.value.writable.abort(new Error("application closed incoming bidi stream"));
+
+			await waitFor(() => peer.count("reset_stream") === 3);
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			session.close();
+			warn.mockRestore();
+		}
 	});
 
 	test("cancelling with a WebTransportError sends its streamErrorCode as STOP_SENDING", async () => {

--- a/js/qmux/src/session.ts
+++ b/js/qmux/src/session.ts
@@ -1375,7 +1375,6 @@ export default class Session implements WebTransport {
 						await this.#sendStreamData(frame.id, chunk);
 					},
 					abort: (e) => {
-						console.warn("abort", e);
 						this.#scheduler?.dropStream(streamId, e instanceof Error ? e : new Error("stream aborted"));
 						this.#sendPriorityFrame({
 							type: "reset_stream",
@@ -1711,7 +1710,6 @@ export default class Session implements WebTransport {
 				await this.#sendStreamData(streamId, chunk);
 			},
 			abort: (e) => {
-				console.warn("abort", e);
 				this.#scheduler?.dropStream(streamIdVal, e instanceof Error ? e : new Error("stream aborted"));
 				this.#sendPriorityFrame({
 					type: "reset_stream",
@@ -1791,7 +1789,6 @@ export default class Session implements WebTransport {
 				await session.#sendStreamData(streamId, chunk);
 			},
 			abort(e) {
-				console.warn("abort", e);
 				session.#scheduler?.dropStream(streamIdVal, e instanceof Error ? e : new Error("stream aborted"));
 				session.#sendPriorityFrame({
 					type: "reset_stream",


### PR DESCRIPTION
## Summary

- remove unconditional `console.warn("abort", ...)` calls from all three QMux writable-stream abort handlers
- add regression coverage for application aborts on unidirectional, locally-created bidirectional, and peer-created bidirectional streams
- bump `@moq/qmux` from 0.3.2 to 0.3.3 for the consumer-visible fix

## Root cause and impact

A writable stream sink's `abort` handler runs for ordinary application-initiated teardown. QMux treated that expected path as a warning, so healthy resets polluted application and production consoles even though the reset protocol behavior completed normally.

The abort handlers now continue dropping queued data, sending `RESET_STREAM`, and cleaning up stream state without logging an unsolicited warning.

Closes #344.

## Validation

- `bun run --cwd js/qmux test` — 158 passed
- `bun run --cwd js/qmux check`
- `bun run check`
- `bun run --filter '*' check`
- `bun install --frozen-lockfile`
- `git diff --check`
- `just fix` completed native workspace `cargo fix` and clippy; the later WASM pass was blocked by a non-writable existing build artifact under `target/wasm32-unknown-unknown`