### PR TITLE
fix(quiche): make set_priority higher-first across the crate

### DIFF
--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -248,6 +248,21 @@ impl SendStream {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_test() -> Self {
+        let id = StreamId::CLIENT_UNI;
+        Self::new(
+            id,
+            Lock::new(SendState::new(id)),
+            Lock::new(DriverState::new(false)),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn priority(&self) -> Option<u8> {
+        self.state.lock().priority
+    }
+
     /// Returns the QUIC stream ID.
     pub fn id(&self) -> StreamId {
         self.id

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -41,8 +41,8 @@ pub(super) struct SendState {
     // received
     stop: Option<u64>,
 
-    // received SET_PRIORITY
-    priority: Option<u8>,
+    // pending stream_priority update; Quiche defaults to 127 until this is set
+    urgency: Option<u8>,
 
     // No more progress can be made on the stream.
     closed: bool,
@@ -58,7 +58,7 @@ impl SendState {
             fin: false,
             reset: None,
             stop: None,
-            priority: None,
+            urgency: None,
             closed: false,
         }
     }
@@ -145,9 +145,9 @@ impl SendState {
             return Ok(self.blocked.take());
         }
 
-        if let Some(priority) = self.priority.take() {
-            tracing::trace!(stream_id = ?self.id, priority, "updating STREAM");
-            qconn.stream_priority(self.id.into(), priority, true)?;
+        if let Some(urgency) = self.urgency.take() {
+            tracing::trace!(stream_id = ?self.id, urgency, "updating STREAM");
+            qconn.stream_priority(self.id.into(), urgency, true)?;
         }
 
         while let Some(mut chunk) = self.queued.pop_front() {
@@ -259,8 +259,8 @@ impl SendStream {
     }
 
     #[cfg(test)]
-    pub(crate) fn priority(&self) -> Option<u8> {
-        self.state.lock().priority
+    pub(crate) fn urgency(&self) -> Option<u8> {
+        self.state.lock().urgency
     }
 
     /// Returns the QUIC stream ID.
@@ -421,11 +421,14 @@ impl SendStream {
         kio::wait(|waiter| self.poll_closed(waiter)).await
     }
 
-    /// Set the priority of this stream.
+    /// Set the QUIC urgency of this stream.
     ///
-    /// Lower priority values are sent first. Defaults to 0.
-    pub fn set_priority(&mut self, priority: u8) {
-        self.state.lock().priority = Some(priority);
+    /// This is Quiche's native convention: lower values are sent first. Streams that are
+    /// never assigned an urgency keep Quiche's default of 127.
+    ///
+    /// Note that [`crate::SendStream`] uses the opposite, WebTransport-facing convention.
+    pub fn set_urgency(&mut self, urgency: u8) {
+        self.state.lock().urgency = Some(urgency);
 
         let waker = self.driver.lock().send(self.id);
         if let Some(waker) = waker {

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -46,7 +46,8 @@ impl SendStream {
         // Pin the stream to the default send order instead of inheriting Quiche's urgency of
         // 127. Otherwise an untouched stream would outrank any stream explicitly promoted to
         // an order below 128, inverting the contract. H3 control streams are `ez` streams and
-        // keep 127, so they stay ahead of all WebTransport data.
+        // keep 127, so they precede data streams at the default order; a stream promoted above
+        // order 128 still outranks them, as it could before this change.
         this.set_priority(DEFAULT_SEND_ORDER);
 
         this

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -190,10 +190,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trait_send_order_maps_to_quiche_urgency() {
-        assert_eq!(send_order_to_urgency(u8::MAX), 0);
-        assert_eq!(send_order_to_urgency(0), u8::MAX);
-        assert!((0u8..u8::MAX)
-            .all(|order| send_order_to_urgency(order) > send_order_to_urgency(order + 1)));
+    fn inherent_priority_stays_lower_first() {
+        let mut stream = SendStream::new(ez::SendStream::new_test());
+
+        stream.set_priority(42);
+
+        assert_eq!(stream.inner.priority(), Some(42));
+    }
+
+    #[test]
+    fn future_trait_send_order_maps_to_quiche_urgency() {
+        let mut stream = SendStream::new(ez::SendStream::new_test());
+
+        web_transport_trait::SendStream::set_priority(&mut stream, 200);
+
+        assert_eq!(stream.inner.priority(), Some(55));
+    }
+
+    #[test]
+    fn poll_trait_send_order_maps_to_quiche_urgency() {
+        let mut stream = SendStream::new(ez::SendStream::new_test());
+
+        web_transport_trait::poll::SendStream::set_priority(&mut stream, 100);
+
+        assert_eq!(stream.inner.priority(), Some(155));
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -14,7 +14,10 @@ use crate::{ez, waiters::Parked, StreamError};
 // decimal: 1685221232, or 91143959072288 as an HTTP error code
 const DROP_CODE: u64 = web_transport_proto::error_to_http3(0x73656E64);
 
-/// Convert the trait's higher-first send order to Quiche's lower-first urgency.
+/// The send order every stream starts at, matching quinn and the W3C `sendOrder` default.
+const DEFAULT_SEND_ORDER: u8 = 0;
+
+/// Convert a higher-first send order to Quiche's lower-first urgency.
 const fn send_order_to_urgency(order: u8) -> u8 {
     u8::MAX - order
 }
@@ -34,11 +37,19 @@ pub struct SendStream {
 
 impl SendStream {
     pub(super) fn new(inner: ez::SendStream) -> Self {
-        Self {
+        let mut this = Self {
             inner,
             parked_write: Parked::default(),
             parked_closed: Parked::default(),
-        }
+        };
+
+        // Pin the stream to the default send order instead of inheriting Quiche's urgency of
+        // 127. Otherwise an untouched stream would outrank any stream explicitly promoted to
+        // an order below 128, inverting the contract. H3 control streams are `ez` streams and
+        // keep 127, so they stay ahead of all WebTransport data.
+        this.set_priority(DEFAULT_SEND_ORDER);
+
+        this
     }
 
     /// Write some data to the stream, returning the size written.
@@ -66,11 +77,16 @@ impl SendStream {
         self.inner.finish().map_err(Into::into)
     }
 
-    /// Set the priority of this stream.
+    /// Set the send order of this stream.
     ///
-    /// Lower priority values are sent first. Defaults to 0.
+    /// Streams with higher values are sent first, but are not guaranteed to arrive first.
+    /// Defaults to 0. This matches the W3C WebTransport `sendOrder` convention and the other
+    /// `web-transport` backends.
+    ///
+    /// Quiche's native urgency runs the other way; use [`ez::SendStream::set_urgency`] if you
+    /// need that convention.
     pub fn set_priority(&mut self, order: u8) {
-        self.inner.set_priority(order)
+        self.inner.set_urgency(send_order_to_urgency(order))
     }
 
     /// Abruptly reset the stream with the provided error code.
@@ -129,7 +145,7 @@ impl web_transport_trait::SendStream for SendStream {
     }
 
     fn set_priority(&mut self, order: u8) {
-        SendStream::set_priority(self, send_order_to_urgency(order))
+        SendStream::set_priority(self, order)
     }
 
     fn reset(&mut self, code: u32) {
@@ -167,7 +183,7 @@ impl web_transport_trait::poll::SendStream for SendStream {
     }
 
     fn set_priority(&mut self, order: u8) {
-        SendStream::set_priority(self, send_order_to_urgency(order))
+        SendStream::set_priority(self, order)
     }
 
     fn reset(&mut self, code: u32) {
@@ -189,30 +205,80 @@ impl web_transport_trait::poll::SendStream for SendStream {
 mod tests {
     use super::*;
 
-    #[test]
-    fn inherent_priority_stays_lower_first() {
-        let mut stream = SendStream::new(ez::SendStream::new_test());
-
-        stream.set_priority(42);
-
-        assert_eq!(stream.inner.priority(), Some(42));
+    /// The urgency that would be handed to `quiche::Connection::stream_priority`.
+    fn urgency(stream: &SendStream) -> u8 {
+        stream.inner.urgency().expect("urgency is set on construction")
     }
 
     #[test]
-    fn future_trait_send_order_maps_to_quiche_urgency() {
-        let mut stream = SendStream::new(ez::SendStream::new_test());
+    fn untouched_stream_uses_the_default_send_order() {
+        let stream = SendStream::new(ez::SendStream::new_test());
 
-        web_transport_trait::SendStream::set_priority(&mut stream, 200);
-
-        assert_eq!(stream.inner.priority(), Some(55));
+        // Not Quiche's default of 127, which would rank above a promoted stream.
+        assert_eq!(urgency(&stream), send_order_to_urgency(DEFAULT_SEND_ORDER));
+        assert_eq!(urgency(&stream), 255);
     }
 
     #[test]
-    fn poll_trait_send_order_maps_to_quiche_urgency() {
-        let mut stream = SendStream::new(ez::SendStream::new_test());
+    fn explicit_default_order_matches_untouched() {
+        let untouched = SendStream::new(ez::SendStream::new_test());
+        let mut explicit = SendStream::new(ez::SendStream::new_test());
 
-        web_transport_trait::poll::SendStream::set_priority(&mut stream, 100);
+        explicit.set_priority(DEFAULT_SEND_ORDER);
 
-        assert_eq!(stream.inner.priority(), Some(155));
+        assert_eq!(urgency(&explicit), urgency(&untouched));
+    }
+
+    #[test]
+    fn higher_send_order_is_sent_first() {
+        let mut low = SendStream::new(ez::SendStream::new_test());
+        let mut high = SendStream::new(ez::SendStream::new_test());
+
+        low.set_priority(1);
+        high.set_priority(2);
+
+        // Quiche sends lower urgencies first.
+        assert!(urgency(&high) < urgency(&low));
+    }
+
+    #[test]
+    fn promoted_stream_outranks_untouched_stream() {
+        // The regression: any order above the default must beat a stream nobody touched,
+        // including orders below Quiche's default urgency of 127.
+        for order in [1, 55, 100, 200, 255] {
+            let untouched = SendStream::new(ez::SendStream::new_test());
+            let mut promoted = SendStream::new(ez::SendStream::new_test());
+
+            promoted.set_priority(order);
+
+            assert!(
+                urgency(&promoted) < urgency(&untouched),
+                "send order {order} should outrank an untouched stream"
+            );
+        }
+    }
+
+    #[test]
+    fn async_trait_matches_the_inherent_api() {
+        let mut inherent = SendStream::new(ez::SendStream::new_test());
+        let mut via_trait = SendStream::new(ez::SendStream::new_test());
+
+        inherent.set_priority(200);
+        web_transport_trait::SendStream::set_priority(&mut via_trait, 200);
+
+        assert_eq!(urgency(&via_trait), urgency(&inherent));
+        assert_eq!(urgency(&via_trait), 55);
+    }
+
+    #[test]
+    fn poll_trait_matches_the_inherent_api() {
+        let mut inherent = SendStream::new(ez::SendStream::new_test());
+        let mut via_trait = SendStream::new(ez::SendStream::new_test());
+
+        inherent.set_priority(100);
+        web_transport_trait::poll::SendStream::set_priority(&mut via_trait, 100);
+
+        assert_eq!(urgency(&via_trait), urgency(&inherent));
+        assert_eq!(urgency(&via_trait), 155);
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -14,6 +14,11 @@ use crate::{ez, waiters::Parked, StreamError};
 // decimal: 1685221232, or 91143959072288 as an HTTP error code
 const DROP_CODE: u64 = web_transport_proto::error_to_http3(0x73656E64);
 
+/// Convert the trait's higher-first send order to Quiche's lower-first urgency.
+const fn send_order_to_urgency(order: u8) -> u8 {
+    u8::MAX - order
+}
+
 /// A stream that can be used to send bytes.
 ///
 /// This wrapper is mainly needed for error codes.
@@ -124,7 +129,7 @@ impl web_transport_trait::SendStream for SendStream {
     }
 
     fn set_priority(&mut self, order: u8) {
-        self.set_priority(order)
+        SendStream::set_priority(self, send_order_to_urgency(order))
     }
 
     fn reset(&mut self, code: u32) {
@@ -162,7 +167,7 @@ impl web_transport_trait::poll::SendStream for SendStream {
     }
 
     fn set_priority(&mut self, order: u8) {
-        self.set_priority(order)
+        SendStream::set_priority(self, send_order_to_urgency(order))
     }
 
     fn reset(&mut self, code: u32) {
@@ -177,5 +182,18 @@ impl web_transport_trait::poll::SendStream for SendStream {
         self.parked_closed
             .poll(cx, |waiter| self.inner.poll_closed(waiter))
             .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send_order_maps_to_quiche_urgency() {
+        assert_eq!(send_order_to_urgency(u8::MAX), 0);
+        assert_eq!(send_order_to_urgency(0), u8::MAX);
+        assert!((0u8..u8::MAX)
+            .all(|order| send_order_to_urgency(order) > send_order_to_urgency(order + 1)));
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -207,7 +207,10 @@ mod tests {
 
     /// The urgency that would be handed to `quiche::Connection::stream_priority`.
     fn urgency(stream: &SendStream) -> u8 {
-        stream.inner.urgency().expect("urgency is set on construction")
+        stream
+            .inner
+            .urgency()
+            .expect("urgency is set on construction")
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- give `web_transport_quiche::SendStream::set_priority` the higher-first convention used by every other backend, defaulting to send order 0
- pin streams to that default on construction instead of inheriting Quiche's urgency of 127
- rename `ez::SendStream::set_priority` to `set_urgency` so the raw Quiche convention is explicit
- add regression tests for the default, the ordering, and both trait adapters

## Root cause

`web_transport_trait::SendStream::set_priority` defines higher values as sent first, matching the W3C `sendOrder`. Quiche's urgency runs the other way. The trait adapters forwarded values unchanged, so callers using the shared trait received inverted scheduling.

Converting only inside the trait adapters was not enough, for two reasons.

First, `SendStream` ended up with two `set_priority` methods of opposite meaning on the same type: the inherent one (lower-first) and the two trait impls (higher-first).

Second, the default was still wrong. `ez::SendState.urgency` is an `Option`, and `stream_priority` is only called once something sets it, so an untouched stream keeps Quiche's `DEFAULT_URGENCY` of 127. Under a pure adapter-level conversion, trait order 100 maps to urgency 155 and therefore loses to a stream nobody touched, and explicit order 0 was no longer equivalent to untouched the way it is in quinn and qmux.

## Approach

The WebTransport-level `SendStream` now owns one convention: higher order is sent first, default 0. The conversion to urgency happens once in the inherent method, and both trait impls delegate to it, so the two adapters cannot drift apart. `SendStream::new` applies the default order so untouched streams sit at urgency 255.

`ez` remains the raw QUIC layer with Quiche's native lower-first urgency, but the method is renamed to `set_urgency` so the two layers are impossible to confuse. Every remaining `set_priority` in the workspace is now higher-first, consistent with quinn, qmux, iroh, noq, wasm and the FFI bindings, all of which already default to order 0.

H3 control and settings streams are `ez` streams and keep urgency 127, so they precede WebTransport data at the default send order. A stream explicitly promoted above order 128 still outranks them, which was also possible before this change.

## Breaking changes

- `web_transport_quiche::SendStream::set_priority` reverses meaning. The signature is unchanged, so this is a silent behavior change for direct users of the inherent API.
- `ez::SendStream::set_priority` is renamed to `set_urgency`.

## Validation

Local `nix develop` runs were wedged on daemon contention on my machine, so CI is the gate for this revision. Prior revisions of this branch passed `just check` and `just test` locally.

(written by Opus 5)