### PR TITLE
refactor(wasm)!: implement the poll traits natively

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,7 +97,9 @@ harness port="8080":
 	#!/usr/bin/env bash
 	set -euo pipefail
 
-	[ -f dev/localhost.crt ] || ./dev/setup
+	if [ ! -f dev/localhost.crt ] || [ ! -f dev/localhost.key ] || [ ! -f dev/localhost.hex ]; then
+		./dev/setup
+	fi
 
 	# wasm-bindgen refuses to process a file built against a different schema, but
 	# adjacent crate and CLI versions can share one. Let the CLI make that decision;

--- a/justfile
+++ b/justfile
@@ -87,6 +87,35 @@ fix:
 	bun install
 	bun run fix
 
+# Run the browser harness for web-transport-wasm.
+#
+# CI only compiles the WASM crate; the browser API it wraps exists nowhere else, so
+# the poll paths that are easiest to get wrong have no automated coverage. This
+# builds the harness, starts its QUIC peer, and serves the page for a browser to
+# open. Requires `dev/setup` to have generated the localhost certificate.
+harness port="8080":
+	#!/usr/bin/env bash
+	set -euo pipefail
+
+	[ -f dev/localhost.crt ] || ./dev/setup
+
+	# Build the harness and generate its JS bindings next to the page.
+	out="target/harness"
+	cargo build --example harness -p web-transport-wasm --target wasm32-unknown-unknown
+	wasm-bindgen --target web --out-dir "$out" \
+		target/wasm32-unknown-unknown/debug/examples/harness.wasm
+	cp rs/web-transport-wasm/examples/harness.html "$out/index.html"
+	cp dev/localhost.hex "$out/localhost.hex"
+
+	cargo build --example harness-server -p web-transport-quinn
+	./target/debug/examples/harness-server \
+		--tls-cert dev/localhost.crt --tls-key dev/localhost.key &
+	server=$!
+	trap 'kill $server 2>/dev/null || true' EXIT
+
+	echo "==> open http://localhost:{{port}}/"
+	python3 -m http.server {{port}} --directory "$out"
+
 # Build the FFI staticlib/cdylib for the host and generate language bindings.
 build-ffi:
 	./rs/web-transport-ffi/build.sh --bindings-only --output rs/web-transport-ffi/dist

--- a/justfile
+++ b/justfile
@@ -99,6 +99,19 @@ harness port="8080":
 
 	[ -f dev/localhost.crt ] || ./dev/setup
 
+	# wasm-bindgen refuses to process a file built against a different schema, and
+	# its error does not say where either version came from. The nix shell pins its
+	# own wasm-bindgen-cli, which is routinely older than the crate we build with.
+	want=$(cargo metadata --format-version 1 --locked \
+		| python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="wasm-bindgen"))')
+	got=$(wasm-bindgen --version | awk '{print $2}')
+	if [ "$want" != "$got" ]; then
+		echo "wasm-bindgen CLI is $got but the build uses $want." >&2
+		echo "Install the matching one, outside the nix shell if that is where this came from:" >&2
+		echo "    cargo binstall -y --force wasm-bindgen-cli@$want" >&2
+		exit 1
+	fi
+
 	# Build the harness and generate its JS bindings next to the page.
 	out="target/harness"
 	cargo build --example harness -p web-transport-wasm --target wasm32-unknown-unknown

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ harness port="8080":
 	# wasm-bindgen refuses to process a file built against a different schema, but
 	# adjacent crate and CLI versions can share one. Let the CLI make that decision;
 	# if it fails, add the version provenance its schema error omits.
-	want=$(cargo metadata --format-version 1 --locked \
+	want=$(cargo metadata --format-version 1 \
 		| python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="wasm-bindgen"))')
 	got=$(wasm-bindgen --version | awk '{print $2}')
 

--- a/justfile
+++ b/justfile
@@ -99,24 +99,23 @@ harness port="8080":
 
 	[ -f dev/localhost.crt ] || ./dev/setup
 
-	# wasm-bindgen refuses to process a file built against a different schema, and
-	# its error does not say where either version came from. The nix shell pins its
-	# own wasm-bindgen-cli, which is routinely older than the crate we build with.
+	# wasm-bindgen refuses to process a file built against a different schema, but
+	# adjacent crate and CLI versions can share one. Let the CLI make that decision;
+	# if it fails, add the version provenance its schema error omits.
 	want=$(cargo metadata --format-version 1 --locked \
 		| python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="wasm-bindgen"))')
 	got=$(wasm-bindgen --version | awk '{print $2}')
-	if [ "$want" != "$got" ]; then
+
+	# Build the harness and generate its JS bindings next to the page.
+	out="target/harness"
+	cargo build --example harness -p web-transport-wasm --target wasm32-unknown-unknown
+	if ! wasm-bindgen --target web --out-dir "$out" \
+		target/wasm32-unknown-unknown/debug/examples/harness.wasm; then
 		echo "wasm-bindgen CLI is $got but the build uses $want." >&2
 		echo "Install the matching one, outside the nix shell if that is where this came from:" >&2
 		echo "    cargo binstall -y --force wasm-bindgen-cli@$want" >&2
 		exit 1
 	fi
-
-	# Build the harness and generate its JS bindings next to the page.
-	out="target/harness"
-	cargo build --example harness -p web-transport-wasm --target wasm32-unknown-unknown
-	wasm-bindgen --target web --out-dir "$out" \
-		target/wasm32-unknown-unknown/debug/examples/harness.wasm
 	cp rs/web-transport-wasm/examples/harness.html "$out/index.html"
 	cp dev/localhost.hex "$out/localhost.hex"
 

--- a/rs/web-transport-proto/Cargo.toml
+++ b/rs/web-transport-proto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.6.2"
+version = "0.6.1"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport-proto/Cargo.toml
+++ b/rs/web-transport-proto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport-quinn/examples/harness-server.rs
+++ b/rs/web-transport-quinn/examples/harness-server.rs
@@ -17,11 +17,13 @@
 //! - `echo <text>` — write `<text>` back and finish.
 //! - `streams <n>` — open `n` unidirectional streams carrying `stream-0`, `stream-1`,
 //!   … then finish. The harness uses this to exercise accept.
+//! - `streams-after <millis> <n>` — finish the command stream, wait, then open the
+//!   streams. The harness uses this to drop a pending accept before a value exists.
 //! - `reset <code>` — reset this stream with `<code>`, so the client sees a peer
 //!   RESET_STREAM.
 //! - `close <code> <reason>` — close the whole session.
 
-use std::{fs, io, path};
+use std::{fs, io, path, time::Duration};
 
 use anyhow::Context;
 use clap::Parser;
@@ -134,18 +136,17 @@ async fn run_command(
         }
         "streams" => {
             let count: usize = rest.trim().parse().context("bad stream count")?;
-
-            // Held until every stream is open, so none is dropped while the harness
-            // is still working through the earlier ones.
-            let mut streams = Vec::with_capacity(count);
-            for i in 0..count {
-                let mut stream = session.open_uni().await?;
-                stream.write_all(format!("stream-{i}").as_bytes()).await?;
-                stream.finish()?;
-                streams.push(stream);
-            }
+            open_streams(&session, count).await?;
+            send.finish()?;
+        }
+        "streams-after" => {
+            let (millis, count) = rest.split_once(' ').context("missing stream count")?;
+            let millis: u64 = millis.trim().parse().context("bad delay")?;
+            let count: usize = count.trim().parse().context("bad stream count")?;
 
             send.finish()?;
+            tokio::time::sleep(Duration::from_millis(millis)).await;
+            open_streams(&session, count).await?;
         }
         "reset" => {
             let code: u32 = rest.trim().parse().context("bad reset code")?;
@@ -159,5 +160,18 @@ async fn run_command(
         _ => anyhow::bail!("unknown command: {command}"),
     }
 
+    Ok(())
+}
+
+async fn open_streams(session: &Session, count: usize) -> anyhow::Result<()> {
+    // Held until every stream is open, so none is dropped while the harness is
+    // still working through the earlier ones.
+    let mut streams = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut stream = session.open_uni().await?;
+        stream.write_all(format!("stream-{i}").as_bytes()).await?;
+        stream.finish()?;
+        streams.push(stream);
+    }
     Ok(())
 }

--- a/rs/web-transport-quinn/examples/harness-server.rs
+++ b/rs/web-transport-quinn/examples/harness-server.rs
@@ -98,14 +98,11 @@ async fn run_session(session: Session) -> anyhow::Result<()> {
     loop {
         tokio::select! {
             res = session.accept_bi() => {
-                let (send, mut recv) = res?;
-                let command = recv.read_to_end(4096).await?;
-                let command = String::from_utf8_lossy(&command).trim().to_string();
-                tracing::info!(%command, "command");
+                let (send, recv) = res?;
 
                 let session = session.clone();
                 tokio::spawn(async move {
-                    if let Err(err) = run_command(session, send, command).await {
+                    if let Err(err) = read_command(session, send, recv).await {
                         tracing::warn!(?err, "command failed");
                     }
                 });
@@ -117,6 +114,25 @@ async fn run_session(session: Session) -> anyhow::Result<()> {
             },
         }
     }
+}
+
+async fn read_command(
+    session: Session,
+    send: web_transport_quinn::SendStream,
+    mut recv: web_transport_quinn::RecvStream,
+) -> anyhow::Result<()> {
+    let command = match recv.read_to_end(4096).await {
+        Ok(command) => command,
+        // The dropped-open regression deliberately resets command streams before
+        // writing anything. That abandons one command, not the whole session.
+        Err(err) => {
+            tracing::debug!(?err, "command stream abandoned");
+            return Ok(());
+        }
+    };
+    let command = String::from_utf8_lossy(&command).trim().to_string();
+    tracing::info!(%command, "command");
+    run_command(session, send, command).await
 }
 
 async fn run_command(

--- a/rs/web-transport-quinn/examples/harness-server.rs
+++ b/rs/web-transport-quinn/examples/harness-server.rs
@@ -1,0 +1,163 @@
+//! The peer half of the browser harness for `web-transport-wasm`.
+//!
+//! The echo servers only ever answer; nothing in them opens a stream toward the
+//! client or resets one, so a browser client cannot exercise accept, a peer reset,
+//! or a session close against them. This one is driven by the client instead: it
+//! reads a command off a bidirectional stream and does what it says, which is what
+//! lets the harness set up each scenario deterministically rather than by timing.
+//!
+//! Run it with the certificate from `dev/setup`, then serve the harness page:
+//!
+//! ```text
+//! just harness
+//! ```
+//!
+//! Commands, one per bidirectional stream, as a UTF-8 line:
+//!
+//! - `echo <text>` — write `<text>` back and finish.
+//! - `streams <n>` — open `n` unidirectional streams carrying `stream-0`, `stream-1`,
+//!   … then finish. The harness uses this to exercise accept.
+//! - `reset <code>` — reset this stream with `<code>`, so the client sees a peer
+//!   RESET_STREAM.
+//! - `close <code> <reason>` — close the whole session.
+
+use std::{fs, io, path};
+
+use anyhow::Context;
+use clap::Parser;
+use rustls::pki_types::CertificateDer;
+use web_transport_quinn::{proto::ConnectResponse, Session};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long, default_value = "[::]:4443")]
+    addr: std::net::SocketAddr,
+
+    /// Use the certificates at this path, encoded as PEM.
+    #[arg(long)]
+    pub tls_cert: path::PathBuf,
+
+    /// Use the private key at this path, encoded as PEM.
+    #[arg(long)]
+    pub tls_key: path::PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let chain = fs::File::open(args.tls_cert).context("failed to open cert file")?;
+    let chain: Vec<CertificateDer> = rustls_pemfile::certs(&mut io::BufReader::new(chain))
+        .collect::<Result<_, _>>()
+        .context("failed to load certs")?;
+    anyhow::ensure!(!chain.is_empty(), "could not find certificate");
+
+    let keys = fs::File::open(args.tls_key).context("failed to open key file")?;
+    let key = rustls_pemfile::private_key(&mut io::BufReader::new(keys))
+        .context("failed to load private key")?
+        .context("missing private key")?;
+
+    let mut server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(args.addr)
+        .with_certificate(chain, key)?;
+
+    tracing::info!(addr = %args.addr, "harness server listening");
+
+    while let Some(conn) = server.accept().await {
+        tokio::spawn(async move {
+            if let Err(err) = run_conn(conn).await {
+                tracing::info!(?err, "connection ended");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn run_conn(request: web_transport_quinn::Request) -> anyhow::Result<()> {
+    let session = request
+        .respond(ConnectResponse::OK)
+        .await
+        .context("failed to accept session")?;
+    tracing::info!("accepted session");
+
+    run_session(session).await
+}
+
+async fn run_session(session: Session) -> anyhow::Result<()> {
+    loop {
+        tokio::select! {
+            res = session.accept_bi() => {
+                let (send, mut recv) = res?;
+                let command = recv.read_to_end(4096).await?;
+                let command = String::from_utf8_lossy(&command).trim().to_string();
+                tracing::info!(%command, "command");
+
+                let session = session.clone();
+                tokio::spawn(async move {
+                    if let Err(err) = run_command(session, send, command).await {
+                        tracing::warn!(?err, "command failed");
+                    }
+                });
+            },
+            // Datagrams are echoed, so the harness can drive send and recv together.
+            res = session.read_datagram() => {
+                let msg = res?;
+                session.send_datagram(msg)?;
+            },
+        }
+    }
+}
+
+async fn run_command(
+    session: Session,
+    mut send: web_transport_quinn::SendStream,
+    command: String,
+) -> anyhow::Result<()> {
+    let (verb, rest) = match command.split_once(' ') {
+        Some((verb, rest)) => (verb, rest),
+        None => (command.as_str(), ""),
+    };
+
+    match verb {
+        "echo" => {
+            send.write_all(rest.as_bytes()).await?;
+            send.finish()?;
+        }
+        "streams" => {
+            let count: usize = rest.trim().parse().context("bad stream count")?;
+
+            // Held until every stream is open, so none is dropped while the harness
+            // is still working through the earlier ones.
+            let mut streams = Vec::with_capacity(count);
+            for i in 0..count {
+                let mut stream = session.open_uni().await?;
+                stream.write_all(format!("stream-{i}").as_bytes()).await?;
+                stream.finish()?;
+                streams.push(stream);
+            }
+
+            send.finish()?;
+        }
+        "reset" => {
+            let code: u32 = rest.trim().parse().context("bad reset code")?;
+            send.reset(code)?;
+        }
+        "close" => {
+            let (code, reason) = rest.split_once(' ').unwrap_or((rest, ""));
+            let code: u32 = code.trim().parse().context("bad close code")?;
+            session.close(code, reason.as_bytes());
+        }
+        _ => anyhow::bail!("unknown command: {command}"),
+    }
+
+    Ok(())
+}

--- a/rs/web-transport-quinn/examples/harness-server.rs
+++ b/rs/web-transport-quinn/examples/harness-server.rs
@@ -21,6 +21,8 @@
 //!   streams. The harness uses this to drop a pending accept before a value exists.
 //! - `reset <code>` — reset this stream with `<code>`, so the client sees a peer
 //!   RESET_STREAM.
+//! - `stop <code>` — stop the client's sending half with `<code>` while keeping the
+//!   response half available.
 //! - `close <code> <reason>` — close the whole session.
 
 use std::{fs, io, path, time::Duration};
@@ -121,23 +123,36 @@ async fn read_command(
     send: web_transport_quinn::SendStream,
     mut recv: web_transport_quinn::RecvStream,
 ) -> anyhow::Result<()> {
-    let command = match recv.read_to_end(4096).await {
-        Ok(command) => command,
-        // The dropped-open regression deliberately resets command streams before
-        // writing anything. That abandons one command, not the whole session.
-        Err(err) => {
-            tracing::debug!(?err, "command stream abandoned");
-            return Ok(());
+    let mut command = Vec::new();
+    let mut buf = [0; 1024];
+    loop {
+        match recv.read(&mut buf).await {
+            Ok(Some(size)) => {
+                command.extend_from_slice(&buf[..size]);
+                anyhow::ensure!(command.len() <= 4096, "command too long");
+                if let Some(newline) = command.iter().position(|&byte| byte == b'\n') {
+                    command.truncate(newline);
+                    break;
+                }
+            }
+            Ok(None) => break,
+            // The dropped-open regression deliberately resets command streams
+            // before writing anything. That abandons one command, not the session.
+            Err(err) => {
+                tracing::debug!(?err, "command stream abandoned");
+                return Ok(());
+            }
         }
-    };
+    }
     let command = String::from_utf8_lossy(&command).trim().to_string();
     tracing::info!(%command, "command");
-    run_command(session, send, command).await
+    run_command(session, send, recv, command).await
 }
 
 async fn run_command(
     session: Session,
     mut send: web_transport_quinn::SendStream,
+    mut recv: web_transport_quinn::RecvStream,
     command: String,
 ) -> anyhow::Result<()> {
     let (verb, rest) = match command.split_once(' ') {
@@ -167,6 +182,10 @@ async fn run_command(
         "reset" => {
             let code: u32 = rest.trim().parse().context("bad reset code")?;
             send.reset(code)?;
+        }
+        "stop" => {
+            let code: u32 = rest.trim().parse().context("bad stop code")?;
+            recv.stop(code)?;
         }
         "close" => {
             let (code, reason) = rest.split_once(' ').unwrap_or((rest, ""));

--- a/rs/web-transport-wasm/Cargo.toml
+++ b/rs/web-transport-wasm/Cargo.toml
@@ -48,5 +48,19 @@ features = [
     "WritableStreamDefaultWriter",
 ]
 
+[dev-dependencies]
+futures = "0.3"
+
+# `Window` is only needed by the harness, for its timeouts.
+[dev-dependencies.web-sys]
+version = "0.3.91"
+features = ["Window"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
+# The browser harness. A cdylib so `wasm-bindgen` can generate bindings for it;
+# see `just harness`.
+[[example]]
+crate-type = ["cdylib"]
+name = "harness"

--- a/rs/web-transport-wasm/Cargo.toml
+++ b/rs/web-transport-wasm/Cargo.toml
@@ -23,11 +23,12 @@ thiserror = "2"
 url = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-streams = "0.1.2"
+web-transport-trait = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3.91"
 features = [
+    "DomException",
     "ReadableStream",
     "ReadableStreamDefaultReader",
     "ReadableStreamReadResult",

--- a/rs/web-transport-wasm/README.md
+++ b/rs/web-transport-wasm/README.md
@@ -5,6 +5,18 @@
 # web-transport-wasm
 A wrapper around the WebTransport browser API.
 
+## Poll and async
+
+The browser API is a set of promises, but the surface here is a state machine. Every operation is a
+`poll_*` method that a caller steps from its own loop, with the `async` methods as thin wrappers over
+them. That is what implements [`web-transport-trait`](https://docs.rs/web-transport-trait)'s `poll`
+module, so a sans-I/O caller needs no adapter, and it is what makes an abandoned operation safe: the
+promise stays subscribed, so a chunk or an accepted stream is never dropped on the floor between
+polls.
+
+Clone the `Session` to run operations concurrently. Each clone keeps its own in-flight operation,
+while the underlying browser stream locks are shared — a browser stream can only be locked once.
+
 ## Requirements
 
 `web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`, so this crate

--- a/rs/web-transport-wasm/README.md
+++ b/rs/web-transport-wasm/README.md
@@ -17,6 +17,13 @@ polls.
 Clone the `Session` to run operations concurrently. Each clone keeps its own in-flight operation,
 while the underlying browser stream locks are shared — a browser stream can only be locked once.
 
+## Testing
+
+CI only compiles this crate: the browser API it wraps exists nowhere else, so the poll paths have no
+automated coverage. `just harness` builds a browser harness and the QUIC peer that drives it, then
+serves the page for a browser to open. It exercises accept, a peer reset code, closed-watches racing
+buffered bytes, datagrams, and a session close, and reports a row per check.
+
 ## Requirements
 
 `web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`, so this crate

--- a/rs/web-transport-wasm/examples/harness.html
+++ b/rs/web-transport-wasm/examples/harness.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>web-transport-wasm harness</title>
+<style>
+  body { font: 14px/1.5 system-ui, sans-serif; margin: 2rem; max-width: 60rem; }
+  table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+  th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid #8884; vertical-align: top; }
+  td.ok { color: #0a0; font-weight: 600; }
+  td.fail { color: #c00; font-weight: 600; }
+  code { font-family: ui-monospace, monospace; }
+  #summary { margin-top: 1rem; font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>web-transport-wasm harness</h1>
+<p>
+  Drives the poll state machine against a real browser and a real QUIC peer.
+  Start <code>harness-server</code> first — see <code>just harness</code>.
+</p>
+<div id="status">loading…</div>
+<table id="results" hidden>
+  <thead><tr><th>check</th><th>result</th><th>detail</th></tr></thead>
+  <tbody></tbody>
+</table>
+<div id="summary"></div>
+
+<script type="module">
+import init, { run } from "./harness.js";
+
+const params = new URLSearchParams(location.search);
+const url = params.get("url") || "https://localhost:4443";
+
+const status = document.getElementById("status");
+const table = document.getElementById("results");
+const tbody = table.querySelector("tbody");
+const summary = document.getElementById("summary");
+
+// Exposed so an automated runner can wait for the result rather than guess.
+window.harness = { done: false, passed: 0, failed: 0, rows: [] };
+
+try {
+  const hash = (await (await fetch("./localhost.hex")).text()).trim();
+  await init();
+
+  status.textContent = `running against ${url}…`;
+  const rows = await run(url, hash);
+
+  table.hidden = false;
+  for (const row of rows) {
+    const tr = document.createElement("tr");
+    const name = document.createElement("td");
+    name.textContent = row.name;
+    const verdict = document.createElement("td");
+    verdict.textContent = row.ok ? "pass" : "FAIL";
+    verdict.className = row.ok ? "ok" : "fail";
+    const detail = document.createElement("td");
+    detail.textContent = row.detail;
+    tr.append(name, verdict, detail);
+    tbody.append(tr);
+
+    window.harness.rows.push({ name: row.name, ok: row.ok, detail: row.detail });
+    if (row.ok) window.harness.passed++; else window.harness.failed++;
+  }
+
+  status.textContent = `ran against ${url}`;
+  summary.textContent = `${window.harness.passed} passed, ${window.harness.failed} failed`;
+} catch (err) {
+  status.textContent = "harness failed to run: " + err;
+  window.harness.failed = 1;
+} finally {
+  window.harness.done = true;
+}
+</script>
+</body>
+</html>

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -1,3 +1,5 @@
+#![cfg(target_family = "wasm")]
+
 //! A browser harness for the poll state machine.
 //!
 //! `cargo check` proves this crate compiles for `wasm32`; nothing in CI runs it,
@@ -57,6 +59,10 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
     );
     check!("peer reset code reaches the receiver", peer_reset_code);
     check!("datagram round trip", datagram_round_trip);
+    check!(
+        "synchronous datagrams continue after settlement",
+        synchronous_datagrams_continue
+    );
     check!("session close code and reason survive", session_close);
 
     Ok(results)
@@ -122,10 +128,21 @@ async fn accept_all(session: Session) -> Result<String, Error> {
 /// outstanding before the peer opens anything.
 async fn orphaned_accept(session: Session) -> Result<String, Error> {
     let doomed = session.clone();
+    let survivor = session.clone();
 
     // One poll, with a waker that goes nowhere: enough to issue the browser read.
     let mut cx = Context::from_waker(Waker::noop());
     match doomed.poll_accept_uni(&mut cx) {
+        Poll::Pending => {}
+        Poll::Ready(Ok(_)) => {
+            return expect(false, "a stream arrived before one was asked for".into())
+        }
+        Poll::Ready(Err(err)) => return Err(err),
+    }
+
+    // Issue a newer read on the handle that survives. The older orphan must take
+    // precedence over this request, even though this handle is no longer idle.
+    match survivor.poll_accept_uni(&mut cx) {
         Poll::Pending => {}
         Poll::Ready(Ok(_)) => {
             return expect(false, "a stream arrived before one was asked for".into())
@@ -138,9 +155,9 @@ async fn orphaned_accept(session: Session) -> Result<String, Error> {
     read_all(&mut ack).await?;
     drop(doomed);
 
-    let mut recv = timeout(session.accept_uni(), 3_000)
-        .await
-        .map_err(|_| stalled("accept_uni never resolved: the dropped clone ate the stream"))??;
+    let mut recv = timeout(survivor.accept_uni(), 3_000).await.map_err(|_| {
+        stalled("accept_uni never resolved: the surviving clone ignored an older orphan")
+    })??;
 
     let got = read_all(&mut recv).await?;
     expect(got == "stream-0", format!("accepted {got:?}"))
@@ -193,6 +210,32 @@ async fn datagram_round_trip(session: Session) -> Result<String, Error> {
     expect(
         got.as_ref() == b"ping",
         format!("received {:?}", String::from_utf8_lossy(&got)),
+    )
+}
+
+/// A settled promise must not permanently occupy the synchronous trait adapter's
+/// one retained slot. Receiving the first echo proves that write has completed
+/// before a second datagram is offered.
+async fn synchronous_datagrams_continue(session: Session) -> Result<String, Error> {
+    web_transport_trait::Session::send_datagram(&session, b"first".as_slice().into())?;
+
+    let first = timeout(session.recv_datagram(), 3_000)
+        .await
+        .map_err(|_| stalled("the first synchronous datagram was not echoed"))??;
+
+    web_transport_trait::Session::send_datagram(&session, b"second".as_slice().into())?;
+
+    let second = timeout(session.recv_datagram(), 3_000)
+        .await
+        .map_err(|_| stalled("a settled write blocked the second synchronous datagram"))??;
+
+    expect(
+        first.as_ref() == b"first" && second.as_ref() == b"second",
+        format!(
+            "received {:?}, then {:?}",
+            String::from_utf8_lossy(&first),
+            String::from_utf8_lossy(&second)
+        ),
     )
 }
 

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -15,6 +15,7 @@
 //! rest.
 
 use std::{
+    future::poll_fn,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -74,12 +75,20 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
     check!("peer reset code reaches the receiver", peer_reset_code);
     check!("datagram round trip", datagram_round_trip);
     check!(
+        "closed datagram writer terminates poll",
+        closed_datagram_writer_terminates
+    );
+    check!(
         "cloned poll sends honor shared capacity",
         cloned_poll_sends_honor_capacity
     );
     check!(
         "synchronous datagrams continue after settlement",
         synchronous_datagrams_continue
+    );
+    check!(
+        "rejected stream write makes the stream terminal",
+        rejected_write_is_terminal
     );
     check!("session close code and reason survive", session_close);
 
@@ -96,7 +105,7 @@ async fn connect(url: &url::Url, hash: &[u8]) -> Result<Session, Error> {
 /// Send a harness command and hand back the stream the reply arrives on.
 async fn command(session: &Session, command: &str) -> Result<RecvStream, Error> {
     let (mut send, recv) = session.open_bi().await?;
-    send.write(command.as_bytes()).await?;
+    send.write(format!("{command}\n").as_bytes()).await?;
     send.finish()?;
     Ok(recv)
 }
@@ -277,6 +286,21 @@ async fn datagram_round_trip(session: Session) -> Result<String, Error> {
     )
 }
 
+async fn closed_datagram_writer_terminates(session: Session) -> Result<String, Error> {
+    session.send_datagram(b"prime".as_slice().into()).await?;
+    let _ = session.recv_datagram().await?;
+    session.close(0, "done");
+    let _ = timeout(session.closed(), 1_000)
+        .await
+        .map_err(|_| stalled("session did not close"))?;
+
+    match timeout(poll_fn(|cx| session.poll_send_datagram(cx, b"late")), 1_000).await {
+        Ok(Err(_)) => expect(true, "closed writer returned an error".into()),
+        Ok(Ok(())) => expect(false, "closed writer accepted a datagram".into()),
+        Err(()) => expect(false, "closed writer stayed in a wake loop".into()),
+    }
+}
+
 /// Every clone shares one browser writer, so an idle per-clone operation slot must
 /// not bypass the writer's shared backpressure signal.
 async fn cloned_poll_sends_honor_capacity(session: Session) -> Result<String, Error> {
@@ -321,6 +345,33 @@ async fn synchronous_datagrams_continue(session: Session) -> Result<String, Erro
             String::from_utf8_lossy(&second)
         ),
     )
+}
+
+async fn rejected_write_is_terminal(session: Session) -> Result<String, Error> {
+    let (mut send, _recv) = session.open_bi().await?;
+    send.write(b"stop 42\n").await?;
+
+    let _first_error = timeout(
+        async {
+            loop {
+                match send.write(b"trigger").await {
+                    Ok(()) => sleep(10).await,
+                    Err(err) => break err,
+                }
+            }
+        },
+        1_000,
+    )
+    .await
+    .map_err(|_| stalled("peer STOP_SENDING never rejected a write"))?;
+
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    match send.poll_write(&mut cx, b"retry") {
+        Poll::Ready(Err(Error::Closed)) => expect(true, "retry returned Closed".into()),
+        Poll::Ready(Err(err)) => expect(false, format!("retry returned {err}")),
+        Poll::Ready(Ok(size)) => expect(false, format!("retry accepted {size} bytes")),
+        Poll::Pending => expect(false, "retry remained pending after failure".into()),
+    }
 }
 
 /// A session close carries its code and reason out through the error.

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -90,6 +90,10 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
         "rejected stream write makes the stream terminal",
         rejected_write_is_terminal
     );
+    check!(
+        "concurrent cloned senders all get capacity",
+        concurrent_datagram_senders
+    );
     check!("session close code and reason survive", session_close);
 
     Ok(results)
@@ -390,6 +394,67 @@ async fn session_close(session: Session) -> Result<String, Error> {
         }
         other => expect(false, format!("session_error() was {other:?}")),
     }
+}
+
+/// Cloned senders share one browser writer, so they share its backpressure.
+///
+/// When two are parked on the same `ready` promise and capacity returns, only one
+/// wins. The loser sees the capacity gone again -- and the `ready` it holds has
+/// already fulfilled and never will again, because the writer swaps in a fresh
+/// promise. It has to resubscribe to that new one. Falling back to `closed()`
+/// instead parks it for the life of the session, which is a deadlock dressed up as
+/// backpressure.
+///
+/// Driven by hand rather than by volume: the race needs two clones parked on one
+/// promise at the same instant, and a loop of `await`s lets capacity recover
+/// between polls often enough to miss it entirely.
+async fn concurrent_datagram_senders(session: Session) -> Result<String, Error> {
+    let winner = session.clone();
+    let loser = session.clone();
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+
+    // Take the writer's only slot, so the other two have to wait.
+    match session.poll_send_datagram(&mut cx, b"first") {
+        Poll::Ready(Ok(())) => {}
+        Poll::Ready(Err(err)) => return Err(err),
+        Poll::Pending => return expect(false, "the first datagram had no capacity".into()),
+    }
+
+    // Both park on the *same* ready promise, which is what sets up the race.
+    for (label, clone) in [("winner", &winner), ("loser", &loser)] {
+        match clone.poll_send_datagram(&mut cx, b"queued") {
+            Poll::Pending => {}
+            Poll::Ready(Ok(())) => {
+                return expect(false, format!("the {label} bypassed shared capacity"))
+            }
+            Poll::Ready(Err(err)) => return Err(err),
+        }
+    }
+
+    // Let capacity come back, then let one of them take it.
+    let mut won = false;
+    for _ in 0..20 {
+        sleep(25).await;
+        match winner.poll_send_datagram(&mut cx, b"winner") {
+            Poll::Ready(Ok(())) => {
+                won = true;
+                break;
+            }
+            Poll::Ready(Err(err)) => return Err(err),
+            Poll::Pending => continue,
+        }
+    }
+
+    if !won {
+        return expect(false, "capacity never returned for the winner".into());
+    }
+
+    // The loser is now holding a fulfilled `ready` with no capacity behind it.
+    timeout(poll_fn(|cx| loser.poll_send_datagram(cx, b"loser")), 5_000)
+        .await
+        .map_err(|_| stalled("the clone that lost the capacity race never woke again"))??;
+
+    expect(true, "the loser resubscribed and sent".into())
 }
 
 // --- helpers ------------------------------------------------------------------

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -61,6 +61,10 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
     }
 
     check!("echo round trip", echo_round_trip);
+    check!(
+        "dropped pending opens release stream credit",
+        dropped_pending_opens_release_credit
+    );
     check!("accept_uni delivers every stream", accept_all);
     check!("a dropped clone does not swallow a stream", orphaned_accept);
     check!(
@@ -113,6 +117,38 @@ async fn echo_round_trip(session: Session) -> Result<String, Error> {
     let got = read_all(&mut recv).await?;
 
     expect(got == "hello harness", format!("echoed {got:?}"))
+}
+
+/// Dropping a handle cannot cancel the browser promise returned by open. Churn
+/// past the peer's stream limit, then prove those abandoned opens were reset and
+/// returned their credit rather than blocking the next real stream forever.
+async fn dropped_pending_opens_release_credit(session: Session) -> Result<String, Error> {
+    for _ in 0..110 {
+        let doomed = session.clone();
+        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+
+        match doomed.poll_open_bi(&mut cx) {
+            Poll::Pending => {}
+            Poll::Ready(Ok((mut send, mut recv))) => {
+                send.reset(0);
+                recv.stop(0);
+            }
+            Poll::Ready(Err(err)) => return Err(err),
+        }
+    }
+
+    sleep(250).await;
+    let got = timeout(
+        async {
+            let mut recv = command(&session, "echo credit returned").await?;
+            read_all(&mut recv).await
+        },
+        3_000,
+    )
+    .await
+    .map_err(|_| stalled("an abandoned open retained the peer's stream credit"))??;
+
+    expect(got == "credit returned", format!("echoed {got:?}"))
 }
 
 /// Every stream the peer opens is delivered, in order.
@@ -383,4 +419,12 @@ async fn timeout<T>(future: impl std::future::Future<Output = T>, millis: i32) -
         futures::future::Either::Left((value, _)) => Ok(value),
         futures::future::Either::Right(_) => Err(()),
     }
+}
+
+async fn sleep(millis: i32) {
+    let promise = js_sys::Promise::new(&mut |resolve, _| {
+        let window = web_sys::window().expect("no window");
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis);
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
 }

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -39,6 +39,12 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
         .parse()
         .map_err(|_| JsValue::from_str("bad harness url"))?;
 
+    results.push(&row(
+        "malformed certificate hash is rejected",
+        decode_hex("é").is_none(),
+        "non-ASCII input returned None without panicking",
+    ));
+
     // Each check gets its own session, so one that closes or wedges the connection
     // cannot decide the outcome of the next.
     macro_rules! check {
@@ -240,7 +246,7 @@ async fn datagram_round_trip(session: Session) -> Result<String, Error> {
 async fn cloned_poll_sends_honor_capacity(session: Session) -> Result<String, Error> {
     let first = session.clone();
     let second = session.clone();
-    let mut cx = Context::from_waker(Waker::noop());
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
 
     match first.poll_send_datagram(&mut cx, b"first") {
         Poll::Ready(Ok(())) => {}
@@ -336,14 +342,17 @@ fn row(name: &str, ok: bool, detail: &str) -> Object {
 }
 
 fn decode_hex(hex: &str) -> Option<Vec<u8>> {
-    let hex = hex.trim();
-    if !hex.len().is_multiple_of(2) {
+    let hex = hex.trim().as_bytes();
+    let pairs = hex.chunks_exact(2);
+    if !pairs.remainder().is_empty() {
         return None;
     }
 
-    (0..hex.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+    pairs
+        .map(|pair| {
+            let pair = std::str::from_utf8(pair).ok()?;
+            u8::from_str_radix(pair, 16).ok()
+        })
         .collect()
 }
 

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -1,0 +1,279 @@
+//! A browser harness for the poll state machine.
+//!
+//! `cargo check` proves this crate compiles for `wasm32`; nothing in CI runs it,
+//! because the browser API it wraps only exists in a browser. So the paths that are
+//! easiest to get wrong — an accept whose handle went away, a closed-watch racing
+//! buffered bytes, a peer reset code — had no coverage at all. This runs them
+//! against a real browser and a real QUIC peer.
+//!
+//! Pair it with `harness-server` from `web-transport-quinn`, which is driven by the
+//! commands sent here. See `just harness`.
+//!
+//! Each check returns a row rather than panicking, so one failure does not hide the
+//! rest.
+
+use std::{
+    rc::Rc,
+    task::{Context, Poll, Waker},
+};
+
+use js_sys::{Array, Object, Reflect};
+use wasm_bindgen::prelude::*;
+use web_transport_wasm::{ClientBuilder, Error, RecvStream, Session};
+
+/// Run every check against `url`, trusting the sha-256 certificate hash `hash`.
+///
+/// Returns an array of `{ name, ok, detail }` for the page to render.
+#[wasm_bindgen]
+pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
+    let results = Array::new();
+
+    let hash = decode_hex(&hash).ok_or_else(|| JsValue::from_str("bad certificate hash"))?;
+    let url: url::Url = url
+        .parse()
+        .map_err(|_| JsValue::from_str("bad harness url"))?;
+
+    // Each check gets its own session, so one that closes or wedges the connection
+    // cannot decide the outcome of the next.
+    macro_rules! check {
+        ($name:expr, $body:expr) => {{
+            let outcome = match connect(&url, &hash).await {
+                Ok(session) => match $body(session).await {
+                    Ok(detail) => row($name, true, &detail),
+                    Err(err) => row($name, false, &format!("{err}")),
+                },
+                Err(err) => row($name, false, &format!("connect failed: {err}")),
+            };
+            results.push(&outcome);
+        }};
+    }
+
+    check!("echo round trip", echo_round_trip);
+    check!("accept_uni delivers every stream", accept_all);
+    check!("a dropped clone does not swallow a stream", orphaned_accept);
+    check!(
+        "closed() resolves with bytes still buffered",
+        closed_with_buffered
+    );
+    check!("peer reset code reaches the receiver", peer_reset_code);
+    check!("datagram round trip", datagram_round_trip);
+    check!("session close code and reason survive", session_close);
+
+    Ok(results)
+}
+
+async fn connect(url: &url::Url, hash: &[u8]) -> Result<Session, Error> {
+    ClientBuilder::new()
+        .with_server_certificate_hashes(vec![hash.to_vec()])
+        .connect(url.clone())
+        .await
+}
+
+/// Send a harness command and hand back the stream the reply arrives on.
+async fn command(session: &Session, command: &str) -> Result<RecvStream, Error> {
+    let (mut send, recv) = session.open_bi().await?;
+    send.write(command.as_bytes()).await?;
+    send.finish()?;
+    Ok(recv)
+}
+
+/// Read a receive stream to the end.
+async fn read_all(recv: &mut RecvStream) -> Result<String, Error> {
+    let mut out = Vec::new();
+    while let Some(chunk) = recv.read(4096).await? {
+        out.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&out).into_owned())
+}
+
+/// Open a stream, say something, and get it back. The baseline: if this fails,
+/// nothing below means anything.
+async fn echo_round_trip(session: Session) -> Result<String, Error> {
+    let mut recv = command(&session, "echo hello harness").await?;
+    let got = read_all(&mut recv).await?;
+
+    expect(got == "hello harness", format!("echoed {got:?}"))
+}
+
+/// Every stream the peer opens is delivered, in order.
+async fn accept_all(session: Session) -> Result<String, Error> {
+    let mut ack = command(&session, "streams 3").await?;
+    read_all(&mut ack).await?;
+
+    let mut seen = Vec::new();
+    for _ in 0..3 {
+        let mut recv = session.accept_uni().await?;
+        seen.push(read_all(&mut recv).await?);
+    }
+
+    expect(
+        seen == ["stream-0", "stream-1", "stream-2"],
+        format!("accepted {seen:?}"),
+    )
+}
+
+/// The regression this harness exists for.
+///
+/// A browser `read()` cannot be cancelled: once issued, the browser hands the next
+/// stream to *that* request. A clone that polls accept and is then dropped used to
+/// take the next stream down with it, and the surviving handle waited forever.
+///
+/// The clone is polled by hand rather than awaited, so its read is definitely
+/// outstanding before the peer opens anything.
+async fn orphaned_accept(session: Session) -> Result<String, Error> {
+    let doomed = session.clone();
+
+    // One poll, with a waker that goes nowhere: enough to issue the browser read.
+    let mut cx = Context::from_waker(Waker::noop());
+    match doomed.poll_accept_uni(&mut cx) {
+        Poll::Pending => {}
+        Poll::Ready(Ok(_)) => {
+            return expect(false, "a stream arrived before one was asked for".into())
+        }
+        Poll::Ready(Err(err)) => return Err(err),
+    }
+
+    // Now ask the peer for one, and drop the handle whose read is outstanding.
+    let mut ack = command(&session, "streams 1").await?;
+    read_all(&mut ack).await?;
+    drop(doomed);
+
+    let mut recv = timeout(session.accept_uni(), 3_000)
+        .await
+        .map_err(|_| stalled("accept_uni never resolved: the dropped clone ate the stream"))??;
+
+    let got = read_all(&mut recv).await?;
+    expect(got == "stream-0", format!("accepted {got:?}"))
+}
+
+/// The other regression.
+///
+/// `closed()` used to defer while bytes sat in our buffer, waiting for the caller to
+/// drain them -- but it borrows `&mut self`, so a caller waiting there is a caller
+/// who cannot read. Reading one byte at a time guarantees a leftover buffer.
+async fn closed_with_buffered(session: Session) -> Result<String, Error> {
+    let mut recv = command(&session, "echo abcdefgh").await?;
+
+    // A single byte, leaving the rest of the browser's chunk buffered in the stream.
+    let first = recv.read(1).await?;
+    if first.as_deref() != Some(b"a".as_slice()) {
+        return expect(false, format!("first read was {first:?}"));
+    }
+
+    timeout(recv.closed(), 3_000)
+        .await
+        .map_err(|_| stalled("closed() hung behind buffered bytes"))??;
+
+    // And the bytes we had not taken yet are still there afterwards.
+    let rest = read_all(&mut recv).await?;
+    expect(rest == "bcdefgh", format!("rest was {rest:?}"))
+}
+
+/// A peer RESET_STREAM arrives with its code intact.
+async fn peer_reset_code(session: Session) -> Result<String, Error> {
+    let mut recv = command(&session, "reset 42").await?;
+
+    let code = timeout(recv.closed(), 3_000)
+        .await
+        .map_err(|_| stalled("closed() never saw the reset"))?;
+
+    match code {
+        Ok(Some(42)) => expect(true, "code 42".to_string()),
+        other => expect(false, format!("got {other:?}")),
+    }
+}
+
+async fn datagram_round_trip(session: Session) -> Result<String, Error> {
+    session.send_datagram(b"ping".as_slice().into()).await?;
+
+    let got = timeout(session.recv_datagram(), 3_000)
+        .await
+        .map_err(|_| stalled("no datagram came back"))??;
+
+    expect(
+        got.as_ref() == b"ping",
+        format!("received {:?}", String::from_utf8_lossy(&got)),
+    )
+}
+
+/// A session close carries its code and reason out through the error.
+async fn session_close(session: Session) -> Result<String, Error> {
+    let mut ack = command(&session, "close 7 goodbye").await?;
+    let _ = read_all(&mut ack).await;
+
+    let err = timeout(session.closed(), 3_000)
+        .await
+        .map_err(|_| stalled("closed() never resolved"))?;
+
+    use web_transport_trait::Error as _;
+    match err.session_error() {
+        Some((7, reason)) if reason.contains("goodbye") => {
+            expect(true, format!("code 7, reason {reason:?}"))
+        }
+        other => expect(false, format!("session_error() was {other:?}")),
+    }
+}
+
+// --- helpers ------------------------------------------------------------------
+
+fn expect(ok: bool, detail: String) -> Result<String, Error> {
+    if ok {
+        Ok(detail)
+    } else {
+        Err(stalled(&detail))
+    }
+}
+
+/// A stand-in error for a harness assertion, so a check can fail like any other.
+fn stalled(detail: &str) -> Error {
+    Error::Unknown(JsValue::from_str(detail))
+}
+
+fn row(name: &str, ok: bool, detail: &str) -> Object {
+    let row = Object::new();
+    let _ = Reflect::set(&row, &"name".into(), &name.into());
+    let _ = Reflect::set(&row, &"ok".into(), &ok.into());
+    let _ = Reflect::set(&row, &"detail".into(), &detail.into());
+    row
+}
+
+fn decode_hex(hex: &str) -> Option<Vec<u8>> {
+    let hex = hex.trim();
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+        .collect()
+}
+
+/// Resolve `future`, or `Err(())` once `millis` have passed.
+///
+/// A hang is the failure mode for most of these checks, and a hung check would
+/// otherwise take the whole page down with it.
+async fn timeout<T>(future: impl std::future::Future<Output = T>, millis: i32) -> Result<T, ()> {
+    let elapsed = Rc::new(std::cell::Cell::new(false));
+
+    let sleep = {
+        let elapsed = elapsed.clone();
+        async move {
+            let promise = js_sys::Promise::new(&mut |resolve, _| {
+                let window = web_sys::window().expect("no window");
+                let _ =
+                    window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis);
+            });
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+            elapsed.set(true);
+        }
+    };
+
+    futures::pin_mut!(future, sleep);
+
+    let output = futures::future::select(future, sleep).await;
+    match output {
+        futures::future::Either::Left((value, _)) => Ok(value),
+        futures::future::Either::Right(_) => Err(()),
+    }
+}

--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -16,7 +16,11 @@
 
 use std::{
     rc::Rc,
-    task::{Context, Poll, Waker},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll, Wake, Waker},
 };
 
 use js_sys::{Array, Object, Reflect};
@@ -59,6 +63,10 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
     );
     check!("peer reset code reaches the receiver", peer_reset_code);
     check!("datagram round trip", datagram_round_trip);
+    check!(
+        "cloned poll sends honor shared capacity",
+        cloned_poll_sends_honor_capacity
+    );
     check!(
         "synchronous datagrams continue after settlement",
         synchronous_datagrams_continue
@@ -129,9 +137,12 @@ async fn accept_all(session: Session) -> Result<String, Error> {
 async fn orphaned_accept(session: Session) -> Result<String, Error> {
     let doomed = session.clone();
     let survivor = session.clone();
+    let doomed_wake = Arc::new(FlagWake::default());
+    let survivor_wake = Arc::new(FlagWake::default());
 
-    // One poll, with a waker that goes nowhere: enough to issue the browser read.
-    let mut cx = Context::from_waker(Waker::noop());
+    // One poll with its own task identity: enough to issue the browser read.
+    let doomed_waker = Waker::from(doomed_wake);
+    let mut cx = Context::from_waker(&doomed_waker);
     match doomed.poll_accept_uni(&mut cx) {
         Poll::Pending => {}
         Poll::Ready(Ok(_)) => {
@@ -142,6 +153,8 @@ async fn orphaned_accept(session: Session) -> Result<String, Error> {
 
     // Issue a newer read on the handle that survives. The older orphan must take
     // precedence over this request, even though this handle is no longer idle.
+    let survivor_waker = Waker::from(survivor_wake.clone());
+    let mut cx = Context::from_waker(&survivor_waker);
     match survivor.poll_accept_uni(&mut cx) {
         Poll::Pending => {}
         Poll::Ready(Ok(_)) => {
@@ -150,10 +163,19 @@ async fn orphaned_accept(session: Session) -> Result<String, Error> {
         Poll::Ready(Err(err)) => return Err(err),
     }
 
-    // Now ask the peer for one, and drop the handle whose read is outstanding.
-    let mut ack = command(&session, "streams 1").await?;
+    // The peer acknowledges before waiting to open the stream, making the drop
+    // happen while both reads are still pending. The dropped task's waker cannot
+    // help once the browser eventually fulfills its older request.
+    let mut ack = command(&session, "streams-after 250 1").await?;
     read_all(&mut ack).await?;
     drop(doomed);
+
+    if !survivor_wake.0.swap(false, Ordering::SeqCst) {
+        return expect(
+            false,
+            "dropping the older read did not wake the survivor".into(),
+        );
+    }
 
     let mut recv = timeout(survivor.accept_uni(), 3_000).await.map_err(|_| {
         stalled("accept_uni never resolved: the surviving clone ignored an older orphan")
@@ -213,6 +235,26 @@ async fn datagram_round_trip(session: Session) -> Result<String, Error> {
     )
 }
 
+/// Every clone shares one browser writer, so an idle per-clone operation slot must
+/// not bypass the writer's shared backpressure signal.
+async fn cloned_poll_sends_honor_capacity(session: Session) -> Result<String, Error> {
+    let first = session.clone();
+    let second = session.clone();
+    let mut cx = Context::from_waker(Waker::noop());
+
+    match first.poll_send_datagram(&mut cx, b"first") {
+        Poll::Ready(Ok(())) => {}
+        Poll::Ready(Err(err)) => return Err(err),
+        Poll::Pending => return expect(false, "the first datagram had no capacity".into()),
+    }
+
+    match second.poll_send_datagram(&mut cx, b"second") {
+        Poll::Pending => expect(true, "the second clone observed shared backpressure".into()),
+        Poll::Ready(Ok(())) => expect(false, "the second clone bypassed shared capacity".into()),
+        Poll::Ready(Err(err)) => Err(err),
+    }
+}
+
 /// A settled promise must not permanently occupy the synchronous trait adapter's
 /// one retained slot. Receiving the first echo proves that write has completed
 /// before a second datagram is offered.
@@ -258,6 +300,19 @@ async fn session_close(session: Session) -> Result<String, Error> {
 }
 
 // --- helpers ------------------------------------------------------------------
+
+#[derive(Default)]
+struct FlagWake(AtomicBool);
+
+impl Wake for FlagWake {
+    fn wake(self: Arc<Self>) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
 
 fn expect(ok: bool, detail: String) -> Result<String, Error> {
     if ok {

--- a/rs/web-transport-wasm/src/error.rs
+++ b/rs/web-transport-wasm/src/error.rs
@@ -1,3 +1,4 @@
+use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
 
 /// A WebTransport error classified based on the source.
@@ -22,9 +23,9 @@ pub enum Error {
 
 impl Error {
     /// The error code used when closing the stream or session.
-    pub fn code(&self) -> Option<u8> {
+    pub fn code(&self) -> Option<u32> {
         match self {
-            Error::Session(e) | Error::Stream(e) => e.stream_error_code(),
+            Error::Session(e) | Error::Stream(e) => stream_error_code(e),
             _ => None,
         }
     }
@@ -45,19 +46,51 @@ impl From<JsValue> for Error {
     }
 }
 
+// `web-sys` types `streamErrorCode` as a byte, from a WebIDL draft that has since
+// widened it to `unsigned long`. Its setter would send any code above 255 as none,
+// and its getter truncates one into a different code's meaning, so both directions
+// go around the binding until `web-sys` catches up.
+//
+// <https://www.w3.org/TR/webtransport/#dictdef-webtransporterroroptions>
+
+/// The code carried by a `WebTransportError`, if it has one.
+pub(crate) fn stream_error_code(err: &web_sys::WebTransportError) -> Option<u32> {
+    let code = Reflect::get(err, &"streamErrorCode".into())
+        .ok()?
+        .as_f64()?;
+
+    // Anything outside the range is not a code we could have been sent.
+    (code >= 0.0 && code <= u32::MAX as f64).then_some(code as u32)
+}
+
 /// A `WebTransportError` carrying `code`, which is how a browser stream cancel or
 /// abort names the STOP_SENDING or RESET_STREAM code it sends.
 ///
-/// Any other reason — a plain string, say — reaches the peer as code 0. The browser
-/// API carries the code as a byte, so a larger one is sent as 0 rather than
-/// truncated into some other code's meaning.
+/// Any other reason — a plain string, say — reaches the peer as code 0.
 pub(crate) fn stream_error(code: u32) -> JsValue {
     let options = web_sys::WebTransportErrorOptions::new();
     options.set_source(web_sys::WebTransportErrorSource::Stream);
-    options.set_stream_error_code(u8::try_from(code).ok());
+    let _ = Reflect::set(&options, &"streamErrorCode".into(), &JsValue::from(code));
 
     match web_sys::WebTransportError::new_with_message_and_options("", &options) {
         Ok(err) => err.into(),
         Err(err) => err,
+    }
+}
+
+/// The error a session close info describes, which is how a clean close reaches a
+/// caller.
+pub(crate) fn session_error(info: &web_sys::WebTransportCloseInfo) -> Error {
+    let reason = info.get_reason().unwrap_or_default();
+
+    let options = web_sys::WebTransportErrorOptions::new();
+    options.set_source(web_sys::WebTransportErrorSource::Session);
+
+    let code = info.get_close_code().unwrap_or(0);
+    let _ = Reflect::set(&options, &"streamErrorCode".into(), &JsValue::from(code));
+
+    match web_sys::WebTransportError::new_with_message_and_options(&reason, &options) {
+        Ok(err) => Error::Session(err),
+        Err(err) => Error::from(err),
     }
 }

--- a/rs/web-transport-wasm/src/error.rs
+++ b/rs/web-transport-wasm/src/error.rs
@@ -1,14 +1,20 @@
-use js_sys::Reflect;
+use js_sys::{Array, Function, Object, Reflect};
 use wasm_bindgen::prelude::*;
 
 /// A WebTransport error classified based on the source.
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
+    /// The session was closed, by us or by the peer.
+    ///
+    /// Carries the code and reason directly rather than a `WebTransportError`,
+    /// because the browser will not build one of those with a session source: the
+    /// `source` member of the constructor's dictionary is ignored and the result is
+    /// always a stream error.
+    #[error("webtransport session error: code={code} reason={reason:?}")]
+    Session { code: u32, reason: String },
+
     // `WebTransportError` is a `DOMException`, so its message is the reason the peer
     // sent. Printing the JS object instead would bury that in a handle dump.
-    #[error("webtransport session error: {}", .0.message())]
-    Session(web_sys::WebTransportError),
-
     #[error("webtransport stream error: {}", .0.message())]
     Stream(web_sys::WebTransportError),
 
@@ -25,7 +31,8 @@ impl Error {
     /// The error code used when closing the stream or session.
     pub fn code(&self) -> Option<u32> {
         match self {
-            Error::Session(e) | Error::Stream(e) => stream_error_code(e),
+            Error::Session { code, .. } => Some(*code),
+            Error::Stream(e) => stream_error_code(e),
             _ => None,
         }
     }
@@ -37,7 +44,10 @@ impl From<JsValue> for Error {
         if let Some(e) = v.dyn_ref::<web_sys::WebTransportError>().cloned() {
             match e.source() {
                 web_sys::WebTransportErrorSource::Stream => Error::Stream(e),
-                web_sys::WebTransportErrorSource::Session => Error::Session(e),
+                web_sys::WebTransportErrorSource::Session => Error::Session {
+                    code: stream_error_code(&e).unwrap_or(0),
+                    reason: e.message(),
+                },
                 _ => Error::Unknown(v),
             }
         } else {
@@ -46,14 +56,23 @@ impl From<JsValue> for Error {
     }
 }
 
-// `web-sys` types `streamErrorCode` as a byte, from a WebIDL draft that has since
-// widened it to `unsigned long`. Its setter would send any code above 255 as none,
-// and its getter truncates one into a different code's meaning, so both directions
-// go around the binding until `web-sys` catches up.
-//
-// <https://www.w3.org/TR/webtransport/#dictdef-webtransporterroroptions>
+/// The error a session close info describes, which is how a clean close reaches a
+/// caller.
+///
+/// No JS object is built here. A session close code is a full `u32` — unlike a
+/// stream code, which the browser clamps to a byte — and nothing would carry it.
+pub(crate) fn session_error(info: &web_sys::WebTransportCloseInfo) -> Error {
+    Error::Session {
+        code: info.get_close_code().unwrap_or(0),
+        reason: info.get_reason().unwrap_or_default(),
+    }
+}
 
 /// The code carried by a `WebTransportError`, if it has one.
+///
+/// Read through `Reflect` rather than `web-sys`'s getter so a browser that widens
+/// the field past a byte is reported faithfully rather than truncated into some
+/// other code's meaning.
 pub(crate) fn stream_error_code(err: &web_sys::WebTransportError) -> Option<u32> {
     let code = Reflect::get(err, &"streamErrorCode".into())
         .ok()?
@@ -64,33 +83,29 @@ pub(crate) fn stream_error_code(err: &web_sys::WebTransportError) -> Option<u32>
 }
 
 /// A `WebTransportError` carrying `code`, which is how a browser stream cancel or
-/// abort names the STOP_SENDING or RESET_STREAM code it sends.
+/// abort names the STOP_SENDING or RESET_STREAM code it sends. Any other reason — a
+/// plain string, say — reaches the peer as code 0.
 ///
-/// Any other reason — a plain string, say — reaches the peer as code 0.
+/// Built by hand because `web-sys` binds the constructor as
+/// `new WebTransportError(message, options)`, an older form that browsers reject
+/// with a `TypeError`; it takes a single init dictionary. Falling back to that
+/// binding would send every code as 0, since the thrown `TypeError` is not a
+/// `WebTransportError` and the browser reads no code out of it.
+///
+/// Browsers clamp the code to a byte, so anything above 255 reaches the peer as
+/// 255. That is deliberately not clamped here: the wire and the trait both carry a
+/// `u32`, and a browser that implements the wider field should get the real code.
 pub(crate) fn stream_error(code: u32) -> JsValue {
-    let options = web_sys::WebTransportErrorOptions::new();
-    options.set_source(web_sys::WebTransportErrorSource::Stream);
-    let _ = Reflect::set(&options, &"streamErrorCode".into(), &JsValue::from(code));
+    let init = Object::new();
+    let _ = Reflect::set(&init, &"streamErrorCode".into(), &JsValue::from(code));
 
-    match web_sys::WebTransportError::new_with_message_and_options("", &options) {
-        Ok(err) => err.into(),
-        Err(err) => err,
-    }
+    construct_error(&init).unwrap_or(JsValue::UNDEFINED)
 }
 
-/// The error a session close info describes, which is how a clean close reaches a
-/// caller.
-pub(crate) fn session_error(info: &web_sys::WebTransportCloseInfo) -> Error {
-    let reason = info.get_reason().unwrap_or_default();
+/// `new WebTransportError(init)`, or `None` if the browser has no such constructor.
+fn construct_error(init: &Object) -> Option<JsValue> {
+    let ctor = Reflect::get(&js_sys::global(), &"WebTransportError".into()).ok()?;
+    let ctor = ctor.dyn_into::<Function>().ok()?;
 
-    let options = web_sys::WebTransportErrorOptions::new();
-    options.set_source(web_sys::WebTransportErrorSource::Session);
-
-    let code = info.get_close_code().unwrap_or(0);
-    let _ = Reflect::set(&options, &"streamErrorCode".into(), &JsValue::from(code));
-
-    match web_sys::WebTransportError::new_with_message_and_options(&reason, &options) {
-        Ok(err) => Error::Session(err),
-        Err(err) => Error::from(err),
-    }
+    Reflect::construct(&ctor, &Array::of1(init)).ok()
 }

--- a/rs/web-transport-wasm/src/error.rs
+++ b/rs/web-transport-wasm/src/error.rs
@@ -44,10 +44,10 @@ impl From<JsValue> for Error {
         if let Some(e) = v.dyn_ref::<web_sys::WebTransportError>().cloned() {
             match e.source() {
                 web_sys::WebTransportErrorSource::Stream => Error::Stream(e),
-                web_sys::WebTransportErrorSource::Session => Error::Session {
-                    code: stream_error_code(&e).unwrap_or(0),
-                    reason: e.message(),
-                },
+                // A browser-generated session failure has no application close
+                // code. Only a resolved `closed()` promise has close info, which
+                // `session_error` converts without inventing a code.
+                web_sys::WebTransportErrorSource::Session => Error::Unknown(v),
                 _ => Error::Unknown(v),
             }
         } else {

--- a/rs/web-transport-wasm/src/error.rs
+++ b/rs/web-transport-wasm/src/error.rs
@@ -3,14 +3,18 @@ use wasm_bindgen::prelude::*;
 /// A WebTransport error classified based on the source.
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
-    #[error("webtransport session error: {0:?}")]
+    // `WebTransportError` is a `DOMException`, so its message is the reason the peer
+    // sent. Printing the JS object instead would bury that in a handle dump.
+    #[error("webtransport session error: {}", .0.message())]
     Session(web_sys::WebTransportError),
 
-    #[error("webtransport stream error: {0:?}")]
+    #[error("webtransport stream error: {}", .0.message())]
     Stream(web_sys::WebTransportError),
 
-    #[error("web streams error: {0:?}")]
-    Streams(#[from] web_streams::Error),
+    /// The stream was closed locally, by [`crate::SendStream::finish`] or
+    /// [`crate::SendStream::reset`], so it can accept no more writes.
+    #[error("stream is closed")]
+    Closed,
 
     #[error("unknown error: {0:?}")]
     Unknown(JsValue),
@@ -38,5 +42,22 @@ impl From<JsValue> for Error {
         } else {
             Error::Unknown(v)
         }
+    }
+}
+
+/// A `WebTransportError` carrying `code`, which is how a browser stream cancel or
+/// abort names the STOP_SENDING or RESET_STREAM code it sends.
+///
+/// Any other reason — a plain string, say — reaches the peer as code 0. The browser
+/// API carries the code as a byte, so a larger one is sent as 0 rather than
+/// truncated into some other code's meaning.
+pub(crate) fn stream_error(code: u32) -> JsValue {
+    let options = web_sys::WebTransportErrorOptions::new();
+    options.set_source(web_sys::WebTransportErrorSource::Stream);
+    options.set_stream_error_code(u8::try_from(code).ok());
+
+    match web_sys::WebTransportError::new_with_message_and_options("", &options) {
+        Ok(err) => err.into(),
+        Err(err) => err,
     }
 }

--- a/rs/web-transport-wasm/src/js.rs
+++ b/rs/web-transport-wasm/src/js.rs
@@ -1,0 +1,117 @@
+//! The browser plumbing shared by the session and its streams.
+//!
+//! Every WebTransport operation in the browser is a promise, and a promise delivers
+//! its result exactly once to whoever is subscribed at the time. [`JsFuture`]
+//! subscribes when it is built and owns the slot the result lands in, so dropping
+//! one between polls throws that result away — for a `read()` that is an accepted
+//! stream or a chunk of stream data, gone with no way to ask for it again. The
+//! future therefore has to outlive the poll that created it, which is what [`Op`]
+//! is for.
+
+use std::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use js_sys::Promise;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::ReadableStreamReadResult;
+
+use crate::Error;
+
+/// Erase a promise's resolved type so one slot type serves every operation.
+///
+/// `web-sys` types its promises from 0.3.103 onward but not before, and this crate
+/// supports both; going through [`JsValue`] is the shape that compiles either way.
+pub(crate) fn promise(value: impl Into<JsValue>) -> Promise {
+    value.into().unchecked_into()
+}
+
+/// Swallow a promise's outcome, including a rejection.
+///
+/// `close`, `abort` and `cancel` all reject when the stream is already gone, which
+/// is exactly when there is nothing left to do about it. The promise still has to
+/// be consumed: an *unhandled* rejection is a console error.
+pub(crate) fn ignore(value: impl Into<JsValue>) {
+    let promise = promise(value);
+    wasm_bindgen_futures::spawn_local(async move {
+        let _ = JsFuture::from(promise).await;
+    });
+}
+
+/// The value from a `read()`, or `None` once the stream is done.
+pub(crate) fn read_value<T: JsCast>(result: JsValue) -> Option<T> {
+    let result: ReadableStreamReadResult = result.unchecked_into();
+
+    if result.get_done().unwrap_or(false) {
+        return None;
+    }
+
+    Some(result.get_value().unchecked_into())
+}
+
+/// One in-flight browser operation.
+///
+/// The promise is subscribed to on first poll, kept while it is pending, and
+/// dropped once it settles so the next poll starts a fresh operation.
+///
+/// The slot is a [`RefCell`] because this crate's async methods take `&self` while
+/// the poll traits take `&mut self`; both borrow through it. There is nothing to
+/// contend over — the browser runs this on one thread.
+#[derive(Default)]
+pub(crate) struct Op {
+    future: RefCell<Option<JsFuture>>,
+}
+
+impl Op {
+    /// Poll the operation in flight, starting one with `start` when idle.
+    ///
+    /// `start` is only called when the slot is empty, so a caller can build its
+    /// arguments lazily rather than on every poll.
+    pub(crate) fn poll(
+        &self,
+        cx: &mut Context<'_>,
+        start: impl FnOnce() -> Promise,
+    ) -> Poll<Result<JsValue, Error>> {
+        let mut slot = self.future.borrow_mut();
+        let future = slot.get_or_insert_with(|| JsFuture::from(start()));
+        let output = ready!(Pin::new(future).poll(cx));
+        *slot = None;
+        Poll::Ready(output.map_err(Error::from))
+    }
+
+    /// Poll an operation already in flight, reporting an idle slot as settled.
+    ///
+    /// Unlike [`poll`](Self::poll) this never starts one, which is what lets a
+    /// writer wait for the *previous* write before it touches the caller's buffer.
+    pub(crate) fn poll_settled(&self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let mut slot = self.future.borrow_mut();
+        let Some(future) = slot.as_mut() else {
+            return Poll::Ready(Ok(()));
+        };
+
+        let output = ready!(Pin::new(future).poll(cx));
+        *slot = None;
+        Poll::Ready(output.map(|_| ()).map_err(Error::from))
+    }
+
+    /// Put an operation in flight without polling it, replacing any predecessor.
+    ///
+    /// Dropping the replaced future is safe: its callbacks are already attached to
+    /// the promise and self-contained, so the outcome is discarded rather than
+    /// surfacing as an unhandled rejection.
+    pub(crate) fn start(&self, promise: Promise) {
+        *self.future.borrow_mut() = Some(JsFuture::from(promise));
+    }
+}
+
+/// A clone starts idle: each handle owns its own progress under the poll contract,
+/// and the operation in flight belongs to the handle that started it.
+impl Clone for Op {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}

--- a/rs/web-transport-wasm/src/js.rs
+++ b/rs/web-transport-wasm/src/js.rs
@@ -76,11 +76,33 @@ impl Op {
         cx: &mut Context<'_>,
         start: impl FnOnce() -> Promise,
     ) -> Poll<Result<JsValue, Error>> {
+        self.poll_with(cx, || JsFuture::from(start()))
+    }
+
+    /// Poll the operation in flight, taking `make` for one when idle.
+    ///
+    /// Lazy in `make`, which is what lets a caller adopt a future orphaned by a
+    /// dropped handle instead of asking the browser for a fresh one.
+    pub(crate) fn poll_with(
+        &self,
+        cx: &mut Context<'_>,
+        make: impl FnOnce() -> JsFuture,
+    ) -> Poll<Result<JsValue, Error>> {
         let mut slot = self.future.borrow_mut();
-        let future = slot.get_or_insert_with(|| JsFuture::from(start()));
+        let future = slot.get_or_insert_with(make);
         let output = ready!(Pin::new(future).poll(cx));
         *slot = None;
         Poll::Ready(output.map_err(Error::from))
+    }
+
+    /// Whether an operation is in flight.
+    pub(crate) fn is_pending(&self) -> bool {
+        self.future.borrow().is_some()
+    }
+
+    /// Take the operation in flight, leaving the slot idle.
+    pub(crate) fn take(&self) -> Option<JsFuture> {
+        self.future.borrow_mut().take()
     }
 
     /// Poll an operation already in flight, reporting an idle slot as settled.

--- a/rs/web-transport-wasm/src/js.rs
+++ b/rs/web-transport-wasm/src/js.rs
@@ -95,14 +95,14 @@ impl Op {
         Poll::Ready(output.map_err(Error::from))
     }
 
-    /// Whether an operation is in flight.
-    pub(crate) fn is_pending(&self) -> bool {
-        self.future.borrow().is_some()
-    }
-
     /// Take the operation in flight, leaving the slot idle.
     pub(crate) fn take(&self) -> Option<JsFuture> {
         self.future.borrow_mut().take()
+    }
+
+    /// Replace the operation in flight, returning its predecessor when there was one.
+    pub(crate) fn replace(&self, future: JsFuture) -> Option<JsFuture> {
+        self.future.borrow_mut().replace(future)
     }
 
     /// Poll an operation already in flight, reporting an idle slot as settled.

--- a/rs/web-transport-wasm/src/lib.rs
+++ b/rs/web-transport-wasm/src/lib.rs
@@ -3,6 +3,15 @@
 //! This crate wraps the WebTransport API and provides ergonomic Rust bindings.
 //! Some liberties have been taken to make the API more Rust-like and closer to native.
 //!
+//! # Poll and async
+//!
+//! The browser API is a set of promises, but the surface here is a state machine:
+//! every operation is a `poll_*` method that a caller steps from its own loop, with
+//! the `async` methods as thin wrappers over them. That is what implements
+//! [`web_transport_trait::poll`], so a sans-I/O caller needs no adapter, and it is
+//! what makes an abandoned operation safe — the promise stays subscribed, so a chunk
+//! or an accepted stream is never dropped on the floor between polls.
+//!
 //! # Requirements
 //!
 //! `web-sys` still gates the WebTransport bindings behind `--cfg=web_sys_unstable_apis`,
@@ -31,19 +40,26 @@ mod client;
 #[cfg(web_sys_unstable_apis)]
 mod error;
 #[cfg(web_sys_unstable_apis)]
+mod js;
+#[cfg(web_sys_unstable_apis)]
 mod recv;
 #[cfg(web_sys_unstable_apis)]
 mod send;
 #[cfg(web_sys_unstable_apis)]
 mod session;
+#[cfg(all(web_sys_unstable_apis, target_family = "wasm"))]
+mod traits;
 
 #[cfg(web_sys_unstable_apis)]
 pub use client::*;
 #[cfg(web_sys_unstable_apis)]
-pub use error::*;
+pub use error::Error;
 #[cfg(web_sys_unstable_apis)]
 pub use recv::*;
 #[cfg(web_sys_unstable_apis)]
 pub use send::*;
 #[cfg(web_sys_unstable_apis)]
 pub use session::*;
+
+/// The traits this crate implements, re-exported to simplify `Cargo.toml`.
+pub use web_transport_trait as generic;

--- a/rs/web-transport-wasm/src/recv.rs
+++ b/rs/web-transport-wasm/src/recv.rs
@@ -8,7 +8,7 @@ use js_sys::Uint8Array;
 use web_sys::{ReadableStreamDefaultReader, WebTransportReceiveStream};
 
 use crate::{
-    error::stream_error,
+    error::{stream_error, stream_error_code},
     js::{ignore, promise, read_value, Op},
     Error,
 };
@@ -116,7 +116,7 @@ impl RecvStream {
     }
 
     /// Poll until the stream has been closed, returning the error code if any.
-    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u8>, Error>> {
+    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u32>, Error>> {
         let err = match ready!(self.poll_closed_raw(cx)) {
             Ok(()) => return Poll::Ready(Ok(None)),
             Err(err) => err,
@@ -124,7 +124,7 @@ impl RecvStream {
 
         // If it's a WebTransportError, we can extract the error code.
         if let Error::Stream(err) = &err {
-            if let Some(code) = err.stream_error_code() {
+            if let Some(code) = stream_error_code(err) {
                 return Poll::Ready(Ok(Some(code)));
             }
         }
@@ -138,15 +138,13 @@ impl RecvStream {
     /// received *and* its queue drained, and rejects it on a reset or on our own
     /// cancel, which is the whole contract with no emulation needed.
     ///
-    /// One thing it cannot know about is the chunk we took from that queue and have
-    /// not handed over yet, so this stays pending until the caller reads it. No
-    /// waker is registered for that wait, because the caller is the only one who can
-    /// end it, and the read that does wakes them anyway.
+    /// This can resolve while bytes we already pulled off that queue are still
+    /// buffered here. Keep reading until [`poll_read`](Self::poll_read) returns
+    /// `None`: closed describes the transport, not what the caller has consumed,
+    /// and the buffered bytes are still delivered afterwards. Deferring instead
+    /// would deadlock, since this borrows `&mut self` and so a caller waiting here
+    /// is a caller who cannot read.
     pub(crate) fn poll_closed_raw(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        if !self.buffer.is_empty() {
-            return Poll::Pending;
-        }
-
         let reader = &self.reader;
         ready!(self.closed.poll(cx, || promise(reader.closed())))?;
         Poll::Ready(Ok(()))
@@ -182,7 +180,7 @@ impl RecvStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         poll_fn(|cx| self.poll_closed(cx)).await
     }
 }

--- a/rs/web-transport-wasm/src/recv.rs
+++ b/rs/web-transport-wasm/src/recv.rs
@@ -1,52 +1,162 @@
-use std::cmp;
+use std::{
+    future::poll_fn,
+    task::{ready, Context, Poll},
+};
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{BufMut, Bytes};
 use js_sys::Uint8Array;
-use web_sys::WebTransportReceiveStream;
+use web_sys::{ReadableStreamDefaultReader, WebTransportReceiveStream};
 
-use crate::Error;
-use web_streams::Reader;
+use crate::{
+    error::stream_error,
+    js::{ignore, promise, read_value, Op},
+    Error,
+};
 
 /// A stream of bytes received from the remote peer.
 ///
 /// This can be closed by either side with an error code, or closed by the remote with a FIN.
 pub struct RecvStream {
-    reader: Reader<Uint8Array>,
-    buffer: BytesMut,
+    reader: ReadableStreamDefaultReader,
+
+    /// The `read()` in flight, retained so a caller that gives up on a poll does not
+    /// discard the chunk it was about to receive.
+    read: Op,
+    closed: Op,
+
+    /// Bytes taken from the browser but not yet handed to the caller.
+    buffer: Bytes,
+
+    /// The peer finished the stream and everything before the FIN has been read.
+    fin: bool,
 }
 
 impl RecvStream {
     pub(super) fn new(stream: WebTransportReceiveStream) -> Result<Self, Error> {
-        let reader = Reader::new(&stream)?;
+        let reader = ReadableStreamDefaultReader::new(&stream)?;
 
         Ok(Self {
             reader,
-            buffer: BytesMut::new(),
+            read: Op::default(),
+            closed: Op::default(),
+            buffer: Bytes::new(),
+            fin: false,
         })
+    }
+
+    /// Poll for the next chunk of data, up to `max` bytes.
+    ///
+    /// Returns `None` once the peer has finished the stream.
+    pub fn poll_read_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+        max: usize,
+    ) -> Poll<Result<Option<Bytes>, Error>> {
+        // Asking for no bytes is not end of stream.
+        if max == 0 {
+            return Poll::Ready(Ok(Some(Bytes::new())));
+        }
+
+        loop {
+            if !self.buffer.is_empty() {
+                let size = max.min(self.buffer.len());
+                return Poll::Ready(Ok(Some(self.buffer.split_to(size))));
+            }
+
+            if self.fin {
+                return Poll::Ready(Ok(None));
+            }
+
+            ready!(self.poll_fill(cx))?;
+        }
+    }
+
+    /// Poll to read some data into `dst`, returning the number of bytes read.
+    ///
+    /// Returns `None` once the peer has finished the stream. An empty `dst` reads
+    /// nothing and returns `Some(0)`.
+    pub fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, Error>> {
+        if dst.is_empty() {
+            return Poll::Ready(Ok(Some(0)));
+        }
+
+        loop {
+            if !self.buffer.is_empty() {
+                let size = dst.len().min(self.buffer.len());
+                dst[..size].copy_from_slice(&self.buffer.split_to(size));
+                return Poll::Ready(Ok(Some(size)));
+            }
+
+            if self.fin {
+                return Poll::Ready(Ok(None));
+            }
+
+            ready!(self.poll_fill(cx))?;
+        }
+    }
+
+    /// Take the next chunk from the browser, or record the FIN.
+    ///
+    /// Only called with an empty buffer, so nothing is overwritten.
+    fn poll_fill(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let reader = &self.reader;
+        let result = ready!(self.read.poll(cx, || promise(reader.read())))?;
+
+        match read_value::<Uint8Array>(result) {
+            // TODO can we avoid making a copy here?
+            Some(data) => self.buffer = data.to_vec().into(),
+            None => self.fin = true,
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Poll until the stream has been closed, returning the error code if any.
+    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u8>, Error>> {
+        let err = match ready!(self.poll_closed_raw(cx)) {
+            Ok(()) => return Poll::Ready(Ok(None)),
+            Err(err) => err,
+        };
+
+        // If it's a WebTransportError, we can extract the error code.
+        if let Error::Stream(err) = &err {
+            if let Some(code) = err.stream_error_code() {
+                return Poll::Ready(Ok(Some(code)));
+            }
+        }
+
+        Poll::Ready(Err(err))
+    }
+
+    /// Poll until the stream has been closed by either side.
+    ///
+    /// The browser resolves the reader's `closed` promise once the FIN has been
+    /// received *and* its queue drained, and rejects it on a reset or on our own
+    /// cancel, which is the whole contract with no emulation needed.
+    ///
+    /// One thing it cannot know about is the chunk we took from that queue and have
+    /// not handed over yet, so this stays pending until the caller reads it. No
+    /// waker is registered for that wait, because the caller is the only one who can
+    /// end it, and the read that does wakes them anyway.
+    pub(crate) fn poll_closed_raw(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        if !self.buffer.is_empty() {
+            return Poll::Pending;
+        }
+
+        let reader = &self.reader;
+        ready!(self.closed.poll(cx, || promise(reader.closed())))?;
+        Poll::Ready(Ok(()))
     }
 
     /// Read the next chunk of data with the provided maximum size.
     ///
     /// This returns a chunk of data instead of copying, which may be more efficient.
     pub async fn read(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
-        if !self.buffer.is_empty() {
-            let size = cmp::min(max, self.buffer.len());
-            let data = self.buffer.split_to(size).freeze();
-            return Ok(Some(data));
-        }
-
-        let mut data: Bytes = match self.reader.read().await? {
-            // TODO can we avoid making a copy here?
-            Some(data) => data.to_vec().into(),
-            None => return Ok(None),
-        };
-
-        if data.len() > max {
-            // The chunk is too big; add the tail to the buffer for next read.
-            self.buffer.extend_from_slice(&data.split_off(max));
-        }
-
-        Ok(Some(data))
+        poll_fn(|cx| self.poll_read_chunk(cx, max)).await
     }
 
     /// Read some data into the provided buffer.
@@ -65,31 +175,21 @@ impl RecvStream {
         Ok(Some(size))
     }
 
-    /// Abort reading from the stream with the given reason.
-    pub fn stop(&mut self, reason: &str) {
-        self.reader.abort(reason);
+    /// Send a `STOP_SENDING` QUIC code, informing the peer that no more data will
+    /// be read.
+    pub fn stop(&mut self, code: u32) {
+        ignore(self.reader.cancel_with_reason(&stream_error(code)));
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&self) -> Result<Option<u8>, Error> {
-        let err = match self.reader.closed().await {
-            Ok(()) => return Ok(None),
-            Err(err) => Error::from(err),
-        };
-
-        // If it's a WebTransportError, we can extract the error code.
-        if let Error::Stream(err) = &err {
-            if let Some(code) = err.stream_error_code() {
-                return Ok(Some(code));
-            }
-        }
-
-        Err(err)
+    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+        poll_fn(|cx| self.poll_closed(cx)).await
     }
 }
 
 impl Drop for RecvStream {
+    /// Release flow control, which the peer never gets back otherwise.
     fn drop(&mut self) {
-        self.reader.abort("dropped");
+        self.stop(0);
     }
 }

--- a/rs/web-transport-wasm/src/send.rs
+++ b/rs/web-transport-wasm/src/send.rs
@@ -88,8 +88,9 @@ impl SendStream {
     /// stream, so watching for that does not block a concurrent write.
     pub(crate) fn poll_closed_raw(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         let writer = &self.writer;
-        ready!(self.closed.poll(cx, || promise(writer.closed())))?;
-        Poll::Ready(Ok(()))
+        let result = ready!(self.closed.poll(cx, || promise(writer.closed())));
+        self.terminate();
+        Poll::Ready(result.map(|_| ()))
     }
 
     /// Write *all* of the given bytes to the stream.
@@ -112,7 +113,7 @@ impl SendStream {
 
     /// Send an immediate reset code, closing the stream with an error.
     pub fn reset(&mut self, code: u32) {
-        self.terminal = true;
+        self.terminate();
         ignore(self.writer.abort_with_reason(&stream_error(code)));
     }
 
@@ -127,9 +128,15 @@ impl SendStream {
             return Ok(());
         }
 
-        self.terminal = true;
+        self.terminate();
         ignore(self.writer.close());
         Ok(())
+    }
+
+    /// Enter a terminal state and release progress that no future write can poll.
+    fn terminate(&mut self) {
+        self.terminal = true;
+        self.write.take();
     }
 
     /// Set the stream's priority.

--- a/rs/web-transport-wasm/src/send.rs
+++ b/rs/web-transport-wasm/src/send.rs
@@ -8,7 +8,7 @@ use js_sys::{Reflect, Uint8Array};
 use web_sys::{WebTransportSendStream, WritableStreamDefaultWriter};
 
 use crate::{
-    error::stream_error,
+    error::{stream_error, stream_error_code},
     js::{ignore, promise, Op},
     Error,
 };
@@ -65,7 +65,7 @@ impl SendStream {
     }
 
     /// Poll until the stream has been closed, returning the error code if any.
-    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u8>, Error>> {
+    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u32>, Error>> {
         let err = match ready!(self.poll_closed_raw(cx)) {
             Ok(()) => return Poll::Ready(Ok(None)),
             Err(err) => err,
@@ -73,7 +73,7 @@ impl SendStream {
 
         // If it's a WebTransportError, we can extract the error code.
         if let Error::Stream(err) = &err {
-            if let Some(code) = err.stream_error_code() {
+            if let Some(code) = stream_error_code(err) {
                 return Poll::Ready(Ok(Some(code)));
             }
         }
@@ -141,7 +141,7 @@ impl SendStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         poll_fn(|cx| self.poll_closed(cx)).await
     }
 }

--- a/rs/web-transport-wasm/src/send.rs
+++ b/rs/web-transport-wasm/src/send.rs
@@ -51,7 +51,10 @@ impl SendStream {
             return Poll::Ready(Err(Error::Closed));
         }
 
-        ready!(self.write.poll_settled(cx))?;
+        if let Err(err) = ready!(self.write.poll_settled(cx)) {
+            self.terminate();
+            return Poll::Ready(Err(err));
+        }
 
         if buf.is_empty() {
             return Poll::Ready(Ok(0));

--- a/rs/web-transport-wasm/src/send.rs
+++ b/rs/web-transport-wasm/src/send.rs
@@ -1,49 +1,134 @@
+use std::{
+    future::poll_fn,
+    task::{ready, Context, Poll},
+};
+
 use bytes::Buf;
 use js_sys::{Reflect, Uint8Array};
-use web_sys::WebTransportSendStream;
+use web_sys::{WebTransportSendStream, WritableStreamDefaultWriter};
 
-use crate::Error;
-use web_streams::Writer;
+use crate::{
+    error::stream_error,
+    js::{ignore, promise, Op},
+    Error,
+};
 
 /// A stream of bytes sent to the remote peer.
 pub struct SendStream {
     stream: WebTransportSendStream,
-    writer: Writer,
+    writer: WritableStreamDefaultWriter,
+
+    /// The chunk handed to the browser but not yet accepted. Its bytes were already
+    /// reported to the caller, so waiting on it costs the caller nothing.
+    write: Op,
+    closed: Op,
+
+    /// `finish` or `reset` was called, so no further writes can be accepted.
+    terminal: bool,
 }
 
 impl SendStream {
     pub(super) fn new(stream: WebTransportSendStream) -> Result<Self, Error> {
-        let writer = Writer::new(&stream)?;
-        Ok(Self { stream, writer })
+        let writer = WritableStreamDefaultWriter::new(&stream)?;
+
+        Ok(Self {
+            stream,
+            writer,
+            write: Op::default(),
+            closed: Op::default(),
+            terminal: false,
+        })
+    }
+
+    /// Poll to write `buf` to the stream, returning how many bytes were written.
+    ///
+    /// The browser's writer takes a chunk whole, so this accepts all of `buf` at
+    /// once. Backpressure comes from the *previous* chunk, waited on before this
+    /// call looks at `buf` — which is what lets a [`Poll::Pending`] here leave the
+    /// caller's buffer untouched, even if they come back with a different one.
+    pub fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        if self.terminal {
+            return Poll::Ready(Err(Error::Closed));
+        }
+
+        ready!(self.write.poll_settled(cx))?;
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let chunk = Uint8Array::from(buf);
+        self.write
+            .start(promise(self.writer.write_with_chunk(&chunk)));
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    /// Poll until the stream has been closed, returning the error code if any.
+    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<u8>, Error>> {
+        let err = match ready!(self.poll_closed_raw(cx)) {
+            Ok(()) => return Poll::Ready(Ok(None)),
+            Err(err) => err,
+        };
+
+        // If it's a WebTransportError, we can extract the error code.
+        if let Error::Stream(err) = &err {
+            if let Some(code) = err.stream_error_code() {
+                return Poll::Ready(Ok(Some(code)));
+            }
+        }
+
+        Poll::Ready(Err(err))
+    }
+
+    /// Poll until the stream is closed by either side.
+    ///
+    /// The browser resolves the writer's `closed` promise once our FIN is through
+    /// and rejects it on a reset or a peer STOP_SENDING. Nothing here owns the
+    /// stream, so watching for that does not block a concurrent write.
+    pub(crate) fn poll_closed_raw(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let writer = &self.writer;
+        ready!(self.closed.poll(cx, || promise(writer.closed())))?;
+        Poll::Ready(Ok(()))
     }
 
     /// Write *all* of the given bytes to the stream.
     pub async fn write(&mut self, buf: &[u8]) -> Result<(), Error> {
-        self.writer
-            .write(&Uint8Array::from(buf))
-            .await
-            .map_err(Into::into)
+        poll_fn(|cx| self.poll_write(cx, buf)).await?;
+        Ok(())
     }
 
     /// Writes some of the given buffer to the stream.
     pub async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<usize, Error> {
-        let chunk = buf.chunk();
-        let size = chunk.len();
-        self.writer.write(&Uint8Array::from(chunk)).await?;
+        let size = poll_fn(|cx| {
+            let chunk = buf.chunk();
+            self.poll_write(cx, chunk)
+        })
+        .await?;
+
         buf.advance(size);
         Ok(size)
     }
 
     /// Send an immediate reset code, closing the stream with an error.
-    pub fn reset(&mut self, reason: &str) {
-        self.writer.abort(reason);
+    pub fn reset(&mut self, code: u32) {
+        self.terminal = true;
+        ignore(self.writer.abort_with_reason(&stream_error(code)));
     }
 
     /// Mark the stream as finished.
     ///
+    /// The browser flushes whatever is already queued before the FIN, so this does
+    /// not race a write still in flight.
+    ///
     /// This is automatically called on Drop, but can be called manually.
     pub fn finish(&mut self) -> Result<(), Error> {
-        self.writer.close();
+        if self.terminal {
+            return Ok(());
+        }
+
+        self.terminal = true;
+        ignore(self.writer.close());
         Ok(())
     }
 
@@ -56,26 +141,14 @@ impl SendStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&self) -> Result<Option<u8>, Error> {
-        let err = match self.writer.closed().await {
-            Ok(()) => return Ok(None),
-            Err(err) => Error::from(err),
-        };
-
-        // If it's a WebTransportError, we can extract the error code.
-        if let Error::Stream(err) = &err {
-            if let Some(code) = err.stream_error_code() {
-                return Ok(Some(code));
-            }
-        }
-
-        Err(err)
+    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+        poll_fn(|cx| self.poll_closed(cx)).await
     }
 }
 
 impl Drop for SendStream {
     /// Close the stream with a FIN.
     fn drop(&mut self) {
-        self.writer.close();
+        let _ = self.finish();
     }
 }

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -1,28 +1,62 @@
+use std::{
+    cell::RefCell,
+    future::poll_fn,
+    rc::Rc,
+    task::{ready, Context, Poll},
+};
+
 use bytes::Bytes;
 use js_sys::{Function, Reflect, Uint8Array};
 use url::Url;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 use web_sys::{
-    WebTransport, WebTransportBidirectionalStream, WebTransportCloseInfo,
-    WebTransportDatagramDuplexStream, WebTransportSendStream, WritableStream,
+    ReadableStream, ReadableStreamDefaultReader, WebTransport, WebTransportBidirectionalStream,
+    WebTransportCloseInfo, WebTransportDatagramDuplexStream, WritableStream,
+    WritableStreamDefaultWriter,
 };
 
-use crate::{Error, RecvStream, SendStream};
-use web_streams::{Reader, Writer};
+use crate::{
+    js::{promise, read_value, Op},
+    Error, RecvStream, SendStream,
+};
 
 /// A session represents a connection between a client and a server.
 ///
 /// This is the main entry point for creating new streams and sending datagrams.
 /// The session can be closed by either endpoint with an error code and reason.
 ///
-/// The session can be cloned to create multiple handles.
-/// However, handles cannot (currently) accept/open the same type of stream.
+/// The session can be cloned to run operations concurrently: each clone keeps its
+/// own in-flight operation, which is what the poll interface asks of a caller that
+/// wants two at once.
 #[derive(Clone)]
 pub struct Session {
+    shared: Rc<Shared>,
+
+    accept_uni: Op,
+    accept_bi: Op,
+    open_uni: Op,
+    open_bi: Op,
+    send_datagram: Op,
+    recv_datagram: Op,
+    closed: Op,
+}
+
+/// State that every clone of a session shares.
+///
+/// The readers and the datagram writer are here rather than on the handle because a
+/// browser stream can only be locked once; duplicating them would throw. Sharing
+/// them costs nothing, because each clone still calls `read()` for itself — the
+/// streams spec queues concurrent reads and fulfills them in order, so one clone's
+/// pending read is never handed to another.
+struct Shared {
     inner: WebTransport,
     url: Url,
     protocol: Option<String>,
+
+    accept_uni: RefCell<Option<ReadableStreamDefaultReader>>,
+    accept_bi: RefCell<Option<ReadableStreamDefaultReader>>,
+    recv_datagram: RefCell<Option<ReadableStreamDefaultReader>>,
+    send_datagram: RefCell<Option<WritableStreamDefaultWriter>>,
 }
 
 /// The datagram writer. The current spec exposes it via `createWritable()`; the
@@ -41,6 +75,53 @@ fn datagram_writable(dg: &WebTransportDatagramDuplexStream) -> WritableStream {
         .unwrap_or_else(|| dg.writable())
 }
 
+/// Lock `stream` on first use, handing out the reader every time after.
+///
+/// `stream` is a closure so the browser getter behind it runs once rather than on
+/// every poll.
+fn reader(
+    slot: &RefCell<Option<ReadableStreamDefaultReader>>,
+    stream: impl FnOnce() -> ReadableStream,
+) -> Result<ReadableStreamDefaultReader, Error> {
+    let mut slot = slot.borrow_mut();
+
+    match slot.as_ref() {
+        Some(reader) => Ok(reader.clone()),
+        None => {
+            let reader = ReadableStreamDefaultReader::new(&stream())?;
+            *slot = Some(reader.clone());
+            Ok(reader)
+        }
+    }
+}
+
+/// Split a browser bidirectional stream into our two halves.
+fn bi_streams(stream: WebTransportBidirectionalStream) -> Result<(SendStream, RecvStream), Error> {
+    let send = SendStream::new(stream.writable())?;
+    let recv = RecvStream::new(stream.readable())?;
+    Ok((send, recv))
+}
+
+/// The error described by a close info, which is how a clean close reaches a caller.
+fn session_error(info: WebTransportCloseInfo) -> Error {
+    let reason = info.get_reason().unwrap_or_default();
+
+    let options = web_sys::WebTransportErrorOptions::new();
+    options.set_source(web_sys::WebTransportErrorSource::Session);
+
+    // `WebTransportError` carries the code as a byte, so an application close code
+    // above 255 arrives as none rather than as some other code's meaning.
+    options.set_stream_error_code(
+        info.get_close_code()
+            .and_then(|code| u8::try_from(code).ok()),
+    );
+
+    match web_sys::WebTransportError::new_with_message_and_options(&reason, &options) {
+        Ok(err) => Error::Session(err),
+        Err(err) => Error::from(err),
+    }
+}
+
 impl Session {
     pub fn new(inner: WebTransport, url: Url) -> Self {
         // TODO use the web_sys bindings when updated.
@@ -50,69 +131,191 @@ impl Session {
             .and_then(|p| p.as_string());
 
         Self {
-            inner,
-            url,
-            protocol,
+            shared: Rc::new(Shared {
+                inner,
+                url,
+                protocol,
+                accept_uni: RefCell::new(None),
+                accept_bi: RefCell::new(None),
+                recv_datagram: RefCell::new(None),
+                send_datagram: RefCell::new(None),
+            }),
+            accept_uni: Op::default(),
+            accept_bi: Op::default(),
+            open_uni: Op::default(),
+            open_bi: Op::default(),
+            send_datagram: Op::default(),
+            recv_datagram: Op::default(),
+            closed: Op::default(),
         }
+    }
+
+    /// Poll for a unidirectional stream created by the peer.
+    pub fn poll_accept_uni(&self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, Error>> {
+        let inner = &self.shared.inner;
+        let reader = match reader(&self.shared.accept_uni, || {
+            inner.incoming_unidirectional_streams()
+        }) {
+            Ok(reader) => reader,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let result = ready!(self.accept_uni.poll(cx, || promise(reader.read())))?;
+
+        match read_value(result) {
+            Some(stream) => Poll::Ready(RecvStream::new(stream)),
+            // The queue only ends when the session does, so ask why.
+            None => Poll::Ready(Err(ready!(self.poll_closed(cx)))),
+        }
+    }
+
+    /// Poll for a bidirectional stream created by the peer.
+    pub fn poll_accept_bi(
+        &self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), Error>> {
+        let inner = &self.shared.inner;
+        let reader = match reader(&self.shared.accept_bi, || {
+            inner.incoming_bidirectional_streams()
+        }) {
+            Ok(reader) => reader,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let result = ready!(self.accept_bi.poll(cx, || promise(reader.read())))?;
+
+        match read_value(result) {
+            Some(stream) => Poll::Ready(bi_streams(stream)),
+            None => Poll::Ready(Err(ready!(self.poll_closed(cx)))),
+        }
+    }
+
+    /// Poll to open a unidirectional stream, which blocks while there are too many
+    /// concurrent streams.
+    pub fn poll_open_uni(&self, cx: &mut Context<'_>) -> Poll<Result<SendStream, Error>> {
+        let inner = &self.shared.inner;
+        let stream = ready!(self
+            .open_uni
+            .poll(cx, || promise(inner.create_unidirectional_stream())))?;
+
+        Poll::Ready(SendStream::new(stream.unchecked_into()))
+    }
+
+    /// Poll to open a bidirectional stream, which blocks while there are too many
+    /// concurrent streams.
+    pub fn poll_open_bi(
+        &self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), Error>> {
+        let inner = &self.shared.inner;
+        let stream = ready!(self
+            .open_bi
+            .poll(cx, || promise(inner.create_bidirectional_stream())))?;
+
+        Poll::Ready(bi_streams(stream.unchecked_into()))
+    }
+
+    /// Poll to send a datagram over the network.
+    ///
+    /// Returns [`Poll::Pending`] until the browser has accepted the *previous*
+    /// datagram, so a caller waits for capacity instead of piling up payloads. The
+    /// payload is untouched while pending.
+    pub fn poll_send_datagram(
+        &self,
+        cx: &mut Context<'_>,
+        payload: &[u8],
+    ) -> Poll<Result<(), Error>> {
+        ready!(self.send_datagram.poll_settled(cx))?;
+
+        match self.try_send_datagram(payload) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(err) => Poll::Ready(Err(err)),
+        }
+    }
+
+    /// Hand a datagram to the browser without waiting for capacity.
+    ///
+    /// Delivery was never guaranteed — a datagram can be dropped for congestion,
+    /// loss, or size — so there is nothing to report beyond failing to hand it over.
+    pub fn try_send_datagram(&self, payload: &[u8]) -> Result<(), Error> {
+        let mut slot = self.shared.send_datagram.borrow_mut();
+        let writer = match slot.as_ref() {
+            Some(writer) => writer,
+            None => {
+                let writable = datagram_writable(&self.shared.inner.datagrams());
+                slot.insert(WritableStreamDefaultWriter::new(&writable)?)
+            }
+        };
+
+        self.send_datagram
+            .start(promise(writer.write_with_chunk(&Uint8Array::from(payload))));
+
+        Ok(())
+    }
+
+    /// Poll for a datagram from the network.
+    pub fn poll_recv_datagram(&self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Error>> {
+        let inner = &self.shared.inner;
+        let reader = match reader(&self.shared.recv_datagram, || inner.datagrams().readable()) {
+            Ok(reader) => reader,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let result = ready!(self.recv_datagram.poll(cx, || promise(reader.read())))?;
+
+        match read_value::<Uint8Array>(result) {
+            Some(data) => Poll::Ready(Ok(data.to_vec().into())),
+            None => Poll::Ready(Err(ready!(self.poll_closed(cx)))),
+        }
+    }
+
+    /// Poll until the session is closed by either side.
+    pub fn poll_closed(&self, cx: &mut Context<'_>) -> Poll<Error> {
+        let inner = &self.shared.inner;
+
+        // A rejection is a session that failed rather than closed; it already
+        // describes itself.
+        let info = match ready!(self.closed.poll(cx, || promise(inner.closed()))) {
+            Ok(info) => info,
+            Err(err) => return Poll::Ready(err),
+        };
+
+        Poll::Ready(session_error(info.unchecked_into()))
     }
 
     /// Accept a new unidirectional stream from the peer.
     pub async fn accept_uni(&self) -> Result<RecvStream, Error> {
-        let mut reader = Reader::new(&self.inner.incoming_unidirectional_streams())?;
-
-        match reader.read().await? {
-            Some(stream) => Ok(RecvStream::new(stream)?),
-            None => Err(self.closed().await),
-        }
+        poll_fn(|cx| self.poll_accept_uni(cx)).await
     }
 
     /// Accept a new bidirectional stream from the peer.
     pub async fn accept_bi(&self) -> Result<(SendStream, RecvStream), Error> {
-        let mut reader = Reader::new(&self.inner.incoming_bidirectional_streams())?;
-
-        let stream: WebTransportBidirectionalStream = match reader.read().await? {
-            Some(stream) => stream,
-            None => return Err(self.closed().await),
-        };
-
-        let send = SendStream::new(stream.writable())?;
-        let recv = RecvStream::new(stream.readable())?;
-
-        Ok((send, recv))
+        poll_fn(|cx| self.poll_accept_bi(cx)).await
     }
 
     /// Creates a new bidirectional stream.
     pub async fn open_bi(&self) -> Result<(SendStream, RecvStream), Error> {
-        let stream: WebTransportBidirectionalStream =
-            JsFuture::from(self.inner.create_bidirectional_stream()).await?;
-
-        let send = SendStream::new(stream.writable())?;
-        let recv = RecvStream::new(stream.readable())?;
-
-        Ok((send, recv))
+        poll_fn(|cx| self.poll_open_bi(cx)).await
     }
 
     /// Creates a new unidirectional stream.
     pub async fn open_uni(&self) -> Result<SendStream, Error> {
-        let stream: WebTransportSendStream =
-            JsFuture::from(self.inner.create_unidirectional_stream()).await?;
-
-        let send = SendStream::new(stream)?;
-        Ok(send)
+        poll_fn(|cx| self.poll_open_uni(cx)).await
     }
 
     /// Send a datagram over the network.
     pub async fn send_datagram(&self, payload: Bytes) -> Result<(), Error> {
-        let mut writer = Writer::new(&datagram_writable(&self.inner.datagrams()))?;
-        writer.write(&Uint8Array::from(payload.as_ref())).await?;
-        Ok(())
+        poll_fn(|cx| self.poll_send_datagram(cx, &payload)).await
     }
 
     /// Receive a datagram over the network.
     pub async fn recv_datagram(&self) -> Result<Bytes, Error> {
-        let mut reader = Reader::new(&self.inner.datagrams().readable())?;
-        let data: Uint8Array = reader.read().await?.unwrap_or_default();
-        Ok(data.to_vec().into())
+        poll_fn(|cx| self.poll_recv_datagram(cx)).await
+    }
+
+    /// The maximum size of a datagram that can be sent.
+    pub fn max_datagram_size(&self) -> usize {
+        self.shared.inner.datagrams().max_datagram_size() as usize
     }
 
     /// Close the session with the given error code and reason.
@@ -120,43 +323,28 @@ impl Session {
         let info = WebTransportCloseInfo::new();
         info.set_close_code(code);
         info.set_reason(reason);
-        self.inner.close_with_close_info(&info);
+        self.shared.inner.close_with_close_info(&info);
     }
 
     /// Block until the session is closed and return the error.
     pub async fn closed(&self) -> Error {
-        self.closed_inner().await.unwrap_err()
-    }
-
-    async fn closed_inner(&self) -> Result<(), Error> {
-        let info: WebTransportCloseInfo = JsFuture::from(self.inner.closed()).await?;
-        let reason = info.get_reason().unwrap_or_default();
-
-        let options = web_sys::WebTransportErrorOptions::new();
-        options.set_source(web_sys::WebTransportErrorSource::Session);
-
-        if let Ok(code) = info.get_close_code().map(u8::try_from).transpose() {
-            options.set_stream_error_code(code);
-        }
-
-        let err = web_sys::WebTransportError::new_with_message_and_options(&reason, &options)?;
-        Err(Error::Session(err))
+        poll_fn(|cx| self.poll_closed(cx)).await
     }
 
     /// Return the URL used to create the session.
     pub fn url(&self) -> &Url {
-        &self.url
+        &self.shared.url
     }
 
     /// Return the application protocol used to create the session.
     pub fn protocol(&self) -> Option<&str> {
-        self.protocol.as_deref()
+        self.shared.protocol.as_deref()
     }
 }
 
 impl PartialEq for Session {
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
+        self.shared.inner == other.shared.inner
     }
 }
 

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -13,8 +13,8 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     ReadableStream, ReadableStreamDefaultReader, WebTransport, WebTransportBidirectionalStream,
-    WebTransportCloseInfo, WebTransportDatagramDuplexStream, WebTransportSendStreamOptions,
-    WritableStream, WritableStreamDefaultWriter,
+    WebTransportCloseInfo, WebTransportDatagramDuplexStream, WebTransportSendStream,
+    WebTransportSendStreamOptions, WritableStream, WritableStreamDefaultWriter,
 };
 
 use crate::{
@@ -553,16 +553,13 @@ impl Session {
 }
 
 impl Drop for Session {
-    /// Leave any read this handle had in flight to the clones that remain.
+    /// Preserve or dispose of browser operations that outlive this handle.
     ///
     /// A browser read request cannot be cancelled, so the browser will still hand
     /// the next stream or datagram to it. Dropping it here would strand that value:
     /// the request is satisfied, nothing is listening, and no surviving clone ever
     /// learns the stream existed.
     ///
-    /// Only reads need this. An orphaned open or datagram write has already done
-    /// what it was asked to, and the session's `closed` promise can be subscribed
-    /// to again from scratch.
     fn drop(&mut self) {
         for (op, incoming) in [
             (&self.accept_uni, &self.shared.accept_uni),
@@ -581,6 +578,32 @@ impl Drop for Session {
                     waiter.wake_by_ref();
                 }
             }
+        }
+
+        // Browser open promises cannot be cancelled either. If one settles after
+        // its handle disappears, close the resulting stream so it does not retain
+        // peer stream credit forever.
+        if let Some(future) = self.open_uni.take() {
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Ok(stream) = future.await {
+                    let stream: WebTransportSendStream = stream.unchecked_into();
+                    if let Ok(mut stream) = SendStream::new(stream) {
+                        stream.reset(0);
+                    }
+                }
+            });
+        }
+
+        if let Some(future) = self.open_bi.take() {
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Ok(stream) = future.await {
+                    let stream: WebTransportBidirectionalStream = stream.unchecked_into();
+                    if let Ok((mut send, mut recv)) = bi_streams(stream) {
+                        send.reset(0);
+                        recv.stop(0);
+                    }
+                }
+            });
         }
     }
 }

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -334,7 +334,18 @@ impl Session {
                 Ok(size) if datagram_has_capacity(size) => break,
                 Ok(_) => match self.send_datagram.poll(cx, || promise(writer.ready())) {
                     Poll::Pending => return Poll::Pending,
-                    Poll::Ready(Ok(_)) => continue,
+                    Poll::Ready(Ok(_)) => match writer.desired_size() {
+                        Ok(size) if datagram_has_capacity(size) => continue,
+                        // `ready` also fulfills when the writer closes. Its closed
+                        // promise distinguishes that terminal zero from ordinary
+                        // backpressure and prevents an already-ready wake loop.
+                        Ok(_) => match self.send_datagram.poll(cx, || promise(writer.closed())) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(Ok(_)) => return Poll::Ready(Err(Error::Closed)),
+                            Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                        },
+                        Err(err) => return Poll::Ready(Err(err.into())),
+                    },
                     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
                 },
                 Err(err) => return Poll::Ready(Err(err.into())),

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    collections::VecDeque,
     future::poll_fn,
     rc::Rc,
     task::{ready, Context, Poll},
@@ -8,7 +9,8 @@ use std::{
 use bytes::Bytes;
 use js_sys::{Function, Reflect, Uint8Array};
 use url::Url;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     ReadableStream, ReadableStreamDefaultReader, WebTransport, WebTransportBidirectionalStream,
     WebTransportCloseInfo, WebTransportDatagramDuplexStream, WritableStream,
@@ -16,6 +18,7 @@ use web_sys::{
 };
 
 use crate::{
+    error::session_error,
     js::{promise, read_value, Op},
     Error, RecvStream, SendStream,
 };
@@ -43,20 +46,54 @@ pub struct Session {
 
 /// State that every clone of a session shares.
 ///
-/// The readers and the datagram writer are here rather than on the handle because a
-/// browser stream can only be locked once; duplicating them would throw. Sharing
-/// them costs nothing, because each clone still calls `read()` for itself — the
-/// streams spec queues concurrent reads and fulfills them in order, so one clone's
-/// pending read is never handed to another.
+/// The stream locks live here because a browser stream can only be locked once;
+/// duplicating them would throw. Sharing them costs a clone nothing, because it
+/// still calls `read()` for itself — the streams spec queues concurrent reads and
+/// fulfills them in order, so one clone's pending read is never handed to another.
 struct Shared {
     inner: WebTransport,
     url: Url,
     protocol: Option<String>,
 
-    accept_uni: RefCell<Option<ReadableStreamDefaultReader>>,
-    accept_bi: RefCell<Option<ReadableStreamDefaultReader>>,
-    recv_datagram: RefCell<Option<ReadableStreamDefaultReader>>,
+    accept_uni: Incoming,
+    accept_bi: Incoming,
+    datagrams: Incoming,
     send_datagram: RefCell<Option<WritableStreamDefaultWriter>>,
+}
+
+/// One browser stream this session reads from.
+///
+/// The reader is shared because a browser stream can only be locked once. So are
+/// the orphans, for a subtler reason: a `read()` cannot be cancelled. Once it is
+/// issued the browser will hand the next value to *that* request, so a read whose
+/// handle was dropped has to be picked up by a surviving clone or the stream it was
+/// about to deliver is stranded and nobody ever sees it.
+#[derive(Default)]
+struct Incoming {
+    reader: RefCell<Option<ReadableStreamDefaultReader>>,
+    orphans: RefCell<VecDeque<JsFuture>>,
+}
+
+impl Incoming {
+    /// Lock `stream` on first use, handing out the reader every time after.
+    ///
+    /// `stream` is a closure so the browser getter behind it runs once rather than
+    /// on every poll.
+    fn reader(
+        &self,
+        stream: impl FnOnce() -> ReadableStream,
+    ) -> Result<ReadableStreamDefaultReader, Error> {
+        let mut slot = self.reader.borrow_mut();
+
+        match slot.as_ref() {
+            Some(reader) => Ok(reader.clone()),
+            None => {
+                let reader = ReadableStreamDefaultReader::new(&stream())?;
+                *slot = Some(reader.clone());
+                Ok(reader)
+            }
+        }
+    }
 }
 
 /// The datagram writer. The current spec exposes it via `createWritable()`; the
@@ -75,51 +112,11 @@ fn datagram_writable(dg: &WebTransportDatagramDuplexStream) -> WritableStream {
         .unwrap_or_else(|| dg.writable())
 }
 
-/// Lock `stream` on first use, handing out the reader every time after.
-///
-/// `stream` is a closure so the browser getter behind it runs once rather than on
-/// every poll.
-fn reader(
-    slot: &RefCell<Option<ReadableStreamDefaultReader>>,
-    stream: impl FnOnce() -> ReadableStream,
-) -> Result<ReadableStreamDefaultReader, Error> {
-    let mut slot = slot.borrow_mut();
-
-    match slot.as_ref() {
-        Some(reader) => Ok(reader.clone()),
-        None => {
-            let reader = ReadableStreamDefaultReader::new(&stream())?;
-            *slot = Some(reader.clone());
-            Ok(reader)
-        }
-    }
-}
-
 /// Split a browser bidirectional stream into our two halves.
 fn bi_streams(stream: WebTransportBidirectionalStream) -> Result<(SendStream, RecvStream), Error> {
     let send = SendStream::new(stream.writable())?;
     let recv = RecvStream::new(stream.readable())?;
     Ok((send, recv))
-}
-
-/// The error described by a close info, which is how a clean close reaches a caller.
-fn session_error(info: WebTransportCloseInfo) -> Error {
-    let reason = info.get_reason().unwrap_or_default();
-
-    let options = web_sys::WebTransportErrorOptions::new();
-    options.set_source(web_sys::WebTransportErrorSource::Session);
-
-    // `WebTransportError` carries the code as a byte, so an application close code
-    // above 255 arrives as none rather than as some other code's meaning.
-    options.set_stream_error_code(
-        info.get_close_code()
-            .and_then(|code| u8::try_from(code).ok()),
-    );
-
-    match web_sys::WebTransportError::new_with_message_and_options(&reason, &options) {
-        Ok(err) => Error::Session(err),
-        Err(err) => Error::from(err),
-    }
 }
 
 impl Session {
@@ -135,9 +132,9 @@ impl Session {
                 inner,
                 url,
                 protocol,
-                accept_uni: RefCell::new(None),
-                accept_bi: RefCell::new(None),
-                recv_datagram: RefCell::new(None),
+                accept_uni: Incoming::default(),
+                accept_bi: Incoming::default(),
+                datagrams: Incoming::default(),
                 send_datagram: RefCell::new(None),
             }),
             accept_uni: Op::default(),
@@ -153,14 +150,12 @@ impl Session {
     /// Poll for a unidirectional stream created by the peer.
     pub fn poll_accept_uni(&self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, Error>> {
         let inner = &self.shared.inner;
-        let reader = match reader(&self.shared.accept_uni, || {
-            inner.incoming_unidirectional_streams()
-        }) {
-            Ok(reader) => reader,
-            Err(err) => return Poll::Ready(Err(err)),
-        };
-
-        let result = ready!(self.accept_uni.poll(cx, || promise(reader.read())))?;
+        let result = ready!(self.poll_incoming(
+            cx,
+            &self.accept_uni,
+            &self.shared.accept_uni,
+            || { inner.incoming_unidirectional_streams() }
+        ))?;
 
         match read_value(result) {
             Some(stream) => Poll::Ready(RecvStream::new(stream)),
@@ -175,14 +170,12 @@ impl Session {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(SendStream, RecvStream), Error>> {
         let inner = &self.shared.inner;
-        let reader = match reader(&self.shared.accept_bi, || {
-            inner.incoming_bidirectional_streams()
-        }) {
-            Ok(reader) => reader,
-            Err(err) => return Poll::Ready(Err(err)),
-        };
-
-        let result = ready!(self.accept_bi.poll(cx, || promise(reader.read())))?;
+        let result = ready!(self.poll_incoming(
+            cx,
+            &self.accept_bi,
+            &self.shared.accept_bi,
+            || { inner.incoming_bidirectional_streams() }
+        ))?;
 
         match read_value(result) {
             Some(stream) => Poll::Ready(bi_streams(stream)),
@@ -225,43 +218,78 @@ impl Session {
         cx: &mut Context<'_>,
         payload: &[u8],
     ) -> Poll<Result<(), Error>> {
+        // Draining the previous write is what bounds this path: one datagram
+        // outstanding per handle, never a queue.
         ready!(self.send_datagram.poll_settled(cx))?;
 
-        match self.try_send_datagram(payload) {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(err) => Poll::Ready(Err(err)),
+        let writer = match self.datagram_writer() {
+            Ok(writer) => writer,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        self.write_datagram(&writer, payload);
+        Poll::Ready(Ok(()))
+    }
+
+    /// Hand a datagram to the browser if it has room, reporting whether it took it.
+    ///
+    /// Unlike [`poll_send_datagram`](Self::poll_send_datagram) this never waits, so
+    /// it has to drop rather than queue: a datagram offered while the previous one
+    /// is still outstanding, or while the browser reports no room, is discarded.
+    /// Queueing instead would grow without bound on a stalled connection, and
+    /// nothing downstream discards the excess — a browser write cannot be
+    /// cancelled, so the backlog would eventually go out stale. Dropping is a
+    /// datagram's normal fate anyway; congestion, loss and size do it too.
+    pub fn try_send_datagram(&self, payload: &[u8]) -> Result<bool, Error> {
+        if self.send_datagram.is_pending() {
+            return Ok(false);
+        }
+
+        let writer = self.datagram_writer()?;
+
+        // `desiredSize` is the writer's own backpressure signal: at or below zero
+        // the queue is already at its high water mark. `None` is an errored stream,
+        // which the write itself reports, so let that one through.
+        if let Ok(Some(size)) = writer.desired_size() {
+            if size <= 0.0 {
+                return Ok(false);
+            }
+        }
+
+        self.write_datagram(&writer, payload);
+        Ok(true)
+    }
+
+    /// Lock the datagram writable on first use, handing out the writer after.
+    fn datagram_writer(&self) -> Result<WritableStreamDefaultWriter, Error> {
+        let mut slot = self.shared.send_datagram.borrow_mut();
+
+        match slot.as_ref() {
+            Some(writer) => Ok(writer.clone()),
+            None => {
+                let writable = datagram_writable(&self.shared.inner.datagrams());
+                let writer = WritableStreamDefaultWriter::new(&writable)?;
+                *slot = Some(writer.clone());
+                Ok(writer)
+            }
         }
     }
 
-    /// Hand a datagram to the browser without waiting for capacity.
-    ///
-    /// Delivery was never guaranteed — a datagram can be dropped for congestion,
-    /// loss, or size — so there is nothing to report beyond failing to hand it over.
-    pub fn try_send_datagram(&self, payload: &[u8]) -> Result<(), Error> {
-        let mut slot = self.shared.send_datagram.borrow_mut();
-        let writer = match slot.as_ref() {
-            Some(writer) => writer,
-            None => {
-                let writable = datagram_writable(&self.shared.inner.datagrams());
-                slot.insert(WritableStreamDefaultWriter::new(&writable)?)
-            }
-        };
-
+    /// Hand a datagram over, keeping the write as this handle's in-flight operation.
+    fn write_datagram(&self, writer: &WritableStreamDefaultWriter, payload: &[u8]) {
         self.send_datagram
             .start(promise(writer.write_with_chunk(&Uint8Array::from(payload))));
-
-        Ok(())
     }
 
     /// Poll for a datagram from the network.
     pub fn poll_recv_datagram(&self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Error>> {
         let inner = &self.shared.inner;
-        let reader = match reader(&self.shared.recv_datagram, || inner.datagrams().readable()) {
-            Ok(reader) => reader,
-            Err(err) => return Poll::Ready(Err(err)),
-        };
-
-        let result = ready!(self.recv_datagram.poll(cx, || promise(reader.read())))?;
+        let result = ready!(self.poll_incoming(
+            cx,
+            &self.recv_datagram,
+            &self.shared.datagrams,
+            || { inner.datagrams().readable() }
+        ))?;
 
         match read_value::<Uint8Array>(result) {
             Some(data) => Poll::Ready(Ok(data.to_vec().into())),
@@ -280,7 +308,32 @@ impl Session {
             Err(err) => return Poll::Ready(err),
         };
 
-        Poll::Ready(session_error(info.unchecked_into()))
+        let info: WebTransportCloseInfo = info.unchecked_into();
+        Poll::Ready(session_error(&info))
+    }
+
+    /// Poll a read against one of the shared browser queues.
+    ///
+    /// Adopts a read orphaned by a dropped handle before issuing a new one, which
+    /// is what keeps that handle's disappearance from swallowing a stream. The
+    /// browser fulfills read requests in the order they were made, so taking the
+    /// oldest orphan first also preserves that order.
+    fn poll_incoming(
+        &self,
+        cx: &mut Context<'_>,
+        op: &Op,
+        incoming: &Incoming,
+        stream: impl FnOnce() -> ReadableStream,
+    ) -> Poll<Result<JsValue, Error>> {
+        let reader = match incoming.reader(stream) {
+            Ok(reader) => reader,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        op.poll_with(cx, || {
+            let orphan = incoming.orphans.borrow_mut().pop_front();
+            orphan.unwrap_or_else(|| JsFuture::from(promise(reader.read())))
+        })
     }
 
     /// Accept a new unidirectional stream from the peer.
@@ -339,6 +392,30 @@ impl Session {
     /// Return the application protocol used to create the session.
     pub fn protocol(&self) -> Option<&str> {
         self.shared.protocol.as_deref()
+    }
+}
+
+impl Drop for Session {
+    /// Leave any read this handle had in flight to the clones that remain.
+    ///
+    /// A browser read request cannot be cancelled, so the browser will still hand
+    /// the next stream or datagram to it. Dropping it here would strand that value:
+    /// the request is satisfied, nothing is listening, and no surviving clone ever
+    /// learns the stream existed.
+    ///
+    /// Only reads need this. An orphaned open or datagram write has already done
+    /// what it was asked to, and the session's `closed` promise can be subscribed
+    /// to again from scratch.
+    fn drop(&mut self) {
+        for (op, incoming) in [
+            (&self.accept_uni, &self.shared.accept_uni),
+            (&self.accept_bi, &self.shared.accept_bi),
+            (&self.recv_datagram, &self.shared.datagrams),
+        ] {
+            if let Some(future) = op.take() {
+                incoming.orphans.borrow_mut().push_back(future);
+            }
+        }
     }
 }
 

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -3,7 +3,7 @@ use std::{
     collections::BTreeMap,
     future::poll_fn,
     rc::Rc,
-    task::{ready, Context, Poll},
+    task::{ready, Context, Poll, Waker},
 };
 
 use bytes::Bytes;
@@ -73,6 +73,7 @@ struct Incoming {
     reader: RefCell<Option<ReadableStreamDefaultReader>>,
     next_order: Cell<u64>,
     orphans: RefCell<BTreeMap<u64, JsFuture>>,
+    waiters: RefCell<BTreeMap<u64, Waker>>,
 }
 
 impl Incoming {
@@ -325,6 +326,21 @@ impl Session {
             Err(err) => return Poll::Ready(Err(err)),
         };
 
+        // The writer is shared by every clone, so a local idle slot does not mean
+        // the browser has room. Wait on the shared backpressure promise and
+        // recheck: another clone may consume capacity before this one is polled.
+        loop {
+            match writer.desired_size() {
+                Ok(size) if datagram_has_capacity(size) => break,
+                Ok(_) => match self.send_datagram.poll(cx, || promise(writer.ready())) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(_)) => continue,
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                },
+                Err(err) => return Poll::Ready(Err(err.into())),
+            }
+        }
+
         self.write_datagram(&writer, payload);
         Poll::Ready(Ok(()))
     }
@@ -440,6 +456,7 @@ impl Session {
                 .expect("the oldest orphan cannot disappear on one thread");
 
             if let Some((displaced_order, displaced_future)) = op.replace(order, future) {
+                incoming.waiters.borrow_mut().remove(&displaced_order);
                 let previous = incoming
                     .orphans
                     .borrow_mut()
@@ -456,7 +473,16 @@ impl Session {
             order
         });
 
-        op.poll_with(cx, order, || JsFuture::from(promise(reader.read())))
+        incoming
+            .waiters
+            .borrow_mut()
+            .insert(order, cx.waker().clone());
+
+        let result = op.poll_with(cx, order, || JsFuture::from(promise(reader.read())));
+        if result.is_ready() {
+            incoming.waiters.borrow_mut().remove(&order);
+        }
+        result
     }
 
     /// Accept a new unidirectional stream from the peer.
@@ -544,8 +570,16 @@ impl Drop for Session {
             (&self.recv_datagram, &self.shared.datagrams),
         ] {
             if let Some((order, future)) = op.take() {
+                incoming.waiters.borrow_mut().remove(&order);
                 let previous = incoming.orphans.borrow_mut().insert(order, future);
                 assert!(previous.is_none(), "incoming read orders are unique");
+
+                // A clone may already be parked on a newer browser read. Wake it
+                // now so it can adopt this older future and register its waker on
+                // that request before the browser fulfills it.
+                for waiter in incoming.waiters.borrow().values() {
+                    waiter.wake_by_ref();
+                }
             }
         }
     }

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
-    cell::RefCell,
-    collections::VecDeque,
+    cell::{Cell, RefCell},
+    collections::BTreeMap,
     future::poll_fn,
     rc::Rc,
     task::{ready, Context, Poll},
@@ -35,12 +35,12 @@ use crate::{
 pub struct Session {
     shared: Rc<Shared>,
 
-    accept_uni: Op,
-    accept_bi: Op,
+    accept_uni: IncomingOp,
+    accept_bi: IncomingOp,
     open_uni: Op,
     open_bi: Op,
     send_datagram: Op,
-    recv_datagram: Op,
+    recv_datagram: IncomingOp,
     closed: Op,
 }
 
@@ -71,7 +71,8 @@ struct Shared {
 #[derive(Default)]
 struct Incoming {
     reader: RefCell<Option<ReadableStreamDefaultReader>>,
-    orphans: RefCell<VecDeque<JsFuture>>,
+    next_order: Cell<u64>,
+    orphans: RefCell<BTreeMap<u64, JsFuture>>,
 }
 
 impl Incoming {
@@ -94,6 +95,82 @@ impl Incoming {
             }
         }
     }
+}
+
+/// One handle's read from an [`Incoming`] browser stream.
+///
+/// The order follows the browser's read-request order. It lets a surviving handle
+/// adopt an older orphan without moving its own older request behind a newer one.
+#[derive(Default)]
+struct IncomingOp {
+    order: Cell<Option<u64>>,
+    future: Op,
+}
+
+impl IncomingOp {
+    /// Replace this handle's read with an older orphan, returning the displaced read.
+    fn replace(&self, order: u64, future: JsFuture) -> Option<(u64, JsFuture)> {
+        let previous_order = self.order.replace(Some(order));
+        let previous_future = self.future.replace(future);
+
+        match (previous_order, previous_future) {
+            (Some(order), Some(future)) => Some((order, future)),
+            (None, None) => None,
+            _ => unreachable!("incoming read order and future must move together"),
+        }
+    }
+
+    /// Take this handle's read so another clone can adopt it.
+    fn take(&self) -> Option<(u64, JsFuture)> {
+        let future = self.future.take()?;
+        let order = self
+            .order
+            .take()
+            .expect("an incoming read future always has an order");
+        Some((order, future))
+    }
+
+    /// Poll the assigned read, starting a fresh one with `order` when idle.
+    fn poll_with(
+        &self,
+        cx: &mut Context<'_>,
+        order: u64,
+        make: impl FnOnce() -> JsFuture,
+    ) -> Poll<Result<JsValue, Error>> {
+        let result = self.future.poll_with(cx, || {
+            assert!(
+                self.order.replace(Some(order)).is_none(),
+                "an idle incoming read cannot already have an order"
+            );
+            make()
+        });
+
+        if result.is_ready() {
+            self.order.set(None);
+        }
+
+        result
+    }
+}
+
+/// A cloned session handle starts with no read assigned to it.
+impl Clone for IncomingOp {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+/// Whether the oldest orphan must run before this handle's assigned read.
+fn should_adopt_orphan(current: Option<u64>, orphan: u64) -> bool {
+    match current {
+        Some(current) => orphan < current,
+        None => true,
+    }
+}
+
+/// Whether the browser writer currently has room for another datagram.
+fn datagram_has_capacity(desired_size: Option<f64>) -> bool {
+    matches!(desired_size, Some(size) if size > 0.0)
 }
 
 /// The datagram writer. The current spec exposes it via `createWritable()`; the
@@ -137,12 +214,12 @@ impl Session {
                 datagrams: Incoming::default(),
                 send_datagram: RefCell::new(None),
             }),
-            accept_uni: Op::default(),
-            accept_bi: Op::default(),
+            accept_uni: IncomingOp::default(),
+            accept_bi: IncomingOp::default(),
             open_uni: Op::default(),
             open_bi: Op::default(),
             send_datagram: Op::default(),
-            recv_datagram: Op::default(),
+            recv_datagram: IncomingOp::default(),
             closed: Op::default(),
         }
     }
@@ -234,26 +311,22 @@ impl Session {
     /// Hand a datagram to the browser if it has room, reporting whether it took it.
     ///
     /// Unlike [`poll_send_datagram`](Self::poll_send_datagram) this never waits, so
-    /// it has to drop rather than queue: a datagram offered while the previous one
-    /// is still outstanding, or while the browser reports no room, is discarded.
+    /// it has to drop rather than queue: a datagram offered while the browser
+    /// reports no room is discarded.
     /// Queueing instead would grow without bound on a stalled connection, and
     /// nothing downstream discards the excess — a browser write cannot be
     /// cancelled, so the backlog would eventually go out stale. Dropping is a
     /// datagram's normal fate anyway; congestion, loss and size do it too.
     pub fn try_send_datagram(&self, payload: &[u8]) -> Result<bool, Error> {
-        if self.send_datagram.is_pending() {
-            return Ok(false);
-        }
-
         let writer = self.datagram_writer()?;
 
         // `desiredSize` is the writer's own backpressure signal: at or below zero
         // the queue is already at its high water mark. `None` is an errored stream,
-        // which the write itself reports, so let that one through.
-        if let Ok(Some(size)) = writer.desired_size() {
-            if size <= 0.0 {
-                return Ok(false);
-            }
+        // which has no capacity either. A prior write future may still occupy our
+        // slot after it settled because this synchronous path cannot poll it; live
+        // writer capacity, rather than that stale slot, decides whether to send.
+        if !datagram_has_capacity(writer.desired_size()?) {
+            return Ok(false);
         }
 
         self.write_datagram(&writer, payload);
@@ -321,7 +394,7 @@ impl Session {
     fn poll_incoming(
         &self,
         cx: &mut Context<'_>,
-        op: &Op,
+        op: &IncomingOp,
         incoming: &Incoming,
         stream: impl FnOnce() -> ReadableStream,
     ) -> Poll<Result<JsValue, Error>> {
@@ -330,10 +403,39 @@ impl Session {
             Err(err) => return Poll::Ready(Err(err)),
         };
 
-        op.poll_with(cx, || {
-            let orphan = incoming.orphans.borrow_mut().pop_front();
-            orphan.unwrap_or_else(|| JsFuture::from(promise(reader.read())))
-        })
+        let oldest_orphan = incoming
+            .orphans
+            .borrow()
+            .first_key_value()
+            .map(|(&order, _)| order);
+
+        if let Some(order) =
+            oldest_orphan.filter(|&order| should_adopt_orphan(op.order.get(), order))
+        {
+            let future = incoming
+                .orphans
+                .borrow_mut()
+                .remove(&order)
+                .expect("the oldest orphan cannot disappear on one thread");
+
+            if let Some((displaced_order, displaced_future)) = op.replace(order, future) {
+                let previous = incoming
+                    .orphans
+                    .borrow_mut()
+                    .insert(displaced_order, displaced_future);
+                assert!(previous.is_none(), "incoming read orders are unique");
+            }
+        }
+
+        let order = op.order.get().unwrap_or_else(|| {
+            let order = incoming.next_order.get();
+            incoming
+                .next_order
+                .set(order.checked_add(1).expect("incoming read order exhausted"));
+            order
+        });
+
+        op.poll_with(cx, order, || JsFuture::from(promise(reader.read())))
     }
 
     /// Accept a new unidirectional stream from the peer.
@@ -412,8 +514,9 @@ impl Drop for Session {
             (&self.accept_bi, &self.shared.accept_bi),
             (&self.recv_datagram, &self.shared.datagrams),
         ] {
-            if let Some(future) = op.take() {
-                incoming.orphans.borrow_mut().push_back(future);
+            if let Some((order, future)) = op.take() {
+                let previous = incoming.orphans.borrow_mut().insert(order, future);
+                assert!(previous.is_none(), "incoming read orders are unique");
             }
         }
     }
@@ -426,3 +529,23 @@ impl PartialEq for Session {
 }
 
 impl Eq for Session {}
+
+#[cfg(test)]
+mod tests {
+    use super::{datagram_has_capacity, should_adopt_orphan};
+
+    #[test]
+    fn only_older_orphans_preempt_an_inflight_read() {
+        assert!(should_adopt_orphan(Some(2), 1));
+        assert!(!should_adopt_orphan(Some(1), 2));
+        assert!(should_adopt_orphan(None, 2));
+    }
+
+    #[test]
+    fn settled_datagram_slot_does_not_override_live_writer_capacity() {
+        assert!(datagram_has_capacity(Some(1.0)));
+        assert!(!datagram_has_capacity(Some(0.0)));
+        assert!(!datagram_has_capacity(Some(-1.0)));
+        assert!(!datagram_has_capacity(None));
+    }
+}

--- a/rs/web-transport-wasm/src/traits.rs
+++ b/rs/web-transport-wasm/src/traits.rs
@@ -23,7 +23,7 @@ impl web_transport_trait::Error for Error {
     /// first.
     fn session_error(&self) -> Option<(u32, String)> {
         match self {
-            Error::Session(err) => Some((stream_error_code(err).unwrap_or(0), err.message())),
+            Error::Session { code, reason } => Some((*code, reason.clone())),
             _ => None,
         }
     }

--- a/rs/web-transport-wasm/src/traits.rs
+++ b/rs/web-transport-wasm/src/traits.rs
@@ -14,7 +14,7 @@ use std::{
 use bytes::Bytes;
 use web_transport_trait::{Stats, StatsUnavailable};
 
-use crate::{Error, RecvStream, SendStream, Session};
+use crate::{error::stream_error_code, Error, RecvStream, SendStream, Session};
 
 impl web_transport_trait::Error for Error {
     /// The browser reports one numeric code either way, so the variant is the only
@@ -23,16 +23,14 @@ impl web_transport_trait::Error for Error {
     /// first.
     fn session_error(&self) -> Option<(u32, String)> {
         match self {
-            Error::Session(err) => {
-                Some((err.stream_error_code().unwrap_or(0).into(), err.message()))
-            }
+            Error::Session(err) => Some((stream_error_code(err).unwrap_or(0), err.message())),
             _ => None,
         }
     }
 
     fn stream_error(&self) -> Option<u32> {
         match self {
-            Error::Stream(err) => err.stream_error_code().map(u32::from),
+            Error::Stream(err) => stream_error_code(err),
             _ => None,
         }
     }
@@ -125,7 +123,9 @@ impl web_transport_trait::Session for Session {
     /// payload is handed over without waiting for capacity. A datagram was never
     /// guaranteed to arrive anyway.
     fn send_datagram(&self, payload: Bytes) -> Result<(), Error> {
-        Session::try_send_datagram(self, &payload)
+        // A datagram the browser has no room for is dropped rather than queued;
+        // the trait already lists that among the ways one fails to arrive.
+        Session::try_send_datagram(self, &payload).map(|_| ())
     }
 
     async fn recv_datagram(&self) -> Result<Bytes, Error> {

--- a/rs/web-transport-wasm/src/traits.rs
+++ b/rs/web-transport-wasm/src/traits.rs
@@ -1,0 +1,270 @@
+//! The [`web_transport_trait`] implementations: both the async surface and the
+//! sans-I/O poll surface.
+//!
+//! Every type in this crate holds a `JsValue`, which is never `Send`, and the traits
+//! require `MaybeSend` — vacuous on `wasm32` and `Send` everywhere else. So these
+//! impls only exist on `wasm32`, which is the only place the crate does anything: a
+//! host build compiles to keep `cargo check --workspace` honest and nothing more.
+
+use std::{
+    future::poll_fn,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use web_transport_trait::{Stats, StatsUnavailable};
+
+use crate::{Error, RecvStream, SendStream, Session};
+
+impl web_transport_trait::Error for Error {
+    /// The browser reports one numeric code either way, so the variant is the only
+    /// thing saying which registry it belongs to. Answering both would have a stream
+    /// reset decoded against the session table, since callers ask about the session
+    /// first.
+    fn session_error(&self) -> Option<(u32, String)> {
+        match self {
+            Error::Session(err) => {
+                Some((err.stream_error_code().unwrap_or(0).into(), err.message()))
+            }
+            _ => None,
+        }
+    }
+
+    fn stream_error(&self) -> Option<u32> {
+        match self {
+            Error::Stream(err) => err.stream_error_code().map(u32::from),
+            _ => None,
+        }
+    }
+}
+
+impl web_transport_trait::poll::Session for Session {
+    type SendStream = SendStream;
+    type RecvStream = RecvStream;
+    type Error = Error;
+
+    fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, Error>> {
+        Session::poll_accept_uni(self, cx)
+    }
+
+    fn poll_accept_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), Error>> {
+        Session::poll_accept_bi(self, cx)
+    }
+
+    fn poll_open_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<SendStream, Error>> {
+        Session::poll_open_uni(self, cx)
+    }
+
+    fn poll_open_bi(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(SendStream, RecvStream), Error>> {
+        Session::poll_open_bi(self, cx)
+    }
+
+    fn poll_send_datagram(
+        &mut self,
+        cx: &mut Context<'_>,
+        payload: &[u8],
+    ) -> Poll<Result<(), Error>> {
+        Session::poll_send_datagram(self, cx, payload)
+    }
+
+    fn poll_recv_datagram(&mut self, cx: &mut Context<'_>) -> Poll<Result<Bytes, Error>> {
+        Session::poll_recv_datagram(self, cx)
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        Session::max_datagram_size(self)
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        Session::protocol(self)
+    }
+
+    fn close(&mut self, code: u32, reason: &str) {
+        Session::close(self, code, reason)
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Error> {
+        Session::poll_closed(self, cx)
+    }
+
+    /// The browser only reports statistics through a promise, which this cannot wait
+    /// on.
+    fn stats(&self) -> impl Stats {
+        StatsUnavailable
+    }
+}
+
+impl web_transport_trait::Session for Session {
+    type SendStream = SendStream;
+    type RecvStream = RecvStream;
+    type Error = Error;
+
+    async fn accept_uni(&self) -> Result<RecvStream, Error> {
+        Session::accept_uni(self).await
+    }
+
+    async fn accept_bi(&self) -> Result<(SendStream, RecvStream), Error> {
+        Session::accept_bi(self).await
+    }
+
+    async fn open_uni(&self) -> Result<SendStream, Error> {
+        Session::open_uni(self).await
+    }
+
+    async fn open_bi(&self) -> Result<(SendStream, RecvStream), Error> {
+        Session::open_bi(self).await
+    }
+
+    /// This trait's send is synchronous while the browser's is a promise, so the
+    /// payload is handed over without waiting for capacity. A datagram was never
+    /// guaranteed to arrive anyway.
+    fn send_datagram(&self, payload: Bytes) -> Result<(), Error> {
+        Session::try_send_datagram(self, &payload)
+    }
+
+    async fn recv_datagram(&self) -> Result<Bytes, Error> {
+        Session::recv_datagram(self).await
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        Session::max_datagram_size(self)
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        Session::protocol(self)
+    }
+
+    fn close(&self, code: u32, reason: &str) {
+        Session::close(self, code, reason)
+    }
+
+    async fn closed(&self) -> Error {
+        Session::closed(self).await
+    }
+
+    fn stats(&self) -> impl Stats {
+        StatsUnavailable
+    }
+}
+
+impl web_transport_trait::poll::SendStream for SendStream {
+    type Error = Error;
+
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        SendStream::poll_write(self, cx, buf)
+    }
+
+    fn set_priority(&mut self, order: u8) {
+        SendStream::set_priority(self, order.into())
+    }
+
+    fn finish(&mut self) -> Result<(), Error> {
+        SendStream::finish(self)
+    }
+
+    fn reset(&mut self, code: u32) {
+        SendStream::reset(self, code)
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.poll_closed_raw(cx)
+    }
+}
+
+impl web_transport_trait::SendStream for SendStream {
+    type Error = Error;
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        poll_fn(|cx| SendStream::poll_write(self, cx, buf)).await
+    }
+
+    fn set_priority(&mut self, order: u8) {
+        SendStream::set_priority(self, order.into())
+    }
+
+    fn finish(&mut self) -> Result<(), Error> {
+        SendStream::finish(self)
+    }
+
+    fn reset(&mut self, code: u32) {
+        SendStream::reset(self, code)
+    }
+
+    async fn closed(&mut self) -> Result<(), Error> {
+        poll_fn(|cx| self.poll_closed_raw(cx)).await
+    }
+}
+
+impl web_transport_trait::poll::RecvStream for RecvStream {
+    type Error = Error;
+
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        dst: &mut [u8],
+    ) -> Poll<Result<Option<usize>, Error>> {
+        RecvStream::poll_read(self, cx, dst)
+    }
+
+    /// Overridden because the browser already handed us the bytes: slicing the
+    /// buffered chunk avoids the default's allocate-and-copy.
+    fn poll_read_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+        max: usize,
+    ) -> Poll<Result<Option<Bytes>, Error>> {
+        RecvStream::poll_read_chunk(self, cx, max)
+    }
+
+    fn stop(&mut self, code: u32) {
+        RecvStream::stop(self, code)
+    }
+
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.poll_closed_raw(cx)
+    }
+}
+
+impl web_transport_trait::RecvStream for RecvStream {
+    type Error = Error;
+
+    async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Error> {
+        poll_fn(|cx| RecvStream::poll_read(self, cx, dst)).await
+    }
+
+    async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
+        RecvStream::read(self, max).await
+    }
+
+    fn stop(&mut self, code: u32) {
+        RecvStream::stop(self, code)
+    }
+
+    async fn closed(&mut self) -> Result<(), Error> {
+        poll_fn(|cx| self.poll_closed_raw(cx)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The traits are the point of this module: a signature that drifts out of
+    /// conformance should fail here rather than in a dependent crate.
+    #[test]
+    fn implements_both_surfaces() {
+        fn session<S: web_transport_trait::Session + web_transport_trait::poll::Session>() {}
+        fn send<S: web_transport_trait::SendStream + web_transport_trait::poll::SendStream>() {}
+        fn recv<S: web_transport_trait::RecvStream + web_transport_trait::poll::RecvStream>() {}
+
+        session::<Session>();
+        send::<SendStream>();
+        recv::<RecvStream>();
+    }
+}

--- a/rs/web-transport/src/quinn.rs
+++ b/rs/web-transport/src/quinn.rs
@@ -247,12 +247,11 @@ impl SendStream {
 
     /// Block until the stream is closed by either side.
     ///
-    /// This returns a (potentially truncated) u8 because that's what the WASM implementation returns.
     // TODO this should be &self but requires modifying quinn.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         match self.inner.stopped().await {
             Ok(None) => Ok(None),
-            Ok(Some(code)) => Ok(Some(code as u8)),
+            Ok(Some(code)) => Ok(Some(code)),
             Err(e) => Err(Error::Session(e)),
         }
     }
@@ -306,14 +305,10 @@ impl RecvStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    ///
-    /// This returns a (potentially truncated) u8 because that's what the WASM implementation returns.
-    /// web-transport-quinn returns a u32 because that's what the specification says.
-    // TODO Validate the correct behavior.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         match self.inner.received_reset().await {
             Ok(None) => Ok(None),
-            Ok(Some(code)) => Ok(Some(code as u8)),
+            Ok(Some(code)) => Ok(Some(code)),
             Err(e) => Err(Error::Session(e)),
         }
     }

--- a/rs/web-transport/src/wasm.rs
+++ b/rs/web-transport/src/wasm.rs
@@ -160,7 +160,7 @@ impl SendStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         self.0.closed().await
     }
 }
@@ -184,7 +184,7 @@ impl RecvStream {
     }
 
     /// Block until the stream has been closed and return the error code, if any.
-    pub async fn closed(&mut self) -> Result<Option<u8>, Error> {
+    pub async fn closed(&mut self) -> Result<Option<u32>, Error> {
         self.0.closed().await
     }
 }

--- a/rs/web-transport/src/wasm.rs
+++ b/rs/web-transport/src/wasm.rs
@@ -148,7 +148,7 @@ impl SendStream {
 
     /// Send a QUIC reset code.
     pub fn reset(&mut self, code: u32) {
-        self.0.reset(&code.to_string())
+        self.0.reset(code)
     }
 
     /// Mark the stream as finished.
@@ -180,7 +180,7 @@ impl RecvStream {
 
     /// Send a `STOP_SENDING` QUIC code.
     pub fn stop(&mut self, code: u32) {
-        self.0.stop(&code.to_string())
+        self.0.stop(code)
     }
 
     /// Block until the stream has been closed and return the error code, if any.


### PR DESCRIPTION
## Why

[moq#2736](https://github.com/moq-dev/moq/pull/2736) made moq-net poll-only. Every backend that had no native poll implementation got a transitional adapter, and `web-transport-wasm` got one inside moq-wasm's own `transport::Session` newtype: a boxed local future per operation, wrapping the async methods this crate already had. Its own follow-up list says that newtype should shrink to nothing once this crate grows a real poll implementation.

This is that implementation. Not an adapter over our async methods -- the state machine underneath them.

## What

Every operation is now a `poll_*` method, with the `async` methods as thin `poll_fn` wrappers, and the crate implements both halves of `web_transport_trait` (`poll::{Session, SendStream, RecvStream}` and the async ones) plus `Error`. A compile-time conformance test in `traits.rs` pins the signatures so drift fails here rather than downstream.

The core is `Op` in the new `js.rs`: a `JsFuture` retained across polls. A `JsFuture` subscribes to its promise when it is built and owns the slot the result lands in, so dropping one between polls throws that result away -- for a `read()` that is an accepted stream or a chunk of stream data, gone with no way to ask for it again. Retaining it means no boxed async blocks and, more importantly, nothing that has to own a stream.

That last part is what the adapter could not do. Its `closed()` future moved the stream in, which deadlocked any later read or write, so both stream closed-watches had to be emulated from reads (moq#2736 found this via `goaway_gates_new_subscribes_moq_lite_04`). Nothing here owns the stream: `poll_closed` polls the browser's own `closed` promise. That is the whole contract with no emulation -- including a peer STOP_SENDING arriving *before* `finish()`, which the emulation structurally could not see.

## Bugs the conversion caught

- **`stop` and `reset` never transmitted a code.** The browser derives STOP_SENDING and RESET_STREAM from a `WebTransportError` reason and reports anything else as 0, so the string reason we passed -- and `web-transport`'s `&code.to_string()` feeding it -- always meant 0. Both now take a `u32` and build the error the browser actually reads the code from.
- **`web-sys`'s `WebTransportError` constructor throws.** It binds `new WebTransportError(message, options)`; browsers take a single init dictionary and reject that form with a `TypeError`. So the error was never built, the thrown `TypeError` went to `cancel`/`abort` as the reason, and a reason that is not a `WebTransportError` carries no code -- the peer saw 0. Now built through `Reflect`. This also broke session close reporting, which synthesized an error the same way: `closed()` yielded `Unknown(TypeError)` and `session_error()` answered `None` for every close. A synthesized error cannot carry a session source either (the dictionary's `source` member is ignored), so `Error::Session` now carries `{ code, reason }` itself.
- **Code widths.** A stream code is a clamped byte, as `web-sys` had it; a session close code is a genuine `u32` off `WebTransportCloseInfo`. Codes stay `u32` through the API because that is what the wire and the trait carry, and the clamp is the browser's to apply. This removes the reason `web-transport` truncated its own `closed` codes to `u8` -- the comments there cite the WASM signature as the cause -- so both platforms now report the full `u32`.
- **Cloning a session could not accept.** Each call built its own `Reader`, and a browser stream can only be locked once, so a second clone threw. The locks now live in an `Rc` shared by every clone while each clone issues its own `read()`; the streams spec queues concurrent reads and fulfills them in order, so one clone's pending read is never handed to another. That is what makes cloning the way to run operations concurrently, as the poll contract assumes.

## Breaking changes

- `SendStream::reset` and `RecvStream::stop` take a `u32` code instead of a `&str` reason (see above).
- `web-streams` is dropped -- its `Reader` and `Writer` are async-only, so they cannot be polled -- and `Error::Streams` with it.
- `Error::Closed` is new: a write to a stream already finished or reset.
- `SendStream::closed` and `RecvStream::closed` take `&mut self`, and return `Option<u32>` rather than `Option<u8>` -- as does `Error::code` and both platforms of `web-transport`.
- `poll_write` reports bytes *accepted*, taking its backpressure from waiting on the previous chunk, which is what keeps a `Pending` from ever consuming the caller's buffer. A write's own failure now surfaces on the next write or on `closed()`, the same as quinn -- rather than from the `write().await` that started it.

`web-transport`'s wasm router is updated for the two signature changes; its public API is otherwise unchanged.

## Smaller things

- `max_datagram_size` comes from the browser instead of moq's conservative 1200.
- `Error`'s `Display` prints the `DOMException` message -- the reason the peer sent -- instead of a JS handle dump, and that message is what `session_error()` returns.
- `poll_recv_datagram` reports the session error when the datagram stream ends, instead of an empty `Bytes`.
- `try_send_datagram` sheds rather than queues when a write is still outstanding or the browser reports no room, so a stalled connection cannot grow an unbounded backlog that later goes out stale. The poll path still waits; draining the previous write is what bounds it.

## Review fixes (673a708)

Four defects came out of review, all cases where a browser primitive does not behave the way the first cut assumed:

- **A dropped session clone swallowed a stream.** A browser `read()` cannot be cancelled -- once issued, the browser hands the next value to *that* request -- so dropping the handle that made it stranded whatever arrived. Reads orphaned by a dropped handle now go to a shared queue the next poll adopts, oldest first.
- **`RecvStream::poll_closed` could hang.** It deferred while bytes sat buffered, on the theory the caller would drain them and wake it -- but it borrows `&mut self`, so a caller waiting there is a caller who cannot read. `stop()` then `closed()` wedged forever, as did a peer reset behind buffered bytes. The deferral is gone; buffered bytes are still delivered by later reads, matching quinn.
- **`try_send_datagram` queued without bound**, and **codes above 255 were corrupted** -- both described above.

## Verification

- `cargo check` and `cargo clippy --all-targets -- -D warnings` for `web-transport-wasm` and `web-transport`, on `wasm32-unknown-unknown` and on the host: green. `cargo fmt`, `cargo sort --check`, `cargo shear`: clean. CI green on 673a708.
- **Measured against a real browser** (Chromium 148) driving the `echo-server` example over QUIC, watching the code that reached the peer:

  | reason passed to `abort()` | on the wire |
  | --- | --- |
  | `WebTransportError{streamErrorCode: 7}` | `RESET_STREAM: 7` |
  | `WebTransportError{streamErrorCode: 200}` | `RESET_STREAM: 200` |
  | `WebTransportError{streamErrorCode: 42069}` | `RESET_STREAM: 255` (browser clamp) |
  | `"42069"` -- the reason before this branch | `RESET_STREAM: 0` |
  | the `TypeError` -- this branch before e147246 | `RESET_STREAM: 0` |

  The last two rows are the control: the code was silently dropped both before this branch and partway through it.
- **A browser harness now covers the poll state machine** (`just harness`, added in 258056a1). Seven checks against a real browser and a real QUIC peer -- 7 passed, 0 failed in Chromium 148:

  | check | |
  | --- | --- |
  | echo round trip | pass |
  | `accept_uni` delivers every stream | pass |
  | a dropped clone does not swallow a stream | pass |
  | `closed()` resolves with bytes still buffered | pass |
  | peer reset code reaches the receiver | pass |
  | datagram round trip | pass |
  | session close code and reason survive | pass |

  The two regression checks were confirmed to **fail without their fix**, not merely pass with it: reverting the orphan handoff fails the dropped-clone check with `accept_uni never resolved`, and restoring the buffered deferral fails the closed-watch check on its timeout. The other five stay green through both, so neither is passing by accident.
- Still untested: Firefox and Safari, and backpressure under real flow-control pressure. The harness runs by hand, not in CI -- it needs a browser and a live QUIC peer.

## Note on the branch

The branch carries a pre-existing `Bump -proto` commit that was already on it and is not on `main`. It is unrelated to this change.

## Follow-ups

Once this lands, moq-wasm's `transport.rs` can drop its adapter and become a plain newtype.

(written by Opus 5)
