### PR TITLE
feat(wasm): set waitUntilAvailable when opening streams

### DIFF
--- a/rs/web-transport-wasm/Cargo.toml
+++ b/rs/web-transport-wasm/Cargo.toml
@@ -37,6 +37,7 @@ features = [
     "WebTransportBidirectionalStream",
     "WebTransportCloseInfo",
     "WebTransportSendStream",
+    "WebTransportSendStreamOptions",
     "WebTransportReceiveStream",
     "WebTransportDatagramDuplexStream",
     "WebTransportCongestionControl",

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -1,11 +1,12 @@
 use bytes::Bytes;
 use js_sys::{Function, Reflect, Uint8Array};
 use url::Url;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     WebTransport, WebTransportBidirectionalStream, WebTransportCloseInfo,
-    WebTransportDatagramDuplexStream, WebTransportSendStream, WritableStream,
+    WebTransportDatagramDuplexStream, WebTransportSendStream, WebTransportSendStreamOptions,
+    WritableStream,
 };
 
 use crate::{Error, RecvStream, SendStream};
@@ -39,6 +40,27 @@ fn datagram_writable(dg: &WebTransportDatagramDuplexStream) -> WritableStream {
         .and_then(|f| f.call0(dg).ok())
         .and_then(|ws| ws.dyn_into::<WritableStream>().ok())
         .unwrap_or_else(|| dg.writable())
+}
+
+/// Options used when opening a stream.
+///
+/// `waitUntilAvailable` asks the browser to wait for stream credit when the peer's
+/// concurrent stream limit is exhausted, instead of failing the returned promise.
+/// Waiting is what the other backends do, and what `open_uni`/`open_bi` promise.
+/// <https://www.w3.org/TR/webtransport/#dom-webtransportsendstreamoptions-waituntilavailable>
+///
+/// No engine honors it yet: Chromium omits the member pending
+/// <https://crbug.com/487117768>, WebKit has it commented out, and Gecko's
+/// dictionary carries only `sendGroup`/`sendOrder`. Unknown dictionary members
+/// are ignored, so this is inert until they ship it rather than an error.
+///
+/// TODO use the web_sys setter when the binding exists; the dictionary currently
+/// only exposes `sendOrder`.
+fn stream_options() -> WebTransportSendStreamOptions {
+    let options = WebTransportSendStreamOptions::new();
+    Reflect::set(&options, &"waitUntilAvailable".into(), &JsValue::TRUE)
+        .expect("failed to set waitUntilAvailable");
+    options
 }
 
 impl Session {
@@ -82,9 +104,16 @@ impl Session {
     }
 
     /// Creates a new bidirectional stream.
+    ///
+    /// This asks the browser to wait, rather than fail, when the peer's concurrent
+    /// stream limit has been reached. No engine implements that yet, so this can
+    /// still return an error on exhaustion.
     pub async fn open_bi(&self) -> Result<(SendStream, RecvStream), Error> {
-        let stream: WebTransportBidirectionalStream =
-            JsFuture::from(self.inner.create_bidirectional_stream()).await?;
+        let stream: WebTransportBidirectionalStream = JsFuture::from(
+            self.inner
+                .create_bidirectional_stream_with_options(&stream_options()),
+        )
+        .await?;
 
         let send = SendStream::new(stream.writable())?;
         let recv = RecvStream::new(stream.readable())?;
@@ -93,9 +122,16 @@ impl Session {
     }
 
     /// Creates a new unidirectional stream.
+    ///
+    /// This asks the browser to wait, rather than fail, when the peer's concurrent
+    /// stream limit has been reached. No engine implements that yet, so this can
+    /// still return an error on exhaustion.
     pub async fn open_uni(&self) -> Result<SendStream, Error> {
-        let stream: WebTransportSendStream =
-            JsFuture::from(self.inner.create_unidirectional_stream()).await?;
+        let stream: WebTransportSendStream = JsFuture::from(
+            self.inner
+                .create_unidirectional_stream_with_options(&stream_options()),
+        )
+        .await?;
 
         let send = SendStream::new(stream)?;
         Ok(send)


### PR DESCRIPTION
## What

`web-transport-wasm`'s `open_bi`/`open_uni` called `createBidirectionalStream()` / `createUnidirectionalStream()` with no options, so [`waitUntilAvailable`](https://www.w3.org/TR/webtransport/#dom-webtransportsendstreamoptions-waituntilavailable) defaulted to `false`. Per spec that makes the returned promise reject once the peer's concurrent stream limit is exhausted, rather than waiting for stream credit.

This passes `waitUntilAvailable: true` via the `*_with_options` bindings.

## Why

Waiting is what the other backends do:

- quinn and quiche await stream credit.
- `js/qmux`'s `createUnidirectionalStream` unconditionally awaits `claim(1n)` — it has no `waitUntilAvailable` opt-out at all.
- `web-transport-trait` documents `open_bi`/`open_uni` as "may block when there are too many concurrent streams".

## Important caveat: no engine implements this yet

An adversarial review flagged that this is inert in Chromium. That's correct, and it's true of **all three engines** — I checked each one's IDL:

- **Chromium** — `web_transport_send_stream_options.idl` is empty apart from a comment: *"TODO(crbug.com/487117768): Add waitUntilAvailable once the network service supports queueing stream creation requests instead of rejecting immediately."* `ExtractSendStreamOptions` reads only `sendGroup` and `sendOrder`. On exhaustion `OnCreateSendStreamResponse` rejects with a `NetworkError` ("Failed to create send stream"), not the spec's `QuotaExceededError`.
- **WebKit** — the member is present but commented out: `// FIXME: Add support for 'waitUntilAvailable'.`
- **Gecko** — `WebTransportSendStreamOptions : WebTransportSendOptions {}`; the base carries only `sendGroup`/`sendOrder`.

So this does not change observable behavior today. Unknown WebIDL dictionary members are ignored, so setting it is inert rather than an error, and it takes effect for free once engines ship the option. The doc comments say exactly this instead of promising blocking that no browser performs — that overclaim was the real defect in the first revision of this PR, and it's fixed here.

If you'd rather not carry a forward-compatibility no-op, the alternative is to close this and instead retry on the rejection in `open_uni`/`open_bi` while racing session closure. That's a materially bigger change with its own cancellation hazards, so I did not do it here.

## Known gap, not introduced by this change

Dropping the Rust `open_uni`/`open_bi` future (a `select!` or timeout) does not cancel the underlying JS promise. If it later fulfills, the browser creates a stream that no `SendStream` owns, so nothing runs its `Drop` cleanup and the credit is orphaned. That hazard exists on `main` today; `waitUntilAvailable` would widen the window from one round-trip to unbounded once engines honor it. Worth fixing with a cancellation-aware wrapper that closes the stream if the Rust future is gone — but it's a separate concern from this one-line option, and it is currently unreachable.

## Notes for reviewers

- web-sys 0.3.103's `WebTransportSendStreamOptions` dictionary only exposes `sendOrder`, so `waitUntilAvailable` is set with `Reflect::set` — the same pattern this crate already uses to read `protocol` on the session and write `sendOrder` on a send stream. There's a TODO to switch to the generated setter once the binding lands.
- Adding the `WebTransportSendStreamOptions` web-sys feature is required: the `create_*_stream_with_options` bindings are gated on it.
- CodeRabbit asked for a browser-level regression test for the waiting behavior. I did not add one: no engine implements the option, so such a test cannot pass anywhere today, and `web-transport-wasm` currently has no `wasm-bindgen-test` harness at all. It's the right test to add alongside the retry fallback, if you want that.
- Rebased onto `main`. The unrelated `web-transport-proto` 0.6.1 -> 0.6.2 bump that was on this branch has been dropped, since release-plz owns version bumps.

## Testing

`just check` and `just test` pass, including `cargo clippy --target wasm32-unknown-unknown -p web-transport-wasm --all-targets --all-features -- -D warnings`. No lockfile changes.

(written by Opus 5)
