### PR TITLE
refactor(quiche)!: move the priority inversion into ez

### DIFF
--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -19,6 +19,14 @@ use super::{Lock, StreamError, StreamId};
 // "send" in ascii; if you see this then call finish().await or close(code)
 const DROP_CODE: u64 = 0x73656E64;
 
+/// The priority every stream starts at.
+const DEFAULT_PRIORITY: u8 = 0;
+
+/// quiche schedules lower values first, so flip our higher-is-first priority to match.
+const fn quiche_urgency(priority: u8) -> u8 {
+    u8::MAX - priority
+}
+
 // TODO Move a lot of this into a state machine enum.
 pub(super) struct SendState {
     id: StreamId,
@@ -41,8 +49,8 @@ pub(super) struct SendState {
     // received
     stop: Option<u64>,
 
-    // pending stream_priority update; Quiche defaults to 127 until this is set
-    urgency: Option<u8>,
+    // pending SET_PRIORITY, higher is sent first
+    priority: Option<u8>,
 
     // No more progress can be made on the stream.
     closed: bool,
@@ -58,7 +66,9 @@ impl SendState {
             fin: false,
             reset: None,
             stop: None,
-            urgency: None,
+            // Pin every stream to the default rather than inheriting quiche's, so that a
+            // stream explicitly assigned a low priority can't be outranked by an untouched one.
+            priority: Some(DEFAULT_PRIORITY),
             closed: false,
         }
     }
@@ -145,9 +155,9 @@ impl SendState {
             return Ok(self.blocked.take());
         }
 
-        if let Some(urgency) = self.urgency.take() {
-            tracing::trace!(stream_id = ?self.id, urgency, "updating STREAM");
-            qconn.stream_priority(self.id.into(), urgency, true)?;
+        if let Some(priority) = self.priority.take() {
+            tracing::trace!(stream_id = ?self.id, priority, "updating STREAM");
+            qconn.stream_priority(self.id.into(), quiche_urgency(priority), true)?;
         }
 
         while let Some(mut chunk) = self.queued.pop_front() {
@@ -259,8 +269,8 @@ impl SendStream {
     }
 
     #[cfg(test)]
-    pub(crate) fn urgency(&self) -> Option<u8> {
-        self.state.lock().urgency
+    pub(crate) fn priority(&self) -> Option<u8> {
+        self.state.lock().priority
     }
 
     /// Returns the QUIC stream ID.
@@ -421,14 +431,14 @@ impl SendStream {
         kio::wait(|waiter| self.poll_closed(waiter)).await
     }
 
-    /// Set the QUIC urgency of this stream.
+    /// Set the priority of this stream.
     ///
-    /// This is Quiche's native convention: lower values are sent first. Streams that are
-    /// never assigned an urgency keep Quiche's default of 127.
+    /// Streams with a higher priority are sent first, but are not guaranteed to arrive first.
+    /// Defaults to 0.
     ///
-    /// Note that [`crate::SendStream`] uses the opposite, WebTransport-facing convention.
-    pub fn set_urgency(&mut self, urgency: u8) {
-        self.state.lock().urgency = Some(urgency);
+    /// Note that this is the opposite of quiche's urgency, which is inverted internally.
+    pub fn set_priority(&mut self, priority: u8) {
+        self.state.lock().priority = Some(priority);
 
         let waker = self.driver.lock().send(self.id);
         if let Some(waker) = waker {
@@ -498,5 +508,53 @@ impl AsyncWrite for SendStream {
         self.parked.settle(&res);
 
         res.map_err(|e| io::Error::other(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The urgency handed to `quiche::Connection::stream_priority`.
+    fn urgency(stream: &SendStream) -> u8 {
+        quiche_urgency(stream.priority().expect("priority is set on construction"))
+    }
+
+    #[test]
+    fn higher_priority_is_sent_first() {
+        let mut low = SendStream::new_test();
+        let mut high = SendStream::new_test();
+
+        low.set_priority(1);
+        high.set_priority(2);
+
+        // quiche sends lower urgencies first.
+        assert!(urgency(&high) < urgency(&low));
+    }
+
+    #[test]
+    fn untouched_stream_is_outranked_by_any_promotion() {
+        // quiche's own default urgency is 127, which would outrank anything below priority 128.
+        for priority in [1, 55, 100, 128, 200, 255] {
+            let untouched = SendStream::new_test();
+            let mut promoted = SendStream::new_test();
+
+            promoted.set_priority(priority);
+
+            assert!(
+                urgency(&promoted) < urgency(&untouched),
+                "priority {priority} should outrank an untouched stream"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_default_matches_untouched() {
+        let untouched = SendStream::new_test();
+        let mut explicit = SendStream::new_test();
+
+        explicit.set_priority(DEFAULT_PRIORITY);
+
+        assert_eq!(urgency(&explicit), urgency(&untouched));
     }
 }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -14,14 +14,6 @@ use crate::{ez, waiters::Parked, StreamError};
 // decimal: 1685221232, or 91143959072288 as an HTTP error code
 const DROP_CODE: u64 = web_transport_proto::error_to_http3(0x73656E64);
 
-/// The send order every stream starts at, matching quinn and the W3C `sendOrder` default.
-const DEFAULT_SEND_ORDER: u8 = 0;
-
-/// Convert a higher-first send order to Quiche's lower-first urgency.
-const fn send_order_to_urgency(order: u8) -> u8 {
-    u8::MAX - order
-}
-
 /// A stream that can be used to send bytes.
 ///
 /// This wrapper is mainly needed for error codes.
@@ -37,20 +29,11 @@ pub struct SendStream {
 
 impl SendStream {
     pub(super) fn new(inner: ez::SendStream) -> Self {
-        let mut this = Self {
+        Self {
             inner,
             parked_write: Parked::default(),
             parked_closed: Parked::default(),
-        };
-
-        // Pin the stream to the default send order instead of inheriting Quiche's urgency of
-        // 127. Otherwise an untouched stream would outrank any stream explicitly promoted to
-        // an order below 128, inverting the contract. H3 control streams are `ez` streams and
-        // keep 127, so they precede data streams at the default order; a stream promoted above
-        // order 128 still outranks them, as it could before this change.
-        this.set_priority(DEFAULT_SEND_ORDER);
-
-        this
+        }
     }
 
     /// Write some data to the stream, returning the size written.
@@ -78,16 +61,13 @@ impl SendStream {
         self.inner.finish().map_err(Into::into)
     }
 
-    /// Set the send order of this stream.
+    /// Set the priority of this stream.
     ///
-    /// Streams with higher values are sent first, but are not guaranteed to arrive first.
+    /// Streams with a higher priority are sent first, but are not guaranteed to arrive first.
     /// Defaults to 0. This matches the W3C WebTransport `sendOrder` convention and the other
     /// `web-transport` backends.
-    ///
-    /// Quiche's native urgency runs the other way; use [`ez::SendStream::set_urgency`] if you
-    /// need that convention.
     pub fn set_priority(&mut self, order: u8) {
-        self.inner.set_urgency(send_order_to_urgency(order))
+        self.inner.set_priority(order)
     }
 
     /// Abruptly reset the stream with the provided error code.
@@ -206,60 +186,17 @@ impl web_transport_trait::poll::SendStream for SendStream {
 mod tests {
     use super::*;
 
-    /// The urgency that would be handed to `quiche::Connection::stream_priority`.
-    fn urgency(stream: &SendStream) -> u8 {
+    fn priority(stream: &SendStream) -> u8 {
         stream
             .inner
-            .urgency()
-            .expect("urgency is set on construction")
+            .priority()
+            .expect("priority is set on construction")
     }
 
     #[test]
-    fn untouched_stream_uses_the_default_send_order() {
+    fn untouched_stream_uses_the_default_priority() {
         let stream = SendStream::new(ez::SendStream::new_test());
-
-        // Not Quiche's default of 127, which would rank above a promoted stream.
-        assert_eq!(urgency(&stream), send_order_to_urgency(DEFAULT_SEND_ORDER));
-        assert_eq!(urgency(&stream), 255);
-    }
-
-    #[test]
-    fn explicit_default_order_matches_untouched() {
-        let untouched = SendStream::new(ez::SendStream::new_test());
-        let mut explicit = SendStream::new(ez::SendStream::new_test());
-
-        explicit.set_priority(DEFAULT_SEND_ORDER);
-
-        assert_eq!(urgency(&explicit), urgency(&untouched));
-    }
-
-    #[test]
-    fn higher_send_order_is_sent_first() {
-        let mut low = SendStream::new(ez::SendStream::new_test());
-        let mut high = SendStream::new(ez::SendStream::new_test());
-
-        low.set_priority(1);
-        high.set_priority(2);
-
-        // Quiche sends lower urgencies first.
-        assert!(urgency(&high) < urgency(&low));
-    }
-
-    #[test]
-    fn promoted_stream_outranks_untouched_stream() {
-        // The regression: any order above the default must beat a stream nobody touched,
-        // including orders below Quiche's default urgency of 127.
-        for order in [1, 55, 100, 200, 255] {
-            let untouched = SendStream::new(ez::SendStream::new_test());
-            let mut promoted = SendStream::new(ez::SendStream::new_test());
-
-            promoted.set_priority(order);
-
-            assert!(
-                urgency(&promoted) < urgency(&untouched),
-                "send order {order} should outrank an untouched stream"
-            );
-        }
+        assert_eq!(priority(&stream), 0);
     }
 
     #[test]
@@ -270,8 +207,8 @@ mod tests {
         inherent.set_priority(200);
         web_transport_trait::SendStream::set_priority(&mut via_trait, 200);
 
-        assert_eq!(urgency(&via_trait), urgency(&inherent));
-        assert_eq!(urgency(&via_trait), 55);
+        assert_eq!(priority(&via_trait), priority(&inherent));
+        assert_eq!(priority(&via_trait), 200);
     }
 
     #[test]
@@ -282,7 +219,7 @@ mod tests {
         inherent.set_priority(100);
         web_transport_trait::poll::SendStream::set_priority(&mut via_trait, 100);
 
-        assert_eq!(urgency(&via_trait), urgency(&inherent));
-        assert_eq!(urgency(&via_trait), 155);
+        assert_eq!(priority(&via_trait), priority(&inherent));
+        assert_eq!(priority(&via_trait), 100);
     }
 }


### PR DESCRIPTION
## Summary

- rename `ez::SendStream::set_urgency` back to `set_priority`, with higher sent first
- do the inversion to quiche's urgency in exactly one place, at the `stream_priority` call in `flush`
- pin `ez` streams to the default priority on construction, so `crate::SendStream` no longer has to
- reduce `crate::SendStream::set_priority` to a plain delegation

## Why

#367 fixed a real bug: `web_transport_quiche::SendStream::set_priority` ran the wrong way, and untouched streams sat at quiche's urgency of 127, so a stream explicitly promoted to any order below 128 lost to a stream nobody had touched.

It paid for that by renaming `ez::SendStream::set_priority` to `set_urgency` and documenting quiche's lower-first convention on it. That leaks quiche's HTTP/3 prioritization vocabulary into our public API, and leaves the two layers with methods of opposite meaning. We do not need to mirror quiche's API here.

## Approach

`ez` gets the same convention as everything else: higher priority is sent first, default 0. The inversion lives in a private `quiche_urgency()` helper, called only where the value is handed to `qconn.stream_priority()`. No other code in the crate knows quiche counts backwards.

The default is pinned in `SendState::new` rather than in the WebTransport wrapper, which is what keeps #367's fix intact: an explicitly demoted stream still cannot be outranked by an untouched one. `crate::SendStream::new` is back to a plain struct literal and `set_priority` forwards unchanged.

The ordering tests moved down into `ez`, where the conversion now lives. `send.rs` keeps the tests that pin the two trait adapters to the inherent method.

## Behavior change

H3 control and settings streams are `ez` streams. Under #367 they kept quiche's urgency of 127 and therefore sat ahead of WebTransport data streams at urgency 255. They now sit at the default priority alongside data streams, which is the relative ordering that held before #367.

Neither stream sends anything after the handshake: SETTINGS is written once during negotiation, and after the CONNECT exchange this crate only reads capsules on that stream. `Connection::close()` closes QUIC directly rather than sending a CLOSE capsule or GOAWAY, so no shutdown signalling can end up queued behind bulk data.

One caveat: `write_all_buf` does not flush, so a server's CONNECT response may still be queued when application streams are opened, and it no longer outranks them. That is protocol-safe. The WebTransport-over-HTTP/3 draft explicitly anticipates server streams arriving before the CONNECT response headers and requires the client to buffer them.

If we want control ahead of data as a guarantee rather than as a side effect, the right fix is an explicit `set_priority` in `h3` rather than relying on a leaked quiche default.

## Breaking changes

- `ez::SendStream::set_urgency` is renamed back to `set_priority` and reverses meaning: higher values are sent first.
- `web_transport_quiche::SendStream::set_priority` is unchanged from #367 (higher first, default 0), and #367 has not been released, so there is no net change for users of the WebTransport-level API.

## Validation

Run against the host toolchain rather than `nix develop`, which sat at 0% CPU without spawning cargo for 50 minutes while other builds held the machine:

- `cargo test -p web-transport-quiche --lib`: 10 passed, 0 failed
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p web-transport-quiche --all-targets -- -D warnings`: clean
- `cargo check --workspace --all-targets`: clean

(written by Opus 5)
