### PR TITLE
fix(wasm): set rustdocflags so cargo doc and doctests compile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,13 @@
+# rustdoc does not inherit `rustflags`, so the flag has to be repeated under
+# `rustdocflags` or `cargo doc` and doctests trip the `compile_error!` in
+# web-transport-wasm. This has to live in `[build]`, not the `[target]` table
+# below: newer cargo accepts `rustdocflags` there, but the toolchain pinned by
+# flake.nix (1.94) silently ignores it ("unused key"), so the flag would reach
+# rustdoc locally and not in CI. `RUSTFLAGS`/`RUSTDOCFLAGS` in the environment
+# replace these rather than extend them.
+[build]
+rustdocflags = ["--cfg=web_sys_unstable_apis"]
+
 [target.'cfg(all())']
 rustflags = ["--cfg=web_sys_unstable_apis"]
 

--- a/justfile
+++ b/justfile
@@ -60,6 +60,13 @@ test:
 	cargo test --workspace --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport --all-targets --all-features
 	cargo test --target wasm32-unknown-unknown -p web-transport-wasm --all-targets --all-features
+
+	# --all-targets excludes doctests, so run them separately. These also exercise
+	# the rustdoc path, which needs `rustdocflags` in .cargo/config.toml.
+	cargo test --workspace --doc --all-features
+	cargo test --target wasm32-unknown-unknown -p web-transport --doc --all-features
+	cargo test --target wasm32-unknown-unknown -p web-transport-wasm --doc --all-features
+
 	bun run --cwd js/qmux test
 	bun run --cwd js/qmux test:interop
 

--- a/rs/web-transport-wasm/README.md
+++ b/rs/web-transport-wasm/README.md
@@ -33,9 +33,14 @@ build. Add it to `.cargo/config.toml`:
 ```toml
 [build]
 rustflags = ["--cfg=web_sys_unstable_apis"]
+rustdocflags = ["--cfg=web_sys_unstable_apis"]
 ```
 
-Or set `RUSTFLAGS="--cfg=web_sys_unstable_apis"` in the environment. `RUSTFLAGS` overrides
-`.cargo/config.toml` rather than adding to it, so use one or the other.
+`rustdocflags` is separate because rustdoc does not inherit `rustflags`; without it `cargo doc` and
+doctests fail even though `cargo build` succeeds.
+
+Or set `RUSTFLAGS="--cfg=web_sys_unstable_apis"` and `RUSTDOCFLAGS="--cfg=web_sys_unstable_apis"` in
+the environment. Both override `.cargo/config.toml` rather than adding to it, so use one or the
+other.
 
 Building without the flag fails with a `compile_error!` pointing back here.

--- a/rs/web-transport-wasm/src/lib.rs
+++ b/rs/web-transport-wasm/src/lib.rs
@@ -21,7 +21,11 @@
 //! ```toml
 //! [build]
 //! rustflags = ["--cfg=web_sys_unstable_apis"]
+//! rustdocflags = ["--cfg=web_sys_unstable_apis"]
 //! ```
+//!
+//! `rustdocflags` is separate because rustdoc does not inherit `rustflags`; without it
+//! `cargo doc` and doctests fail even though `cargo build` succeeds.
 
 #[cfg(not(web_sys_unstable_apis))]
 compile_error!(
@@ -29,9 +33,12 @@ compile_error!(
      WebTransport bindings behind it. This flag cannot be enabled by a dependency; add it to \
      your own build, for example in `.cargo/config.toml`:\n\n\
      \x20   [build]\n\
-     \x20   rustflags = [\"--cfg=web_sys_unstable_apis\"]\n\n\
-     or set `RUSTFLAGS=\"--cfg=web_sys_unstable_apis\"` in the environment. Note that RUSTFLAGS \
-     overrides `.cargo/config.toml`, so only one of the two takes effect."
+     \x20   rustflags = [\"--cfg=web_sys_unstable_apis\"]\n\
+     \x20   rustdocflags = [\"--cfg=web_sys_unstable_apis\"]\n\n\
+     `rustdocflags` is required separately because rustdoc does not inherit `rustflags`; if you \
+     are seeing this from `cargo doc` or a doctest, that is the missing piece. Alternatively set \
+     `RUSTFLAGS`/`RUSTDOCFLAGS` in the environment, but note that both replace `.cargo/config.toml` \
+     rather than extending it, so only one of the two takes effect."
 );
 
 // Gated so missing web-sys bindings don't bury the error above.


### PR DESCRIPTION
## What

`cargo test -p web-transport-wasm` failed immediately with the crate's own `compile_error!`:

```
error: web-transport-wasm requires `--cfg=web_sys_unstable_apis` because web-sys gates the
WebTransport bindings behind it.
```

rustdoc does not inherit `rustflags`, so the flag set in `.cargo/config.toml` never reached it. Doctests and `cargo doc` compiled without it and hit the guard, even though `cargo build` succeeded.

CI never caught this: `just test` ran `cargo test --workspace --all-targets`, and `--all-targets` excludes doctests. Only someone running the plain per-crate command hit it, which made it a papercut for anyone new to the crate.

## Changes

- **`.cargo/config.toml`**: set `rustdocflags`. This has to live in `[build]`, not the existing `[target.'cfg(all())']` table — see the compatibility note below.
- **`justfile`**: add separate `--doc` runs rather than dropping `--all-targets`. The two sets are disjoint rather than nested, so dropping it would have traded doctests away for bench compilation. Includes the two wasm32 runs, since that is the target docs.rs builds.
- **`rs/web-transport-wasm/{README.md,src/lib.rs}`**: document the `rustflags` vs `rustdocflags` distinction, including in the `compile_error!` text itself.

## Reviewer notes

**The `[build]` placement is load-bearing, not stylistic.** `target.'cfg(all())'.rustdocflags` is honored by rustup's cargo 1.97 but is *silently ignored* by cargo 1.94.0, which `flake.nix` pins and CI uses via `nix develop` — it emits `warning: unused key 'rustdocflags' in [target] config table 'cfg(all())'` and carries on. The target-scoped form would have fixed local `cargo test` while leaving CI exactly as broken. `rustflags` deliberately stays in the `[target]` table, where cfg-scoped flags skip build scripts and proc macros.

**`package.metadata.docs.rs` is unchanged and still required.** `cargo package --list -p web-transport-wasm` shows the tarball contains only `rs/web-transport-wasm/**`; the repo-root `.cargo/config.toml` is not in it, so docs.rs never sees this fix.

**The error message change is not cosmetic.** It previously pointed at `[build] rustflags`, which does not fix a doctest or `cargo doc` failure — following it left you at the same error. `cargo doc -p web-transport-wasm` fails identically with only `rustflags` set, so this affects downstream consumers too, not just this repo.

## Verification

- `cargo test -p web-transport-wasm` — the originally failing command now passes.
- `just check` and `just test` — both green under `nix develop` from a clean target dir, with zero `unused key` warnings. Doctests now run across 12 crates (qmux has 3 real ones; the rest have none but still compile under rustdoc).
- `RUSTDOCFLAGS` in the environment replaces this config rather than extending it, same trap as `RUSTFLAGS`; confirmed and documented.

Verification for CI has to run inside the Nix shell: local `cargo` is 1.97 here and `nix develop --command cargo` is 1.94.

Reviewed adversarially by Codex (approve, no material findings). Its sandbox blocked `nix develop` and test execution, so that pass was static analysis of the diff and repo config; the execution half is the `just check`/`just test` runs above.

(written by Opus 5)