### PR TITLE
fix(wasm): resubscribe to ready instead of waiting on closed

### DIFF
--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -334,18 +334,17 @@ impl Session {
                 Ok(size) if datagram_has_capacity(size) => break,
                 Ok(_) => match self.send_datagram.poll(cx, || promise(writer.ready())) {
                     Poll::Pending => return Poll::Pending,
-                    Poll::Ready(Ok(_)) => match writer.desired_size() {
-                        Ok(size) if datagram_has_capacity(size) => continue,
-                        // `ready` also fulfills when the writer closes. Its closed
-                        // promise distinguishes that terminal zero from ordinary
-                        // backpressure and prevents an already-ready wake loop.
-                        Ok(_) => match self.send_datagram.poll(cx, || promise(writer.closed())) {
-                            Poll::Pending => return Poll::Pending,
-                            Poll::Ready(Ok(_)) => return Poll::Ready(Err(Error::Closed)),
-                            Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-                        },
-                        Err(err) => return Poll::Ready(Err(err.into())),
-                    },
+                    // Recheck, and resubscribe when the capacity is gone again. A
+                    // clone that lost the race to it holds a `ready` that has
+                    // already fulfilled and never will again, so only the writer's
+                    // current promise can wake it — the slot this `poll` just
+                    // cleared is what the next pass subscribes through. Waiting on
+                    // `closed` here instead would wait out the session, which is
+                    // the deadlock `concurrent_datagram_senders` pins.
+                    //
+                    // A writer that closed rather than filled rejects `ready`, so
+                    // that case leaves through the arm below rather than spinning.
+                    Poll::Ready(Ok(_)) => continue,
                     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
                 },
                 Err(err) => return Poll::Ready(Err(err.into())),


### PR DESCRIPTION
## What

`Session::poll_send_datagram` had a fallback that waited on `writer.closed()` when `ready` had fulfilled but `desiredSize` still reported no capacity. This removes it and `continue`s the loop instead, which resubscribes to the writer's current `ready` promise.

## Why

Two separate problems, both fixed by the same one-line change.

**It was unreachable.** `ready` and `closed` share the same `Op` slot that `poll_settled` drains at the top of the call, so the loop always starts from an empty slot. A freshly built `JsFuture` polls `Pending` on its first poll -- wasm-bindgen attaches `then` callbacks that fire on a microtask -- so reaching that arm required a fulfilled `ready` carried over from an earlier call, which the drain already ruled out. This was verified empirically before removal: the branch was instrumented to set a JS global when entered, and it never fired across the full browser harness, including a hand-driven capacity race.

**It was also wrong if revived.** The natural next refactor -- giving `ready` and `closed` their own slots -- would have made it reachable, and then a clone that lost the capacity race would park on `closed()` against an *open* writer. That promise never fulfills, so the send hangs for the life of the session. That is exactly the deadlock [`concurrent_datagram_senders`](rs/web-transport-wasm/examples/harness.rs) pins, whose doc comment already called it "a deadlock dressed up as backpressure."

So the arm was dead code that also modeled a fix that does not work. Removing it leaves the correct behavior the code already relied on: fall back to an empty slot, resubscribe to the current promise.

## Where the closed-writer hazard goes

The arm was originally added to stop a closed writer from spinning on an already-fulfilled `ready`. That case does not need it: closing the session errors the datagram writable, so `ready` **rejects**, and the error leaves through the `Poll::Ready(Err(_))` arm. The harness check `closed datagram writer terminates poll` distinguishes this from a spin -- it fails with `"closed writer stayed in a wake loop"` on timeout -- and still passes.

## Testing

- `just harness` (Chromium, real QUIC peer): **14 passed, 0 failed**, including the two decisive checks -- `closed datagram writer terminates poll` ("closed writer returned an error") and `concurrent cloned senders all get capacity` ("the loser resubscribed and sent").
- `just check`: passes.

No behavior change for any path that was actually reachable.

## Reviewer notes

The reasoning here was challenged adversarially by Codex, which confirmed the unreachability analysis and caught that an earlier version of this change described the branch as becoming "load-bearing" if the slots were split -- it would in fact deadlock. That correction is why the arm is removed rather than documented.

(written by Opus 5)