### PR TITLE
fix(quiche): keep per-stream teardown out of the connection

### DIFF
--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -587,9 +587,7 @@ impl Driver {
                     }
                 }
                 hash_map::Entry::Vacant(_entry) => {
-                    // Expected: quiche marks a stream writable again when the peer
-                    // stops it, which is also when this driver retires the state.
-                    tracing::trace!(?stream_id, "closed stream was writable");
+                    tracing::warn!(?stream_id, "closed stream was writable");
                 }
             }
         }
@@ -738,9 +736,7 @@ impl Driver {
                 waker.wake();
             }
         } else {
-            // Expected: the application can queue a flush for a stream this driver
-            // has already retired, for example finishing a stream the peer stopped.
-            tracing::trace!(?stream_id, "wakeup for closed stream");
+            tracing::warn!(?stream_id, "wakeup for closed stream");
         }
 
         Ok(())
@@ -767,9 +763,7 @@ impl Driver {
                 waker.wake();
             }
         } else {
-            // Expected: the application can queue a flush for a stream this driver
-            // has already retired, for example finishing a stream the peer stopped.
-            tracing::trace!(?stream_id, "wakeup for closed stream");
+            tracing::warn!(?stream_id, "wakeup for closed stream");
         }
 
         Ok(())

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -587,7 +587,9 @@ impl Driver {
                     }
                 }
                 hash_map::Entry::Vacant(_entry) => {
-                    tracing::warn!(?stream_id, "closed stream was writable");
+                    // Expected: quiche marks a stream writable again when the peer
+                    // stops it, which is also when this driver retires the state.
+                    tracing::trace!(?stream_id, "closed stream was writable");
                 }
             }
         }
@@ -736,7 +738,9 @@ impl Driver {
                 waker.wake();
             }
         } else {
-            tracing::warn!(?stream_id, "wakeup for closed stream");
+            // Expected: the application can queue a flush for a stream this driver
+            // has already retired, for example finishing a stream the peer stopped.
+            tracing::trace!(?stream_id, "wakeup for closed stream");
         }
 
         Ok(())
@@ -763,7 +767,9 @@ impl Driver {
                 waker.wake();
             }
         } else {
-            tracing::warn!(?stream_id, "wakeup for closed stream");
+            // Expected: the application can queue a flush for a stream this driver
+            // has already retired, for example finishing a stream the peer stopped.
+            tracing::trace!(?stream_id, "wakeup for closed stream");
         }
 
         Ok(())

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -318,6 +318,23 @@ impl SendStream {
         self.id
     }
 
+    /// Tell the driver this stream has work to flush.
+    ///
+    /// Skipped once the state is closed: the driver retires a stream as soon as it
+    /// observes that, so a notification afterwards names a stream it no longer
+    /// tracks and is reported as a spurious wakeup.
+    fn notify(&self) {
+        // Take the two locks in sequence, never both at once.
+        let closed = self.state.lock().is_closed();
+        if closed {
+            return;
+        }
+
+        if let Some(waker) = self.driver.lock().send(self.id) {
+            waker.wake();
+        }
+    }
+
     /// Write some data to the stream, returning the size written.
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, StreamError> {
         let mut buf = io::Cursor::new(buf);
@@ -339,12 +356,12 @@ impl SendStream {
         waiter: &Waiter,
         buf: &mut B,
     ) -> Poll<Result<usize, StreamError>> {
-        if let Poll::Ready(res) = self.state.lock().poll_write_buf(waiter, buf) {
+        // Bind before notifying: on edition 2021 the guard from an `if let` scrutinee
+        // lives for the whole block, and `notify` takes the same lock.
+        let polled = self.state.lock().poll_write_buf(waiter, buf);
+        if let Poll::Ready(res) = polled {
             // Tell the driver that the stream has data to send.
-            let waker = self.driver.lock().send(self.id);
-            if let Some(waker) = waker {
-                waker.wake();
-            }
+            self.notify();
 
             return Poll::Ready(res);
         }
@@ -399,10 +416,7 @@ impl SendStream {
             state.fin = true;
         }
 
-        let waker = self.driver.lock().send(self.id);
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        self.notify();
 
         Ok(())
     }
@@ -418,10 +432,7 @@ impl SendStream {
     pub fn reset(&mut self, code: u64) {
         self.state.lock().reset = Some(code);
 
-        let waker = self.driver.lock().send(self.id);
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        self.notify();
     }
 
     /// Returns true if the stream is closed by either side.
@@ -480,10 +491,7 @@ impl SendStream {
     pub fn set_priority(&mut self, priority: u8) {
         self.state.lock().priority = Some(priority);
 
-        let waker = self.driver.lock().send(self.id);
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        self.notify();
     }
 }
 
@@ -496,10 +504,7 @@ impl Drop for SendStream {
             state.reset = Some(DROP_CODE);
             drop(state);
 
-            let waker = self.driver.lock().send(self.id);
-            if let Some(waker) = waker {
-                waker.wake();
-            }
+            self.notify();
         }
     }
 }

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -49,6 +49,10 @@ pub(super) struct SendState {
     // received
     stop: Option<u64>,
 
+    // quiche discarded the stream before we asked it anything, so the peer stopped us
+    // but the code is gone. Terminal exactly like `stop`, with nothing to report.
+    gone: bool,
+
     // pending SET_PRIORITY, higher is sent first
     priority: Option<u8>,
 
@@ -66,6 +70,7 @@ impl SendState {
             fin: false,
             reset: None,
             stop: None,
+            gone: false,
             // Pin every stream to the default rather than inheriting quiche's, so that a
             // stream explicitly assigned a low priority can't be outranked by an untouched one.
             priority: Some(DEFAULT_PRIORITY),
@@ -84,7 +89,7 @@ impl SendState {
             return Poll::Ready(Err(StreamError::Reset(reset)));
         } else if let Some(stop) = self.stop {
             return Poll::Ready(Err(StreamError::Stop(stop)));
-        } else if self.fin {
+        } else if self.gone || self.fin {
             return Poll::Ready(Err(StreamError::Closed));
         }
 
@@ -111,6 +116,8 @@ impl SendState {
             return Poll::Ready(Err(StreamError::Reset(reset)));
         } else if let Some(stop) = self.stop {
             return Poll::Ready(Err(StreamError::Stop(stop)));
+        } else if self.gone {
+            return Poll::Ready(Err(StreamError::Closed));
         } else if self.closed {
             // self.closed means we sent the FIN already
             // TODO wait until the peer has acknowledged the fin
@@ -127,6 +134,10 @@ impl SendState {
             return Poll::Ready(Err(StreamError::Reset(reset)));
         } else if let Some(stop) = self.stop {
             return Poll::Ready(Err(StreamError::Stop(stop)));
+        } else if self.gone {
+            // The queue was discarded rather than sent, so reporting a successful
+            // flush here would tell the application its bytes reached the peer.
+            return Poll::Ready(Err(StreamError::Closed));
         } else if self.queued.is_empty() {
             return Poll::Ready(Ok(()));
         }
@@ -154,10 +165,11 @@ impl SendState {
             }
             quiche::Error::Done | quiche::Error::InvalidStreamState(_) => {
                 tracing::trace!(stream_id = ?self.id, "stream already collected by quiche");
-                // quiche kept no record of how the stream ended, so all that is left to
-                // say is that the write side is over. `fin` is what makes a later write
-                // fail and a pending flush resolve.
-                self.fin = true;
+                // Only a peer STOP_SENDING gets a live stream collected, so this is a
+                // stop whose code quiche has already thrown away. It is not a `fin`:
+                // the application's bytes never left, and saying otherwise would report
+                // a successful flush for data the peer refused.
+                self.gone = true;
             }
             e => return Err(e),
         }
@@ -254,6 +266,8 @@ impl SendState {
             Err(StreamError::Reset(reset))
         } else if let Some(stop) = self.stop {
             Err(StreamError::Stop(stop))
+        } else if self.gone {
+            Err(StreamError::Closed)
         } else {
             Ok(self.fin)
         }
@@ -378,7 +392,7 @@ impl SendStream {
                 return Err(StreamError::Reset(reset));
             } else if let Some(stop) = state.stop {
                 return Err(StreamError::Stop(stop));
-            } else if state.fin {
+            } else if state.gone || state.fin {
                 return Err(StreamError::Closed);
             }
 
@@ -477,7 +491,7 @@ impl Drop for SendStream {
     fn drop(&mut self) {
         let mut state = self.state.lock();
 
-        if !state.fin && state.reset.is_none() && state.stop.is_none() {
+        if !state.fin && !state.gone && state.reset.is_none() && state.stop.is_none() {
             // Reset the stream if we're dropped without calling finish.
             state.reset = Some(DROP_CODE);
             drop(state);

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -154,11 +154,22 @@ impl SendState {
             }
             quiche::Error::Done | quiche::Error::InvalidStreamState(_) => {
                 tracing::trace!(stream_id = ?self.id, "stream already collected by quiche");
+                // quiche kept no record of how the stream ended, so all that is left to
+                // say is that the write side is over. `fin` is what makes a later write
+                // fail and a pending flush resolve.
+                self.fin = true;
             }
             e => return Err(e),
         }
 
+        // The driver drops this state as soon as it sees `closed`, so nothing here will
+        // ever be flushed again: leaving bytes queued would park a flush forever, and
+        // leaving capacity behind would let writes keep accumulating into a queue that
+        // no longer reaches the peer.
+        self.queued.clear();
+        self.capacity = 0;
         self.closed = true;
+
         Ok(self.blocked.take())
     }
 

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -136,16 +136,38 @@ impl SendState {
         Poll::Pending
     }
 
+    /// Close this stream in response to a quiche error, or propagate a genuine
+    /// connection error.
+    ///
+    /// quiche reports the end of an individual stream through errors on otherwise
+    /// ordinary calls: `StreamStopped` once the peer has sent STOP_SENDING, and
+    /// `Done` or `InvalidStreamState` once quiche has reset the stream and collected
+    /// its state. All three mean this stream is over; none of them mean the
+    /// connection is, and promoting one would tear down every other stream on the
+    /// session.
+    #[must_use = "wake the driver"]
+    fn closed_by(&mut self, err: quiche::Error) -> quiche::Result<Option<Waker>> {
+        match err {
+            quiche::Error::StreamStopped(code) => {
+                tracing::trace!(stream_id = ?self.id, code, "received STOP_SENDING");
+                self.stop = Some(code);
+            }
+            quiche::Error::Done | quiche::Error::InvalidStreamState(_) => {
+                tracing::trace!(stream_id = ?self.id, "stream already collected by quiche");
+            }
+            e => return Err(e),
+        }
+
+        self.closed = true;
+        Ok(self.blocked.take())
+    }
+
     #[must_use = "wake the driver"]
     pub fn flush(&mut self, qconn: &mut QuicheConnection) -> quiche::Result<Option<Waker>> {
         if let Some(code) = self.reset {
             tracing::trace!(stream_id = ?self.id, code, "sending RESET_STREAM");
-            // Resetting a single stream must never tear down the whole connection.
-            // quiche returns Done / InvalidStreamState when the stream is already
-            // finished or gone, which is a benign no-op here, not a fatal error.
-            match qconn.stream_shutdown(self.id.into(), quiche::Shutdown::Write, code) {
-                Ok(()) | Err(quiche::Error::Done) | Err(quiche::Error::InvalidStreamState(_)) => {}
-                Err(e) => return Err(e),
+            if let Err(e) = qconn.stream_shutdown(self.id.into(), quiche::Shutdown::Write, code) {
+                return self.closed_by(e);
             }
             self.closed = true;
             return Ok(self.blocked.take());
@@ -163,15 +185,11 @@ impl SendState {
         while let Some(mut chunk) = self.queued.pop_front() {
             let n = match qconn.stream_send(self.id.into(), &chunk, false) {
                 Ok(n) => n,
+                // Out of connection-level capacity, so retry once writable again.
+                // The same error also covers a collected stream, which the
+                // `stream_writable` registration below reports as gone.
                 Err(quiche::Error::Done) => 0,
-                Err(quiche::Error::StreamStopped(code)) => {
-                    tracing::trace!(stream_id = ?self.id, code, "received STOP_SENDING");
-
-                    self.stop = Some(code);
-                    self.closed = true;
-                    return Ok(self.blocked.take());
-                }
-                Err(e) => return Err(e),
+                Err(e) => return self.closed_by(e),
             };
 
             tracing::trace!(
@@ -187,7 +205,9 @@ impl SendState {
                 self.queued.push_front(remaining);
 
                 // Register a `stream_writable_next` callback when at least one byte is ready to send.
-                qconn.stream_writable(self.id.into(), 1)?;
+                if let Err(e) = qconn.stream_writable(self.id.into(), 1) {
+                    return self.closed_by(e);
+                }
 
                 break;
             }
@@ -195,7 +215,9 @@ impl SendState {
 
         if self.queued.is_empty() && self.fin {
             tracing::trace!(stream_id = ?self.id, "sending FIN");
-            qconn.stream_send(self.id.into(), &[], true)?;
+            if let Err(e) = qconn.stream_send(self.id.into(), &[], true) {
+                return self.closed_by(e);
+            }
 
             self.closed = true;
             return Ok(self.blocked.take());
@@ -203,14 +225,7 @@ impl SendState {
 
         self.capacity = match qconn.stream_capacity(self.id.into()) {
             Ok(capacity) => capacity,
-            Err(quiche::Error::StreamStopped(code)) => {
-                tracing::trace!(stream_id = ?self.id, code, "received STOP_SENDING");
-
-                self.stop = Some(code);
-                self.closed = true;
-                return Ok(self.blocked.take());
-            }
-            Err(e) => return Err(e),
+            Err(e) => return self.closed_by(e),
         };
 
         // A flush waiter can make progress as soon as the internal queue has

--- a/rs/web-transport-quiche/tests/drop_recv.rs
+++ b/rs/web-transport-quiche/tests/drop_recv.rs
@@ -1,34 +1,81 @@
-//! Regression: dropping a receive stream early must not close the session.
+//! Regression: dropping a receive stream early must not close the session, and it
+//! must leave the sender's half in a state the application can observe.
 //!
 //! moq-lite-05 opens a unidirectional TRACK stream, writes a header, and holds the
 //! stream open. The subscriber reads the header and drops the receiver because it
-//! needs nothing else, which sends STOP_SENDING. quiche resets the sender's stream
-//! in response and collects it once that RESET_STREAM is acked, so the sender's
-//! later FIN lands on a stream quiche no longer knows about and comes back as
-//! `quiche::Error::Done`. That is per-stream teardown, but it used to be promoted
-//! into a fatal connection error: application close code 500, reason `Done`.
+//! needs nothing else, which sends STOP_SENDING. quiche resets the sender's half in
+//! response and collects it entirely once that RESET_STREAM is acked, so anything
+//! the sender does next lands on a stream quiche no longer knows about and comes
+//! back as `quiche::Error::Done`. That is per-stream teardown, but it used to be
+//! promoted into a fatal connection error: application close code 500, reason
+//! `Done`.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use rcgen::{CertifiedKey, KeyPair};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use url::Url;
-use web_transport_quiche::{ClientBuilder, RecvStream, SendStream, ServerBuilder, Settings};
+use web_transport_quiche::{
+    ClientBuilder, Connection, RecvStream, SendStream, Server, ServerBuilder, SessionError,
+    Settings, StreamError,
+};
 
-const STREAMS: usize = 16;
 const HEADER: &[u8] = b"TRACK_INFO";
 
-fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+fn start_server() -> Result<(Server, SocketAddr)> {
     let CertifiedKey { cert, signing_key } =
         rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
             .context("rcgen self-signed")?;
 
-    let cert_der = CertificateDer::from(cert.der().to_vec());
-    let key_bytes = KeyPair::serialize_der(&signing_key);
-    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+    let chain = vec![CertificateDer::from(cert.der().to_vec())];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
 
-    Ok((vec![cert_der], key_der))
+    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    Ok((server, addr))
+}
+
+async fn connect_client(addr: SocketAddr) -> Result<Connection> {
+    let mut settings = Settings::default();
+    settings.verify_peer = false;
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let client = ClientBuilder::default()
+        .with_settings(settings)
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?;
+
+    let session = client
+        .connect(url)
+        .await?
+        .established()
+        .await
+        .context("client handshake")?;
+
+    Ok(session)
 }
 
 /// Read exactly `buf.len()` bytes, so the two sides stay in lockstep.
@@ -49,34 +96,19 @@ async fn write_msg(send: &mut SendStream, msg: &[u8]) -> Result<()> {
 }
 
 // Current-thread runtime on purpose, matching the sibling reset test: it keeps the
-// FIN-versus-teardown interleaving deterministic.
+// teardown interleaving deterministic.
 #[tokio::test(flavor = "current_thread")]
 async fn drop_recv_keeps_connection_alive() -> Result<()> {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
-        .with_test_writer()
-        .try_init();
+    const STREAMS: usize = 16;
 
-    let (chain, key) = make_self_signed()?;
-
-    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
-    let mut server = ServerBuilder::default()
-        .with_bind(bind)?
-        .with_single_cert(chain, key)?;
-
-    let server_addr = *server
-        .local_addrs()
-        .first()
-        .context("server has no local address")?;
+    init_tracing();
+    let (mut server, addr) = start_server()?;
 
     // Server: open a batch of unidirectional streams, write a header on each, and
     // hold the send halves open. A bidirectional stream sequences the rest: the
     // second "ping" only arrives after the client has acked the RESET_STREAM for
     // every dropped receiver, which is what makes the streams collected — and the
-    // FIN that follows `Done` — deterministic.
+    // resulting `Done` — deterministic.
     let server_task = tokio::spawn(async move {
         let request = server.accept().await.context("server accept")?;
         let session = request.ok().await.context("server session")?;
@@ -91,7 +123,6 @@ async fn drop_recv_keeps_connection_alive() -> Result<()> {
         }
 
         let (mut sync_send, mut sync_recv) = session.accept_bi().await.context("server sync")?;
-
         let mut ping = [0u8; 4];
         read_exact(&mut sync_recv, &mut ping)
             .await
@@ -113,20 +144,7 @@ async fn drop_recv_keeps_connection_alive() -> Result<()> {
         anyhow::Ok(session.closed().await)
     });
 
-    let mut client_settings = Settings::default();
-    client_settings.verify_peer = false;
-
-    let url = Url::parse(&format!("https://127.0.0.1:{}/", server_addr.port()))?;
-    let client = ClientBuilder::default()
-        .with_settings(client_settings)
-        .with_bind((Ipv4Addr::LOCALHOST, 0))?;
-
-    let session = client
-        .connect(url)
-        .await?
-        .established()
-        .await
-        .context("client handshake")?;
+    let session = connect_client(addr).await?;
 
     for i in 0..STREAMS {
         let mut recv = session.accept_uni().await.context("client accept_uni")?;
@@ -167,8 +185,95 @@ async fn drop_recv_keeps_connection_alive() -> Result<()> {
         .context("server task panicked")?
         .context("server task errored")?;
     assert!(
-        matches!(err, web_transport_quiche::SessionError::Remote(0, _)),
+        matches!(err, SessionError::Remote(0, _)),
         "unexpected session error: {err}"
+    );
+
+    Ok(())
+}
+
+/// Once quiche has collected the stream, the sender's cached capacity is stale. A
+/// write must fail rather than queue bytes onto state the driver has already
+/// retired, which nothing will ever flush or wake again.
+#[tokio::test(flavor = "current_thread")]
+async fn write_after_drop_recv_ends_the_stream() -> Result<()> {
+    init_tracing();
+    let (mut server, addr) = start_server()?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("server accept")?;
+        let session = request.ok().await.context("server session")?;
+
+        let mut send = session.open_uni().await.context("server open_uni")?;
+        write_msg(&mut send, HEADER)
+            .await
+            .context("server header")?;
+
+        let (mut sync_send, mut sync_recv) = session.accept_bi().await.context("server sync")?;
+        let mut ping = [0u8; 4];
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 1")?;
+        write_msg(&mut sync_send, b"pong").await?;
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 2")?;
+
+        // The stream is stopped and collected by now. The first writes may still be
+        // accepted against the stale capacity, but the stream has to fail them before
+        // that capacity runs out, or the writer parks with nothing left to wake it.
+        let chunk = vec![0u8; 64 * 1024];
+        let err: StreamError = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Err(e) = send.write_all(&chunk).await {
+                    return e;
+                }
+            }
+        })
+        .await
+        .context("writing to a collected stream never returned")?;
+
+        write_msg(&mut sync_send, b"done").await?;
+
+        // Hold the session (and with it the sync stream) until the client is done,
+        // so "done" is flushed rather than reset by the teardown.
+        session.closed().await;
+
+        anyhow::Ok(err)
+    });
+
+    let session = connect_client(addr).await?;
+
+    let mut recv = session.accept_uni().await.context("client accept_uni")?;
+    let mut header = [0u8; HEADER.len()];
+    read_exact(&mut recv, &mut header).await.context("header")?;
+    assert_eq!(&header, HEADER);
+    drop(recv);
+
+    let (mut sync_send, mut sync_recv) = session.open_bi().await.context("client sync")?;
+    write_msg(&mut sync_send, b"ping").await?;
+    let mut pong = [0u8; 4];
+    read_exact(&mut sync_recv, &mut pong)
+        .await
+        .context("pong")?;
+    write_msg(&mut sync_send, b"ping").await?;
+
+    let mut done = [0u8; 4];
+    read_exact(&mut sync_recv, &mut done)
+        .await
+        .context("server never finished writing to the collected stream")?;
+    assert_eq!(&done, b"done");
+
+    session.close(0, "bye");
+    session.closed().await;
+
+    let err = server_task
+        .await
+        .context("server task panicked")?
+        .context("server task errored")?;
+    assert!(
+        matches!(err, StreamError::Closed),
+        "unexpected stream error: {err}"
     );
 
     Ok(())

--- a/rs/web-transport-quiche/tests/drop_recv.rs
+++ b/rs/web-transport-quiche/tests/drop_recv.rs
@@ -18,6 +18,7 @@ use std::{
 use anyhow::{Context, Result};
 use rcgen::{CertifiedKey, KeyPair};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::io::AsyncWriteExt as _;
 use url::Url;
 use web_transport_quiche::{
     ClientBuilder, Connection, RecvStream, SendStream, Server, ServerBuilder, SessionError,
@@ -232,6 +233,18 @@ async fn write_after_drop_recv_ends_the_stream() -> Result<()> {
         })
         .await
         .context("writing to a collected stream never returned")?;
+
+        // Neither may report success: the queued bytes were discarded, not sent, so an
+        // `Ok` here would tell the application they reached the peer.
+        let flushed = tokio::time::timeout(Duration::from_secs(10), send.flush())
+            .await
+            .context("flushing a collected stream never returned")?;
+        let closed = tokio::time::timeout(Duration::from_secs(10), send.closed())
+            .await
+            .context("closing a collected stream never returned")?;
+
+        assert!(flushed.is_err(), "flush reported success for unsent bytes");
+        assert!(closed.is_err(), "closed reported success for unsent bytes");
 
         write_msg(&mut sync_send, b"done").await?;
 

--- a/rs/web-transport-quiche/tests/drop_recv.rs
+++ b/rs/web-transport-quiche/tests/drop_recv.rs
@@ -1,0 +1,175 @@
+//! Regression: dropping a receive stream early must not close the session.
+//!
+//! moq-lite-05 opens a unidirectional TRACK stream, writes a header, and holds the
+//! stream open. The subscriber reads the header and drops the receiver because it
+//! needs nothing else, which sends STOP_SENDING. quiche resets the sender's stream
+//! in response and collects it once that RESET_STREAM is acked, so the sender's
+//! later FIN lands on a stream quiche no longer knows about and comes back as
+//! `quiche::Error::Done`. That is per-stream teardown, but it used to be promoted
+//! into a fatal connection error: application close code 500, reason `Done`.
+
+use std::net::{Ipv4Addr, SocketAddr};
+
+use anyhow::{Context, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use url::Url;
+use web_transport_quiche::{ClientBuilder, RecvStream, SendStream, ServerBuilder, Settings};
+
+const STREAMS: usize = 16;
+const HEADER: &[u8] = b"TRACK_INFO";
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+/// Read exactly `buf.len()` bytes, so the two sides stay in lockstep.
+async fn read_exact(recv: &mut RecvStream, buf: &mut [u8]) -> Result<()> {
+    let mut got = 0;
+    while got < buf.len() {
+        match recv.read(&mut buf[got..]).await.context("read")? {
+            Some(n) if n > 0 => got += n,
+            _ => anyhow::bail!("stream ended after {got} of {} bytes", buf.len()),
+        }
+    }
+    Ok(())
+}
+
+async fn write_msg(send: &mut SendStream, msg: &[u8]) -> Result<()> {
+    send.write_all(msg).await.context("write")?;
+    Ok(())
+}
+
+// Current-thread runtime on purpose, matching the sibling reset test: it keeps the
+// FIN-versus-teardown interleaving deterministic.
+#[tokio::test(flavor = "current_thread")]
+async fn drop_recv_keeps_connection_alive() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let (chain, key) = make_self_signed()?;
+
+    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let server_addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    // Server: open a batch of unidirectional streams, write a header on each, and
+    // hold the send halves open. A bidirectional stream sequences the rest: the
+    // second "ping" only arrives after the client has acked the RESET_STREAM for
+    // every dropped receiver, which is what makes the streams collected — and the
+    // FIN that follows `Done` — deterministic.
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("server accept")?;
+        let session = request.ok().await.context("server session")?;
+
+        let mut sends = Vec::new();
+        for _ in 0..STREAMS {
+            let mut send = session.open_uni().await.context("server open_uni")?;
+            write_msg(&mut send, HEADER)
+                .await
+                .context("server header")?;
+            sends.push(send);
+        }
+
+        let (mut sync_send, mut sync_recv) = session.accept_bi().await.context("server sync")?;
+
+        let mut ping = [0u8; 4];
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 1")?;
+        write_msg(&mut sync_send, b"pong").await?;
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 2")?;
+
+        for mut send in sends {
+            // The peer stopped these streams, so finishing them is a no-op — but it
+            // must never take the session down with it.
+            let _ = send.finish();
+        }
+
+        // Only observable if the session survived every one of those finishes.
+        write_msg(&mut sync_send, b"done").await?;
+
+        anyhow::Ok(session.closed().await)
+    });
+
+    let mut client_settings = Settings::default();
+    client_settings.verify_peer = false;
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", server_addr.port()))?;
+    let client = ClientBuilder::default()
+        .with_settings(client_settings)
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?;
+
+    let session = client
+        .connect(url)
+        .await?
+        .established()
+        .await
+        .context("client handshake")?;
+
+    for i in 0..STREAMS {
+        let mut recv = session.accept_uni().await.context("client accept_uni")?;
+
+        let mut header = [0u8; HEADER.len()];
+        read_exact(&mut recv, &mut header)
+            .await
+            .with_context(|| format!("stream {i} header"))?;
+        assert_eq!(&header, HEADER, "stream {i} header");
+
+        // Everything needed has been read; drop without reading to FIN.
+        drop(recv);
+    }
+
+    let (mut sync_send, mut sync_recv) = session.open_bi().await.context("client sync")?;
+    write_msg(&mut sync_send, b"ping").await?;
+
+    // The reply shares a flight with the server's RESET_STREAMs, so the second ping
+    // carries the ack that collects them.
+    let mut pong = [0u8; 4];
+    read_exact(&mut sync_recv, &mut pong)
+        .await
+        .context("pong")?;
+    write_msg(&mut sync_send, b"ping").await?;
+
+    let mut done = [0u8; 4];
+    read_exact(&mut sync_recv, &mut done)
+        .await
+        .context("session was torn down by an early receive-stream drop")?;
+    assert_eq!(&done, b"done");
+
+    session.close(0, "bye");
+    session.closed().await;
+
+    // The server must have seen the client's close, not a locally generated one.
+    let err = server_task
+        .await
+        .context("server task panicked")?
+        .context("server task errored")?;
+    assert!(
+        matches!(err, web_transport_quiche::SessionError::Remote(0, _)),
+        "unexpected session error: {err}"
+    );
+
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/retired_stream.rs
+++ b/rs/web-transport-quiche/tests/retired_stream.rs
@@ -1,0 +1,213 @@
+//! Regression: writing to a stream the driver has already retired must not wake it.
+//!
+//! Once the peer's STOP_SENDING has quiche collect the send half, `SendState::flush`
+//! marks the stream closed and the driver drops its entry. The application usually
+//! finds out one write later, and that failing write used to notify the driver
+//! anyway, naming a stream it no longer tracks. The driver logged
+//! `wakeup for closed stream` and did nothing else.
+//!
+//! Harmless on its own, but moq-lite-05 publishers keep writing to a TRACK stream
+//! after the subscriber has dropped its receiver, so it fires once per write. That
+//! is the warning flood reported in moq-dev/web-transport#378.
+
+use std::{
+    io,
+    net::{Ipv4Addr, SocketAddr},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tracing_subscriber::fmt::MakeWriter;
+use url::Url;
+use web_transport_quiche::{
+    ClientBuilder, Connection, RecvStream, SendStream, Server, ServerBuilder, Settings, StreamError,
+};
+
+const HEADER: &[u8] = b"TRACK_INFO";
+
+/// Collects the subscriber's output so the test can assert on what was logged.
+#[derive(Clone, Default)]
+struct Captured(Arc<Mutex<Vec<u8>>>);
+
+impl Captured {
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+    }
+}
+
+impl io::Write for Captured {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for Captured {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn start_server() -> Result<(Server, SocketAddr)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let chain = vec![CertificateDer::from(cert.der().to_vec())];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(KeyPair::serialize_der(
+        &signing_key,
+    )));
+
+    let server = ServerBuilder::default()
+        .with_bind::<SocketAddr>((Ipv4Addr::LOCALHOST, 0).into())?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    Ok((server, addr))
+}
+
+async fn connect_client(addr: SocketAddr) -> Result<Connection> {
+    let mut settings = Settings::default();
+    settings.verify_peer = false;
+
+    let url = Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?;
+    let client = ClientBuilder::default()
+        .with_settings(settings)
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?;
+
+    client
+        .connect(url)
+        .await?
+        .established()
+        .await
+        .context("client handshake")
+}
+
+async fn read_exact(recv: &mut RecvStream, buf: &mut [u8]) -> Result<()> {
+    let mut got = 0;
+    while got < buf.len() {
+        match recv.read(&mut buf[got..]).await.context("read")? {
+            Some(n) if n > 0 => got += n,
+            _ => anyhow::bail!("stream ended after {got} of {} bytes", buf.len()),
+        }
+    }
+    Ok(())
+}
+
+async fn write_msg(send: &mut SendStream, msg: &[u8]) -> Result<()> {
+    send.write_all(msg).await.context("write")?;
+    Ok(())
+}
+
+// One test per binary: the capturing subscriber is global, so a second concurrent
+// test would mix its output into the assertion below.
+#[tokio::test(flavor = "current_thread")]
+async fn writing_to_a_retired_stream_does_not_wake_the_driver() -> Result<()> {
+    let captured = Captured::default();
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+            .with_writer(captured.clone())
+            .with_ansi(false)
+            .finish(),
+    )
+    .context("set global subscriber")?;
+
+    let (mut server, addr) = start_server()?;
+
+    let server_task = tokio::spawn(async move {
+        let request = server.accept().await.context("server accept")?;
+        let session = request.ok().await.context("server session")?;
+
+        let mut send = session.open_uni().await.context("server open_uni")?;
+        write_msg(&mut send, HEADER).await.context("header")?;
+
+        // The second ping only lands after the client has acked the RESET_STREAM,
+        // which is what makes the stream collected rather than merely stopped.
+        let (mut sync_send, mut sync_recv) = session.accept_bi().await.context("server sync")?;
+        let mut ping = [0u8; 4];
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 1")?;
+        write_msg(&mut sync_send, b"pong").await?;
+        read_exact(&mut sync_recv, &mut ping)
+            .await
+            .context("ping 2")?;
+
+        // Keep writing until the retired stream reports itself over. This is the
+        // path that used to notify the driver about a stream it had dropped.
+        let chunk = vec![0u8; 64 * 1024];
+        let err: StreamError = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Err(e) = send.write_all(&chunk).await {
+                    return e;
+                }
+            }
+        })
+        .await
+        .context("writing to a collected stream never returned")?;
+
+        write_msg(&mut sync_send, b"done").await?;
+        session.closed().await;
+
+        anyhow::Ok(err)
+    });
+
+    let session = connect_client(addr).await?;
+
+    let mut recv = session.accept_uni().await.context("client accept_uni")?;
+    let mut header = [0u8; HEADER.len()];
+    read_exact(&mut recv, &mut header).await.context("header")?;
+    assert_eq!(&header, HEADER);
+    drop(recv);
+
+    let (mut sync_send, mut sync_recv) = session.open_bi().await.context("client sync")?;
+    write_msg(&mut sync_send, b"ping").await?;
+    let mut pong = [0u8; 4];
+    read_exact(&mut sync_recv, &mut pong)
+        .await
+        .context("pong")?;
+    write_msg(&mut sync_send, b"ping").await?;
+
+    let mut done = [0u8; 4];
+    read_exact(&mut sync_recv, &mut done)
+        .await
+        .context("done")?;
+    assert_eq!(&done, b"done");
+
+    session.close(0, "bye");
+    session.closed().await;
+
+    let err = server_task
+        .await
+        .context("server task panicked")?
+        .context("server task errored")?;
+
+    // Without this the assertion below is vacuous: it proves the write actually
+    // reached a retired stream rather than succeeding all the way through.
+    assert!(
+        matches!(err, StreamError::Closed),
+        "expected the retired stream to end the write, got: {err}"
+    );
+
+    let logged = captured.text();
+    assert!(
+        !logged.contains("wakeup for closed stream"),
+        "driver was woken for a stream it had already retired:\n{logged}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #378.

## Root cause

Dropping a receive stream before reading it to FIN sends STOP_SENDING. quiche resets the sender's half in response, and collects the stream entirely once that RESET_STREAM is acked. The sender's `SendState` is still live at that point, so the FIN it writes next lands on a stream quiche no longer knows about and comes back as `quiche::Error::Done`.

That `Done` was propagated as a `ConnectionError::Quiche`, which `ez::driver` turns into an application close with code 500 and the error's string as the reason — the `code=500 reason=Done` in the issue. One stream's teardown took the whole session, and every other stream on it, down.

The same path can also surface `StreamStopped` from the FIN, and `StreamStopped` / `InvalidStreamState` from the `stream_writable` registration and the `stream_capacity` probe next to it. Those were fatal too.

## The fix

[rs/web-transport-quiche/src/ez/send.rs](rs/web-transport-quiche/src/ez/send.rs): route every quiche error in `SendState::flush` through one `closed_by` helper. `StreamStopped` records the peer's code, `Done` and `InvalidStreamState` mean quiche already collected the stream, and all three close *this* stream. Anything else is still propagated as a connection error.

Because the driver drops the state as soon as it sees `closed`, ending a stream also has to leave something the application can observe: the collected case marks the write side finished and discards the queue and the cached capacity. Otherwise a blocked `flush` is woken once and then parks forever, and later writes are accepted into a queue nothing will ever send. A write after the peer stopped the stream now fails with `StreamError::Closed`.

This also replaces the two hand-rolled `StreamStopped` arms and the `stream_shutdown` allow-list, so there is a single place that decides what "this stream is over" looks like.

### The `wakeup for closed stream` flood

[rs/web-transport-quiche/src/ez/send.rs](rs/web-transport-quiche/src/ez/send.rs): the driver retires a send stream as soon as `SendState` reports itself closed, but `SendStream` notified it on every transition regardless. The write that follows a collected stream returns `Err(Closed)` and still called `driver.send(id)`, naming a stream the driver had just dropped — so it logged `wakeup for closed stream` and did nothing else.

That is the second warning in #378. It fires once per write, and a lite-05 publisher keeps writing to a TRACK stream after the subscriber drops its receiver, which is what turns it into a flood. It is not new here: the `stop` path did the same before this PR, and `gone` just adds another terminal error reaching the same unconditional wake.

Every wake now goes through `SendStream::notify`, which skips the driver once the state is closed. `is_closed()` is the guard rather than "the write succeeded", because it is exactly the condition the driver retires on — so a write that fails with `Reset` while the RESET_STREAM is still pending keeps its wakeup. `reset()` and `set_priority()` were unguarded the same way and are covered by the same helper.

Note for review: `poll_write_buf` binds the poll result to a local first. On edition 2021 the guard from an `if let` scrutinee lives for the whole block, so calling `notify()` inside the original `if let self.state.lock()...` would deadlock on a non-reentrant `std::sync::Mutex`.

## Tests

[rs/web-transport-quiche/tests/drop_recv.rs](rs/web-transport-quiche/tests/drop_recv.rs) reproduces the lite-05 TRACK pattern. A bidirectional stream sequences the choreography so the sender only acts after the client has acked every RESET_STREAM, which is what makes the streams collected and the resulting `Done` deterministic — no sleeps.

- `drop_recv_keeps_connection_alive`: 16 dropped receivers, then the sender finishes all of them. Fails without the fix with `remote CONNECTION_CLOSE: code=500 reason=Done`.
- `write_after_drop_recv_ends_the_stream`: the sender writes to a collected stream instead. Fails without the terminal-state half of the fix by hanging until the test's 10s timeout.

[rs/web-transport-quiche/tests/retired_stream.rs](rs/web-transport-quiche/tests/retired_stream.rs) covers the wakeup fix. It lives in its own binary because the capturing tracing subscriber is global, and it asserts the write actually ends with `StreamError::Closed` before asserting on the log, so it cannot pass vacuously if the scenario stops reproducing.

- `writing_to_a_retired_stream_does_not_wake_the_driver`: fails on f496315 with `driver was woken for a stream it had already retired`.

`cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -D warnings` are clean, the full `web-transport-quiche` suite is green (52 tests), and `retired_stream` and `drop_recv` each passed 25/25 runs.

## Not addressed

`closed stream was writable` (driver.rs). It still does not fire anywhere in the test suite, and the mechanism above does not explain it — that one comes from quiche's writable set rather than from us notifying the driver. Left as a warning.

The intermittent aarch64 SIGSEGV in the tokio-quiche / BoringSSL stack mentioned at the end of the issue. Nothing here touches that path, and it needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 5)
