### PR TITLE
feat(qmux): report RTT and delivery rate from Session::stats()

### DIFF
--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -38,6 +38,10 @@ tracing = "0.1"
 web-transport-proto = { workspace = true }
 web-transport-trait = { workspace = true }
 
+# TCP_INFO / TCP_CONNECTION_INFO for `SocketStats`.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -27,7 +27,7 @@ bytes = "1"
 futures = { version = "0.3", optional = true }
 rustls = { version = "0.23", optional = true }
 thiserror = "2"
-tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
+tokio = { version = "1.27", features = ["sync", "time", "macros", "rt"] }
 
 # Optional: TLS
 tokio-rustls = { version = "0.26", optional = true }
@@ -44,7 +44,7 @@ libc = "0.2"
 
 [dev-dependencies]
 anyhow = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 url = "2"
 web-transport-proto = { workspace = true }
 web-transport-trait = { workspace = true }

--- a/rs/qmux/src/config.rs
+++ b/rs/qmux/src/config.rs
@@ -82,6 +82,16 @@ pub struct Config {
     /// establishment forever. Default: 10s; a zero duration disables the timeout
     /// (wait indefinitely).
     pub handshake_timeout: Duration,
+
+    /// How often to send a `QX_PING` request purely to measure round-trip time,
+    /// reported by [`Session::stats`](web_transport_trait::Session::stats).
+    ///
+    /// Separate from the keep-alive ping, which is activity-gated and so never
+    /// fires while an application is actively sending. A zero duration disables
+    /// RTT measurement, leaving [`Stats::rtt`](web_transport_trait::Stats::rtt)
+    /// as `None`. Only the record-framed drafts (QMux01+) carry `QX_PING`.
+    /// Default: 1s.
+    pub rtt_interval: Duration,
 }
 
 impl Default for Config {
@@ -100,6 +110,7 @@ impl Default for Config {
             // Fill a full record by default; the record layer bounds the size.
             max_datagram_frame_size: DEFAULT_MAX_RECORD_SIZE,
             handshake_timeout: Duration::from_secs(10),
+            rtt_interval: Duration::from_secs(1),
         }
     }
 }

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -39,6 +39,7 @@ mod rtt;
 mod sched;
 mod session;
 mod shared;
+mod socket;
 mod stream;
 
 /// Transport abstraction and the byte-stream [`transport::Stream`] implementation.
@@ -66,6 +67,9 @@ pub use config::{Config, Protocol};
 pub use error::Error;
 pub use proto::Version;
 pub use session::{RecvStream, SendStream, Session};
+#[cfg(unix)]
+pub use socket::TcpStats;
+pub use socket::{SharedSocketStats, SocketStats};
 pub use stream::{StreamDir, StreamId};
 // Transport-specific types are deliberately *not* re-exported here; they stay
 // behind their module path (`transport::Transport`, `ws::Client`, `tls::Client`,

--- a/rs/qmux/src/lib.rs
+++ b/rs/qmux/src/lib.rs
@@ -35,6 +35,7 @@ mod credit;
 mod error;
 mod proto;
 mod protocol;
+mod rtt;
 mod sched;
 mod session;
 mod shared;

--- a/rs/qmux/src/rtt.rs
+++ b/rs/qmux/src/rtt.rs
@@ -91,17 +91,22 @@ impl Rtt {
 
 /// The connection statistics QMux can report.
 ///
-/// QMux runs over a reliable byte stream and has no congestion controller of its
-/// own, so loss, byte, and bandwidth counters belong to the transport underneath
-/// and are left unreported. Round-trip time is measurable at this layer, from
-/// `QX_PING`, and is the one metric filled in.
+/// QMux has no congestion controller of its own, so loss and byte counters belong
+/// to the transport underneath and are left unreported. Round-trip time it can
+/// always measure itself, from `QX_PING`; a send-rate estimate only ever comes
+/// from the transport.
 pub(crate) struct SessionStats {
     pub(crate) rtt: Option<Duration>,
+    pub(crate) estimated_send_rate: Option<u64>,
 }
 
 impl web_transport_trait::Stats for SessionStats {
     fn rtt(&self) -> Option<Duration> {
         self.rtt
+    }
+
+    fn estimated_send_rate(&self) -> Option<u64> {
+        self.estimated_send_rate
     }
 }
 

--- a/rs/qmux/src/rtt.rs
+++ b/rs/qmux/src/rtt.rs
@@ -1,0 +1,184 @@
+//! Round-trip time estimated from QX_PING request/response pairs.
+//!
+//! QMux has no acknowledgement machinery of its own, so the only latency signal
+//! available is the one the draft already defines: `QX_PING` is a request/response
+//! pair whose Sequence Number the responder MUST echo, and it is not reserved for
+//! keep-alive use. The timer task allocates sequences and the writer stamps each
+//! one as it actually reaches the wire; the reader matches responses back.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+/// The most requests we track before dropping the oldest.
+///
+/// A peer that answers retires its requests immediately, so this only grows
+/// against one that keeps the session alive with data while ignoring `QX_PING`.
+/// The dropped entry is a sample we could no longer have matched anyway.
+const MAX_OUTSTANDING: usize = 64;
+
+/// Round-trip time estimated from `QX_PING` exchanges.
+///
+/// Shared by the timer, writer, and reader tasks, and read synchronously by
+/// [`Session::stats`](crate::Session). Empty until the first response arrives.
+#[derive(Default, Debug)]
+pub(crate) struct Rtt {
+    state: Mutex<State>,
+}
+
+#[derive(Default, Debug)]
+struct State {
+    /// Requests written but not yet answered, oldest first. Sequences are
+    /// allocated in increasing order, so this stays sorted by construction.
+    outstanding: VecDeque<(u64, Instant)>,
+    /// Smoothed estimate, `None` until the first sample.
+    smoothed: Option<Duration>,
+}
+
+impl Rtt {
+    /// Record that a `QX_PING` request left the wire, timing it from `at`.
+    ///
+    /// Called by the writer rather than the timer that enqueued it: the control
+    /// lane's queueing delay is not part of the peer's round trip, and counting it
+    /// would inflate every jitter buffer downstream.
+    pub(crate) fn sent(&self, sequence: u64, at: Instant) {
+        let mut state = self.state.lock().unwrap();
+        if state.outstanding.len() >= MAX_OUTSTANDING {
+            state.outstanding.pop_front();
+        }
+        state.outstanding.push_back((sequence, at));
+    }
+
+    /// Match a `QX_PING` response received at `at` and fold in the sample.
+    ///
+    /// A responder MAY coalesce several outstanding requests into a single response
+    /// carrying the largest Sequence Number, so this retires every request up to and
+    /// including `sequence`. The sample is measured against the *newest* of them:
+    /// that is the one the peer had to receive before it could answer, so the older
+    /// entries would each overstate the round trip.
+    pub(crate) fn received(&self, sequence: u64, at: Instant) {
+        let mut state = self.state.lock().unwrap();
+
+        let mut sent_at = None;
+        while let Some(&(seq, when)) = state.outstanding.front() {
+            if seq > sequence {
+                break;
+            }
+            sent_at = Some(when);
+            state.outstanding.pop_front();
+        }
+
+        // Unmatched: a duplicate response, or one whose request we dropped.
+        let Some(sent_at) = sent_at else {
+            return;
+        };
+        let sample = at.saturating_duration_since(sent_at);
+
+        // QUIC's SRTT recurrence (RFC 9002): 7/8 of the estimate plus 1/8 sample.
+        state.smoothed = Some(match state.smoothed {
+            None => sample,
+            Some(prev) => (prev * 7 + sample) / 8,
+        });
+    }
+
+    /// The current smoothed estimate, or `None` before the first response.
+    pub(crate) fn get(&self) -> Option<Duration> {
+        self.state.lock().unwrap().smoothed
+    }
+}
+
+/// The connection statistics QMux can report.
+///
+/// QMux runs over a reliable byte stream and has no congestion controller of its
+/// own, so loss, byte, and bandwidth counters belong to the transport underneath
+/// and are left unreported. Round-trip time is measurable at this layer, from
+/// `QX_PING`, and is the one metric filled in.
+pub(crate) struct SessionStats {
+    pub(crate) rtt: Option<Duration>,
+}
+
+impl web_transport_trait::Stats for SessionStats {
+    fn rtt(&self) -> Option<Duration> {
+        self.rtt
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A matched response yields the elapsed time as the first estimate.
+    #[test]
+    fn single_sample() {
+        let rtt = Rtt::default();
+        assert_eq!(rtt.get(), None);
+
+        let sent = Instant::now();
+        rtt.sent(0, sent);
+        rtt.received(0, sent + Duration::from_millis(40));
+
+        assert_eq!(rtt.get(), Some(Duration::from_millis(40)));
+    }
+
+    /// A response echoing the largest sequence retires every older request and is
+    /// measured against the newest, not the oldest: the peer could not have
+    /// answered before it received that one.
+    #[test]
+    fn coalesced_response_measures_newest() {
+        let rtt = Rtt::default();
+        let base = Instant::now();
+
+        rtt.sent(0, base);
+        rtt.sent(1, base + Duration::from_millis(100));
+        rtt.sent(2, base + Duration::from_millis(200));
+
+        // One response for all three, 20ms after the newest went out.
+        rtt.received(2, base + Duration::from_millis(220));
+        assert_eq!(rtt.get(), Some(Duration::from_millis(20)));
+
+        // All three were retired, so a duplicate matches nothing.
+        rtt.received(2, base + Duration::from_secs(10));
+        assert_eq!(rtt.get(), Some(Duration::from_millis(20)));
+    }
+
+    /// A response for a sequence we never stamped leaves the estimate alone.
+    #[test]
+    fn unmatched_response_ignored() {
+        let rtt = Rtt::default();
+        rtt.received(7, Instant::now());
+        assert_eq!(rtt.get(), None);
+    }
+
+    /// Later samples are smoothed rather than replacing the estimate outright.
+    #[test]
+    fn smooths_subsequent_samples() {
+        let rtt = Rtt::default();
+        let base = Instant::now();
+
+        rtt.sent(0, base);
+        rtt.received(0, base + Duration::from_millis(80));
+        assert_eq!(rtt.get(), Some(Duration::from_millis(80)));
+
+        // 7/8 * 80ms + 1/8 * 160ms = 90ms.
+        rtt.sent(1, base + Duration::from_secs(1));
+        rtt.received(
+            1,
+            base + Duration::from_secs(1) + Duration::from_millis(160),
+        );
+        assert_eq!(rtt.get(), Some(Duration::from_millis(90)));
+    }
+
+    /// A peer that keeps the session busy but never answers a ping must not grow
+    /// the outstanding list without bound.
+    #[test]
+    fn outstanding_is_bounded() {
+        let rtt = Rtt::default();
+        let base = Instant::now();
+        for seq in 0..(MAX_OUTSTANDING as u64 * 4) {
+            rtt.sent(seq, base + Duration::from_millis(seq));
+        }
+        assert_eq!(rtt.state.lock().unwrap().outstanding.len(), MAX_OUTSTANDING);
+    }
+}

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::config::Config;
 use crate::credit::Credit;
+use crate::rtt::{Rtt, SessionStats};
 use crate::sched::PriorityQueue;
 use crate::transport::{Reader, Transport, Writer};
 use crate::{
@@ -137,6 +138,9 @@ pub struct Session {
     // handed to every `SendStream` we open so it can size its frames. Seeded with
     // the draft-01 default until the peer's parameters arrive.
     record_limit: Arc<AtomicU64>,
+
+    // Round-trip time measured from QX_PING exchanges, reported by `stats()`.
+    rtt: Arc<Rtt>,
 
     // Closes the connection when the last `Session` clone drops. Never read.
     _guard: Arc<SessionGuard>,
@@ -275,6 +279,9 @@ struct SessionState<R: Reader> {
     // requests we've sent, bounding the sequence a received *response* may echo.
     last_ping_recv: Option<u64>,
     pings_sent: Arc<AtomicU64>,
+
+    // Matches QX_PING responses back to the requests the writer stamped.
+    rtt: Arc<Rtt>,
 }
 
 /// Pick the next outbound frame in strict priority order: control (lossless,
@@ -373,6 +380,10 @@ struct WriterState<W: Writer> {
     // which our last send landed — published for keep-alive and idle scheduling.
     base: tokio::time::Instant,
     last_send_at: Arc<AtomicU64>,
+
+    // Stamped when a QX_PING request reaches the wire. The timer allocates the
+    // sequence, but only the writer knows when it actually left.
+    rtt: Arc<Rtt>,
 }
 
 /// Outcome of a teardown-aware write (see [`WriterState::transmit_or_teardown`]).
@@ -485,6 +496,12 @@ impl<W: Writer> WriterState<W> {
             Frame::Stream(stream) if !stream.fin => Some((stream.id, stream.data.len() as u64)),
             _ => None,
         };
+        // Time the round trip from here, not from where the timer enqueued it: the
+        // control lane's queueing delay is ours, not the peer's.
+        let transmitted_ping = match &frame {
+            Frame::Ping(ping) if !ping.response => Some(ping.sequence),
+            _ => None,
+        };
 
         match &mut frame {
             Frame::ResetStream(reset) => {
@@ -527,11 +544,13 @@ impl<W: Writer> WriterState<W> {
                 send.sent_offset += len;
             }
         }
+        let now = tokio::time::Instant::now();
+        if let Some(sequence) = transmitted_ping {
+            self.rtt.sent(sequence, now);
+        }
         // Publish send progress for the timer's keep-alive and idle scheduling.
-        self.last_send_at.store(
-            millis_since(self.base, tokio::time::Instant::now()),
-            Ordering::Release,
-        );
+        self.last_send_at
+            .store(millis_since(self.base, now), Ordering::Release);
         Ok(())
     }
 }
@@ -582,6 +601,7 @@ mod writer_final_size_tests {
             closed: watch::Sender::new(None),
             base: tokio::time::Instant::now(),
             last_send_at: Arc::new(AtomicU64::new(0)),
+            rtt: Arc::new(Rtt::default()),
         };
 
         writer
@@ -695,6 +715,9 @@ struct TimerState {
     // Published for the reader task, which rejects (draft-02) a QX_PING response
     // echoing a sequence we never sent.
     pings_sent: Arc<AtomicU64>,
+
+    // Cadence for RTT-measuring pings, or zero to send only keep-alives.
+    rtt_interval: std::time::Duration,
 }
 
 /// Decides which of the reader's and writer's clocks currently count as "activity"
@@ -775,13 +798,17 @@ impl TimerState {
         // establishment was signalled. 0 = disabled (both sides opted out), leaving
         // the timer with nothing to do.
         let idle_ms = self.idle_timeout_ms.load(Ordering::Acquire);
-        if idle_ms == 0 {
-            return;
-        }
-        let idle = std::time::Duration::from_millis(idle_ms);
+        let idle = (idle_ms != 0).then(|| std::time::Duration::from_millis(idle_ms));
         // Keep-alive cadence: a third of the idle window, clamped so a tiny timeout
         // doesn't yield a zero-duration interval.
-        let ping_every = std::time::Duration::from_millis((idle_ms / 3).max(1));
+        let keepalive_every = idle.map(|_| std::time::Duration::from_millis((idle_ms / 3).max(1)));
+        // RTT cadence, independent of the idle timeout: a peer may disable the
+        // timeout and still want latency reported.
+        let rtt_every =
+            (self.rtt_interval != std::time::Duration::ZERO).then_some(self.rtt_interval);
+        if idle.is_none() && rtt_every.is_none() {
+            return;
+        }
 
         // When we began deferring the idle close for backpressure, or `None` when
         // not deferring. Bounds the deferral to one extra idle window.
@@ -794,18 +821,31 @@ impl TimerState {
 
         loop {
             let last_activity = instant_at(self.base, self.observe_activity(&mut activity));
+            // Keep-alive is activity-gated: only silence on send makes one due.
             let ping_ref = instant_at(
                 self.base,
                 self.last_send_at.load(Ordering::Acquire).max(last_ping_ms),
             );
+            // RTT probing is not gated that way. An application that is actively
+            // sending is exactly when latency matters, and it is also when the
+            // keep-alive never fires, so measure off the last ping alone.
+            let rtt_ref = instant_at(self.base, last_ping_ms);
 
             // While deferring, wait out the remaining grace rather than the (stale)
             // idle deadline, so we don't busy-spin on an already-elapsed instant.
-            let idle_wake = match deferred_since {
-                Some(since) => since + idle,
-                None => last_activity + idle,
-            };
-            let wake = idle_wake.min(ping_ref + ping_every);
+            let deadlines = [
+                idle.map(|idle| match deferred_since {
+                    Some(since) => since + idle,
+                    None => last_activity + idle,
+                }),
+                keepalive_every.map(|every| ping_ref + every),
+                rtt_every.map(|every| rtt_ref + every),
+            ];
+            let wake = deadlines
+                .into_iter()
+                .flatten()
+                .min()
+                .expect("at least one deadline is armed");
 
             tokio::select! {
                 biased;
@@ -819,7 +859,9 @@ impl TimerState {
             // Skip the actual enqueue while the writer is wedged — a ping can't get
             // out anyway, and we mustn't pile them behind a stalled socket — but
             // still advance the marker so we don't spin.
-            if now >= ping_ref + ping_every {
+            let ping_due = keepalive_every.is_some_and(|every| now >= ping_ref + every)
+                || rtt_every.is_some_and(|every| now >= rtt_ref + every);
+            if ping_due {
                 if !self.writer_backpressured.load(Ordering::Acquire) {
                     let ping = Frame::Ping(crate::Ping {
                         sequence: next_ping_seq,
@@ -839,6 +881,9 @@ impl TimerState {
             // Idle close: due once a full window has passed with no qualifying
             // activity. Re-read the clocks; the ping we may have just enqueued does
             // not itself buy another window (see [`IdleActivity`]).
+            let Some(idle) = idle else {
+                continue; // RTT probing only; nothing to close on
+            };
             let last_activity = instant_at(self.base, self.observe_activity(&mut activity));
             if now < last_activity + idle {
                 deferred_since = None; // qualifying activity progressed — not idle
@@ -1315,7 +1360,7 @@ impl<R: Reader> SessionState<R> {
             | Frame::StreamDataBlocked { .. }
             | Frame::StreamsBlockedBidi(_)
             | Frame::StreamsBlockedUni(_) => {}
-            // QX_PING: respond to requests, ignore responses.
+            // QX_PING: respond to requests, measure the round trip from responses.
             Frame::Ping(ping) => {
                 // Draft-02 tightens the sequence-number rules.
                 if self.config.version == Version::QMux02 {
@@ -1336,7 +1381,10 @@ impl<R: Reader> SessionState<R> {
                         self.last_ping_recv = Some(ping.sequence);
                     }
                 }
-                if !ping.response {
+                if ping.response {
+                    self.rtt
+                        .received(ping.sequence, tokio::time::Instant::now());
+                } else {
                     let response = Frame::Ping(crate::Ping {
                         sequence: ping.sequence,
                         response: true,
@@ -1597,6 +1645,9 @@ impl Session {
         // Count of keep-alive pings the timer has sent; the reader consults it to
         // validate draft-02 QX_PING responses. Shared between the two tasks.
         let pings_sent = Arc::new(AtomicU64::new(0));
+        // Round-trip samples from those pings: the writer stamps each request as it
+        // lands, the reader matches the responses, `stats()` reads the estimate.
+        let rtt = Arc::new(Rtt::default());
 
         // Last-activity clocks for the timer task. `base` is the shared origin; the
         // reader/writer publish their progress as millis since it (see
@@ -1636,6 +1687,7 @@ impl Session {
             closed: closed.clone(),
             base,
             last_send_at: last_send_at.clone(),
+            rtt: rtt.clone(),
         };
         tokio::spawn(async move { writer.run().await });
 
@@ -1712,6 +1764,7 @@ impl Session {
             idle_timeout_ms: idle_timeout_ms.clone(),
             last_ping_recv: None,
             pings_sent: pings_sent.clone(),
+            rtt: rtt.clone(),
         };
 
         // Timer task: owns the record-framed-draft idle timeout + keep-alive ping,
@@ -1730,6 +1783,7 @@ impl Session {
                 closed: closed.clone(),
                 established: established_rx.clone(),
                 pings_sent: pings_sent.clone(),
+                rtt_interval: config.rtt_interval,
             };
             tokio::spawn(timer.run());
         }
@@ -1799,6 +1853,7 @@ impl Session {
             datagram_max_size,
             record_limit,
             outbound_datagram: outbound_datagram_tx,
+            rtt,
             _guard: guard,
         }
     }
@@ -1808,6 +1863,12 @@ impl generic::Session for Session {
     type SendStream = SendStream;
     type RecvStream = RecvStream;
     type Error = Error;
+
+    fn stats(&self) -> impl generic::Stats {
+        SessionStats {
+            rtt: self.rtt.get(),
+        }
+    }
 
     async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
         self.accept_uni.recv().await.ok_or(Error::Closed)
@@ -2569,6 +2630,7 @@ mod timer_tests {
             closed: closed.clone(),
             established,
             pings_sent: Arc::new(AtomicU64::new(0)),
+            rtt_interval: std::time::Duration::ZERO,
         };
         tokio::spawn(timer.run());
 

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -775,6 +775,18 @@ impl IdleActivity {
     }
 }
 
+/// The RTT probe cadence for a configured interval: `None` when disabled.
+///
+/// Clamped to a whole millisecond because the timer stores its last-ping instant
+/// as millis since `base` (see [`millis_since`]). A shorter interval would put the
+/// reconstructed deadline at or before `now` on every wake-up, so `sleep_until`
+/// would return immediately and the loop would spin, flooding the control lane
+/// with pings. The keep-alive cadence is clamped for the same reason.
+fn rtt_cadence(interval: std::time::Duration) -> Option<std::time::Duration> {
+    (interval != std::time::Duration::ZERO)
+        .then(|| interval.max(std::time::Duration::from_millis(1)))
+}
+
 impl TimerState {
     /// Read both clocks and fold them into `activity`, returning the millis of the
     /// newest activity that counts toward the idle deadline.
@@ -810,8 +822,7 @@ impl TimerState {
         let keepalive_every = idle.map(|_| std::time::Duration::from_millis((idle_ms / 3).max(1)));
         // RTT cadence, independent of the idle timeout: a peer may disable the
         // timeout and still want latency reported.
-        let rtt_every =
-            (self.rtt_interval != std::time::Duration::ZERO).then_some(self.rtt_interval);
+        let rtt_every = rtt_cadence(self.rtt_interval);
         if idle.is_none() && rtt_every.is_none() {
             return;
         }
@@ -2607,8 +2618,31 @@ mod timer_tests {
 
     use tokio::sync::{mpsc, watch};
 
-    use super::TimerState;
+    use super::{rtt_cadence, TimerState};
     use crate::Error;
+
+    /// The probe cadence must never be sub-millisecond.
+    ///
+    /// The timer reconstructs its last-ping instant from a millisecond counter, so
+    /// a shorter interval leaves the deadline at or before `now` on every wake-up:
+    /// the loop stops sleeping and floods the control lane with pings. The
+    /// keep-alive cadence is clamped for exactly this reason.
+    #[test]
+    fn rtt_cadence_is_clamped_to_a_whole_milli() {
+        assert_eq!(rtt_cadence(Duration::ZERO), None, "zero disables probing");
+        for tiny in [Duration::from_nanos(1), Duration::from_micros(500)] {
+            assert_eq!(
+                rtt_cadence(tiny),
+                Some(Duration::from_millis(1)),
+                "{tiny:?} must not yield a sub-milli cadence"
+            );
+        }
+        assert_eq!(
+            rtt_cadence(Duration::from_secs(1)),
+            Some(Duration::from_secs(1)),
+            "a sane interval passes through"
+        );
+    }
 
     /// Handles for driving a `TimerState` in isolation, without a real transport.
     struct Harness {

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -139,8 +139,14 @@ pub struct Session {
     // the draft-01 default until the peer's parameters arrive.
     record_limit: Arc<AtomicU64>,
 
-    // Round-trip time measured from QX_PING exchanges, reported by `stats()`.
+    // Round-trip time measured from QX_PING exchanges, reported by `stats()` when
+    // the transport underneath has nothing better.
     rtt: Arc<Rtt>,
+
+    // The transport's own view of the connection, when it has one. Preferred over
+    // `rtt`: the kernel's estimate needs no round trip of ours, so it is available
+    // from the first moment rather than one probe interval in.
+    socket_stats: Option<crate::SharedSocketStats>,
 
     // Closes the connection when the last `Session` clone drops. Never read.
     _guard: Arc<SessionGuard>,
@@ -1674,6 +1680,9 @@ impl Session {
         // backpressure must never stall reads. The writer is the sole producer on
         // the wire, pulling the outbound queues in priority order and sharing the
         // stream maps + scalars above with the reader (no message-passing handoff).
+        // Read before the split: the halves go to separate tasks, and the stats
+        // source belongs to neither.
+        let socket_stats = transport.socket_stats();
         let (writer_half, reader_half) = transport.split();
         let mut writer = WriterState {
             writer: writer_half,
@@ -1854,6 +1863,7 @@ impl Session {
             record_limit,
             outbound_datagram: outbound_datagram_tx,
             rtt,
+            socket_stats,
             _guard: guard,
         }
     }
@@ -1865,8 +1875,12 @@ impl generic::Session for Session {
     type Error = Error;
 
     fn stats(&self) -> impl generic::Stats {
+        let socket = self.socket_stats.as_ref();
         SessionStats {
-            rtt: self.rtt.get(),
+            // Fall back to our own QX_PING measurement only when the transport
+            // can't answer; a TCP socket already knows before we've pinged once.
+            rtt: socket.and_then(|s| s.rtt()).or_else(|| self.rtt.get()),
+            estimated_send_rate: socket.and_then(|s| s.estimated_send_rate()),
         }
     }
 

--- a/rs/qmux/src/socket.rs
+++ b/rs/qmux/src/socket.rs
@@ -1,0 +1,303 @@
+//! Statistics read from the connection underneath QMux.
+//!
+//! QMux runs over a reliable byte stream and has no congestion controller of its
+//! own, but the transport it sits on usually does. Where that transport is TCP the
+//! kernel already tracks a smoothed RTT and (on Linux) a delivery-rate estimate,
+//! so the figures are available immediately and cost no extra traffic. This is
+//! strictly better than QMux's own [`QX_PING`](crate::Config::rtt_interval)
+//! measurement, which needs a round trip before it can report anything.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Live statistics for the connection underneath a QMux session.
+///
+/// Implementations read through to the socket on each call rather than caching, so
+/// a caller polling this sees the transport's current view. Every metric is
+/// optional: `None` means this transport doesn't track it.
+pub trait SocketStats: Send + Sync + 'static {
+    /// Smoothed round-trip time, if the transport tracks one.
+    fn rtt(&self) -> Option<Duration> {
+        None
+    }
+
+    /// Estimated delivery rate in **bits per second**, if the transport tracks one.
+    fn estimated_send_rate(&self) -> Option<u64> {
+        None
+    }
+}
+
+/// A shared handle to a transport's statistics.
+pub type SharedSocketStats = Arc<dyn SocketStats>;
+
+#[cfg(unix)]
+pub use unix::TcpStats;
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use std::io;
+    use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+
+    /// Kernel TCP statistics for a socket, via `TCP_INFO` (Linux) or
+    /// `TCP_CONNECTION_INFO` (macOS).
+    ///
+    /// Holds its own duplicate of the file descriptor, so it stays readable for as
+    /// long as the session needs it no matter what the transport does with the
+    /// original. Construct it from the accepted socket and hand it to the transport
+    /// with `with_socket_stats`.
+    ///
+    /// Reports nothing for a non-TCP socket (a Unix socket, say): the `getsockopt`
+    /// simply fails and every metric reads `None`.
+    #[derive(Debug)]
+    pub struct TcpStats {
+        fd: OwnedFd,
+    }
+
+    impl TcpStats {
+        /// Duplicate `socket`'s descriptor and read statistics from the copy.
+        pub fn new<S: AsFd>(socket: &S) -> io::Result<Self> {
+            Ok(Self {
+                fd: socket.as_fd().try_clone_to_owned()?,
+            })
+        }
+
+        /// Take ownership of an already-duplicated descriptor.
+        ///
+        /// Use this when the socket itself has been moved somewhere unreachable (a
+        /// type-erased HTTP upgrade, for instance) and only the descriptor was kept.
+        pub fn from_fd(fd: OwnedFd) -> Self {
+            Self { fd }
+        }
+
+        fn borrow(&self) -> BorrowedFd<'_> {
+            self.fd.as_fd()
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    mod sys {
+        use super::*;
+
+        /// `struct tcp_info` from `linux/tcp.h`.
+        ///
+        /// Mirrored field-for-field rather than hand-computing offsets, so `repr(C)`
+        /// alignment places each member where the kernel put it. The kernel reports
+        /// how much it actually filled in, which is less than this on older
+        /// releases, so every read checks its field against that length.
+        #[repr(C)]
+        #[derive(Default, Clone, Copy)]
+        pub struct TcpInfo {
+            pub state: u8,
+            pub ca_state: u8,
+            pub retransmits: u8,
+            pub probes: u8,
+            pub backoff: u8,
+            pub options: u8,
+            pub wscale: u8,
+            pub app_limited: u8,
+
+            pub rto: u32,
+            pub ato: u32,
+            pub snd_mss: u32,
+            pub rcv_mss: u32,
+
+            pub unacked: u32,
+            pub sacked: u32,
+            pub lost: u32,
+            pub retrans: u32,
+            pub fackets: u32,
+
+            pub last_data_sent: u32,
+            pub last_ack_sent: u32,
+            pub last_data_recv: u32,
+            pub last_ack_recv: u32,
+
+            pub pmtu: u32,
+            pub rcv_ssthresh: u32,
+            /// Smoothed RTT in microseconds.
+            pub rtt: u32,
+            pub rttvar: u32,
+            pub snd_ssthresh: u32,
+            pub snd_cwnd: u32,
+            pub advmss: u32,
+            pub reordering: u32,
+
+            pub rcv_rtt: u32,
+            pub rcv_space: u32,
+            pub total_retrans: u32,
+
+            pub pacing_rate: u64,
+            pub max_pacing_rate: u64,
+            pub bytes_acked: u64,
+            pub bytes_received: u64,
+            pub segs_out: u32,
+            pub segs_in: u32,
+            pub notsent_bytes: u32,
+            pub min_rtt: u32,
+            pub data_segs_out: u32,
+            pub data_segs_in: u32,
+            /// Delivery-rate estimate in bytes per second (Linux 4.9+).
+            pub delivery_rate: u64,
+        }
+
+        const IPPROTO_TCP: libc::c_int = 6;
+        const TCP_INFO: libc::c_int = 11;
+
+        /// Read `tcp_info`, returning it alongside the number of bytes the kernel
+        /// filled in. `None` if the socket isn't TCP.
+        pub fn tcp_info(fd: BorrowedFd<'_>) -> Option<(TcpInfo, usize)> {
+            let mut info = TcpInfo::default();
+            let mut len = std::mem::size_of::<TcpInfo>() as libc::socklen_t;
+
+            // SAFETY: `info` is a live, correctly sized allocation and `len` says how
+            // large it is; the kernel writes at most that much and updates `len` to
+            // what it wrote.
+            let rc = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    IPPROTO_TCP,
+                    TCP_INFO,
+                    (&mut info as *mut TcpInfo).cast(),
+                    &mut len,
+                )
+            };
+
+            (rc == 0).then_some((info, len as usize))
+        }
+
+        /// Whether the kernel filled in the field at `offset` of size `size`.
+        pub fn has_field(len: usize, offset: usize, size: usize) -> bool {
+            len >= offset + size
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    mod sys {
+        use super::*;
+
+        /// `struct tcp_connection_info` from macOS `netinet/tcp.h`.
+        #[repr(C)]
+        #[derive(Default, Clone, Copy)]
+        pub struct TcpInfo {
+            pub state: u8,
+            pub snd_wscale: u8,
+            pub rcv_wscale: u8,
+            _pad1: u8,
+            pub options: u32,
+            pub flags: u32,
+            pub rto: u32,
+            pub maxseg: u32,
+            pub snd_ssthresh: u32,
+            pub snd_cwnd: u32,
+            pub snd_wnd: u32,
+            pub snd_sbbytes: u32,
+            pub rcv_wnd: u32,
+            /// Most recent RTT sample, in milliseconds.
+            pub rttcur: u32,
+            /// Smoothed RTT in milliseconds.
+            pub srtt: u32,
+            pub rttvar: u32,
+        }
+
+        const IPPROTO_TCP: libc::c_int = 6;
+        const TCP_CONNECTION_INFO: libc::c_int = 0x106;
+
+        pub fn tcp_info(fd: BorrowedFd<'_>) -> Option<(TcpInfo, usize)> {
+            let mut info = TcpInfo::default();
+            let mut len = std::mem::size_of::<TcpInfo>() as libc::socklen_t;
+
+            // SAFETY: as for the Linux arm above.
+            let rc = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    IPPROTO_TCP,
+                    TCP_CONNECTION_INFO,
+                    (&mut info as *mut TcpInfo).cast(),
+                    &mut len,
+                )
+            };
+
+            (rc == 0).then_some((info, len as usize))
+        }
+
+        pub fn has_field(len: usize, offset: usize, size: usize) -> bool {
+            len >= offset + size
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    impl SocketStats for TcpStats {
+        fn rtt(&self) -> Option<Duration> {
+            let (info, len) = sys::tcp_info(self.borrow())?;
+
+            // A successful `getsockopt` on a connected socket is a measurement, so
+            // report it even at zero. macOS counts in whole milliseconds, and a
+            // loopback round trip genuinely rounds to zero there.
+            #[cfg(target_os = "linux")]
+            {
+                let offset = std::mem::offset_of!(sys::TcpInfo, rtt);
+                sys::has_field(len, offset, size_of::<u32>())
+                    .then(|| Duration::from_micros(info.rtt as u64))
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                let offset = std::mem::offset_of!(sys::TcpInfo, srtt);
+                sys::has_field(len, offset, size_of::<u32>())
+                    .then(|| Duration::from_millis(info.srtt as u64))
+            }
+        }
+
+        fn estimated_send_rate(&self) -> Option<u64> {
+            // Only Linux measures a delivery rate. macOS exposes a congestion window
+            // but no rate, and cwnd/rtt is a poor stand-in, so report nothing there
+            // rather than a figure callers would mistake for a measurement.
+            #[cfg(target_os = "linux")]
+            {
+                let (info, len) = sys::tcp_info(self.borrow())?;
+                let offset = std::mem::offset_of!(sys::TcpInfo, delivery_rate);
+                if !sys::has_field(len, offset, size_of::<u64>()) || info.delivery_rate == 0 {
+                    return None;
+                }
+                // The kernel reports bytes per second; the trait wants bits.
+                Some(info.delivery_rate.saturating_mul(8))
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                None
+            }
+        }
+    }
+
+    /// Platforms without a readable TCP info struct report nothing.
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    impl SocketStats for TcpStats {}
+
+    /// Pin the field offsets against the kernel's struct.
+    ///
+    /// The struct is mirrored field-for-field so `repr(C)` computes the offsets,
+    /// which means a typo in the middle silently shifts everything after it and we
+    /// would read a plausible-looking wrong number rather than fail.
+    #[cfg(test)]
+    mod tests {
+        /// Offsets from `linux/tcp.h`.
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn linux_tcp_info_layout() {
+            assert_eq!(std::mem::offset_of!(super::sys::TcpInfo, rtt), 68);
+            assert_eq!(
+                std::mem::offset_of!(super::sys::TcpInfo, delivery_rate),
+                160
+            );
+        }
+
+        /// Offsets from macOS `netinet/tcp.h`.
+        #[cfg(target_os = "macos")]
+        #[test]
+        fn macos_tcp_connection_info_layout() {
+            assert_eq!(std::mem::offset_of!(super::sys::TcpInfo, srtt), 44);
+        }
+    }
+}

--- a/rs/qmux/src/tcp.rs
+++ b/rs/qmux/src/tcp.rs
@@ -85,8 +85,19 @@ async fn finish(
     config: crate::Config,
     is_server: bool,
 ) -> Result<Session, Error> {
+    // The kernel already tracks this socket's RTT (and, on Linux, its delivery
+    // rate) from the TCP handshake, so the session can report both immediately
+    // rather than waiting on its own QX_PING round trip. A socket we can't read
+    // stats from just leaves them unreported.
+    #[cfg(unix)]
+    let socket_stats = crate::TcpStats::new(&stream)
+        .ok()
+        .map(|s| std::sync::Arc::new(s) as crate::SharedSocketStats);
+    #[cfg(not(unix))]
+    let socket_stats = None;
+
     // `build_stream_session` awaits the peer's transport parameters before
     // returning, so `protocol()` is resolved on the session we hand back
     // (bounded by the config's handshake timeout).
-    build_stream_session(stream, config, is_server).await
+    build_stream_session(stream, config, is_server, socket_stats).await
 }

--- a/rs/qmux/src/tls.rs
+++ b/rs/qmux/src/tls.rs
@@ -69,6 +69,9 @@ impl Client {
         server_name: &str,
     ) -> Result<Session, Error> {
         let stream = TcpStream::connect(&addr).await?;
+        // Read the socket's stats handle before TLS takes ownership; the kernel's
+        // view of the TCP connection is the same either side of the encryption.
+        let socket_stats = socket_stats(&stream);
 
         let server_name = rustls::pki_types::ServerName::try_from(server_name)
             .map_err(|_| Error::InvalidServerName)?
@@ -105,7 +108,10 @@ impl Client {
         }
 
         let session_config = Config::negotiated(version, protocol);
-        let transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        let mut transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        if let Some(stats) = socket_stats {
+            transport = transport.with_socket_stats(stats);
+        }
         // `connect` awaits the peer's transport parameters so `protocol()` is resolved.
         Session::connect(transport, session_config).await
     }
@@ -137,6 +143,7 @@ impl Server {
     /// connection with `tokio::spawn` so a slow or non-cooperative peer can't
     /// stall your `listener.accept()` loop.
     pub async fn accept(&self, stream: TcpStream) -> Result<Session, Error> {
+        let socket_stats = socket_stats(&stream);
         let acceptor = TlsAcceptor::from(self.config.clone());
         let tls_stream = acceptor.accept(stream).await?;
 
@@ -148,8 +155,26 @@ impl Server {
         tracing::debug!(?version, ?protocol, "parsed ALPN");
 
         let session_config = Config::negotiated(version, protocol);
-        let transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        let mut transport = Stream::new(tls_stream, version, session_config.max_record_size);
+        if let Some(stats) = socket_stats {
+            transport = transport.with_socket_stats(stats);
+        }
         // `accept` awaits the peer's transport parameters so `protocol()` is resolved.
         Session::accept(transport, session_config).await
+    }
+}
+
+/// The kernel's view of `stream`, when this platform exposes one.
+fn socket_stats(stream: &TcpStream) -> Option<crate::SharedSocketStats> {
+    #[cfg(unix)]
+    {
+        crate::TcpStats::new(stream)
+            .ok()
+            .map(|s| std::sync::Arc::new(s) as crate::SharedSocketStats)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = stream;
+        None
     }
 }

--- a/rs/qmux/src/transport.rs
+++ b/rs/qmux/src/transport.rs
@@ -26,6 +26,15 @@ pub trait Transport: Send + 'static {
 
     /// Split into send and receive halves.
     fn split(self) -> (Self::Writer, Self::Reader);
+
+    /// Statistics for the connection underneath, if it exposes any.
+    ///
+    /// Read before the split, since the halves are handed to separate tasks. A
+    /// transport that returns `None` leaves the session reporting only what it can
+    /// measure itself, i.e. the `QX_PING` round trip.
+    fn socket_stats(&self) -> Option<crate::SharedSocketStats> {
+        None
+    }
 }
 
 /// The send half of a [`Transport`].
@@ -100,6 +109,7 @@ mod stream_transport {
     pub struct Stream<T> {
         writer: StreamWriter<T>,
         reader: StreamReader,
+        socket_stats: Option<crate::SharedSocketStats>,
     }
 
     /// The send half of a byte-stream [`Stream`].
@@ -137,7 +147,18 @@ mod stream_transport {
                     version,
                 },
                 reader: StreamReader { rx, reader_task },
+                socket_stats: None,
             }
+        }
+
+        /// Report statistics for the connection underneath this stream.
+        ///
+        /// `Stream` is generic over the byte stream, so it can't discover the socket
+        /// on its own; the builder that knows the concrete type attaches it. See
+        /// [`TcpStats`](crate::TcpStats).
+        pub fn with_socket_stats(mut self, stats: crate::SharedSocketStats) -> Self {
+            self.socket_stats = Some(stats);
+            self
         }
     }
 
@@ -147,6 +168,10 @@ mod stream_transport {
 
         fn split(self) -> (StreamWriter<T>, StreamReader) {
             (self.writer, self.reader)
+        }
+
+        fn socket_stats(&self) -> Option<crate::SharedSocketStats> {
+            self.socket_stats.clone()
         }
     }
 
@@ -591,13 +616,17 @@ mod stream_session {
         stream: T,
         config: Config,
         is_server: bool,
+        socket_stats: Option<crate::SharedSocketStats>,
     ) -> Result<Session, Error> {
         if let Protocol::Negotiate(protocols) = &config.protocol {
             for protocol in protocols {
                 validate_protocol(protocol)?;
             }
         }
-        let transport = Stream::new(stream, config.version, config.max_record_size);
+        let mut transport = Stream::new(stream, config.version, config.max_record_size);
+        if let Some(stats) = socket_stats {
+            transport = transport.with_socket_stats(stats);
+        }
         if is_server {
             Session::accept(transport, config).await
         } else {
@@ -657,6 +686,7 @@ mod ws_transport {
         keep_alive: Option<KeepAlive>,
         /// Largest inbound message we accept, or `None` when nothing bounds it.
         recv_limit: Option<usize>,
+        socket_stats: Option<crate::SharedSocketStats>,
     }
 
     impl<T> WsTransport<T> {
@@ -676,11 +706,17 @@ mod ws_transport {
                 ws,
                 keep_alive: None,
                 recv_limit,
+                socket_stats: None,
             }
         }
 
         pub fn with_keep_alive(mut self, keep_alive: KeepAlive) -> Self {
             self.keep_alive = Some(keep_alive);
+            self
+        }
+
+        pub fn with_socket_stats(mut self, stats: crate::SharedSocketStats) -> Self {
+            self.socket_stats = Some(stats);
             self
         }
     }
@@ -757,6 +793,10 @@ mod ws_transport {
     impl<T: WsStream> Transport for WsTransport<T> {
         type Writer = WsWriter<T>;
         type Reader = WsReader;
+
+        fn socket_stats(&self) -> Option<crate::SharedSocketStats> {
+            self.socket_stats.clone()
+        }
 
         fn split(self) -> (WsWriter<T>, WsReader) {
             use futures::StreamExt;

--- a/rs/qmux/src/uds.rs
+++ b/rs/qmux/src/uds.rs
@@ -81,5 +81,7 @@ async fn finish(
     // `build_stream_session` awaits the peer's transport parameters before
     // returning, so `protocol()` is resolved on the session we hand back
     // (bounded by the config's handshake timeout).
-    build_stream_session(stream, config, is_server).await
+    // A Unix socket has no TCP_INFO to read; loopback latency is negligible
+    // anyway, and QX_PING still covers the round trip.
+    build_stream_session(stream, config, is_server, None).await
 }

--- a/rs/qmux/src/ws.rs
+++ b/rs/qmux/src/ws.rs
@@ -67,6 +67,7 @@ pub struct Upgraded<T> {
     ws: T,
     alpn: Option<String>,
     keep_alive: Option<KeepAlive>,
+    socket_stats: Option<crate::SharedSocketStats>,
 }
 
 impl<T> Upgraded<T>
@@ -82,6 +83,7 @@ where
             ws,
             alpn: None,
             keep_alive: None,
+            socket_stats: None,
         }
     }
 
@@ -94,6 +96,18 @@ where
     /// Drive a keep-alive Ping/timeout on the WebSocket.
     pub fn with_keep_alive(mut self, keep_alive: KeepAlive) -> Self {
         self.keep_alive = Some(keep_alive);
+        self
+    }
+
+    /// Report statistics for the socket underneath the upgrade.
+    ///
+    /// An HTTP server hands over a type-erased upgraded stream, so QMux can't find
+    /// the socket itself. A server that kept a handle on the accepted connection
+    /// can attach it here and get the kernel's RTT (and, on Linux, delivery rate)
+    /// instead of only QMux's own `QX_PING` measurement. See
+    /// [`TcpStats`](crate::TcpStats).
+    pub fn with_socket_stats(mut self, stats: crate::SharedSocketStats) -> Self {
+        self.socket_stats = Some(stats);
         self
     }
 
@@ -120,7 +134,10 @@ where
     }
 
     fn into_transport(self, version: Version, max_record_size: u64) -> WsTransport<T> {
-        let transport = WsTransport::new(self.ws, version, max_record_size);
+        let mut transport = WsTransport::new(self.ws, version, max_record_size);
+        if let Some(stats) = self.socket_stats {
+            transport = transport.with_socket_stats(stats);
+        }
         match self.keep_alive {
             Some(ka) => transport.with_keep_alive(ka),
             None => transport,

--- a/rs/qmux/tests/rtt.rs
+++ b/rs/qmux/tests/rtt.rs
@@ -1,0 +1,102 @@
+//! Round-trip time reported from QX_PING exchanges, over the TCP transport.
+
+#![cfg(feature = "tcp")]
+
+use std::time::Duration;
+
+use qmux::{transport::Stream, Config, Session, Version};
+use tokio::net::{TcpListener, TcpStream};
+use web_transport_trait::{SendStream as _, Session as _, Stats as _};
+
+/// Pair a client and server over TCP loopback with the given configs, awaiting
+/// establishment on both ends.
+async fn pair(client_cfg: Config, server_cfg: Config) -> (Session, Session) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let transport = Stream::new(sock, server_cfg.version, server_cfg.max_record_size);
+        Session::accept(transport, server_cfg).await.unwrap()
+    });
+
+    let sock = TcpStream::connect(addr).await.unwrap();
+    let transport = Stream::new(sock, client_cfg.version, client_cfg.max_record_size);
+    let client = Session::connect(transport, client_cfg).await.unwrap();
+
+    (client, server.await.unwrap())
+}
+
+/// A config that probes often enough to keep the test quick.
+fn probing(version: Version) -> Config {
+    let mut cfg = Config::new(version);
+    cfg.rtt_interval = Duration::from_millis(20);
+    cfg
+}
+
+/// Poll `session` until it reports an RTT, or give up.
+async fn wait_for_rtt(session: &Session) -> Option<Duration> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(rtt) = session.stats().rtt() {
+                return rtt;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .ok()
+}
+
+/// Both ends measure an RTT from the QX_PING exchange, with no application
+/// traffic at all. Before RTT tracking, `stats()` reported `None` forever.
+#[tokio::test]
+async fn both_ends_measure_rtt() {
+    let (client, server) = pair(probing(Version::QMux02), probing(Version::QMux02)).await;
+
+    let client_rtt = wait_for_rtt(&client).await.expect("client measured no RTT");
+    let server_rtt = wait_for_rtt(&server).await.expect("server measured no RTT");
+
+    // Loopback, so the figure is small, but it must be a real measurement rather
+    // than a zero placeholder standing in for "unknown".
+    for rtt in [client_rtt, server_rtt] {
+        assert!(rtt < Duration::from_secs(1), "implausible RTT: {rtt:?}");
+    }
+}
+
+/// RTT is measured while the application is actively sending, which is exactly
+/// when the activity-gated keep-alive ping never fires.
+#[tokio::test]
+async fn measures_rtt_under_load() {
+    let (client, server) = pair(probing(Version::QMux02), probing(Version::QMux02)).await;
+
+    // Keep the connection busy so `last_send_at` never goes quiet.
+    let busy = tokio::spawn(async move {
+        loop {
+            let mut send = match client.open_uni().await {
+                Ok(send) => send,
+                Err(_) => return,
+            };
+            if send.write(&[0u8; 512]).await.is_err() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    });
+
+    let rtt = wait_for_rtt(&server).await;
+    busy.abort();
+
+    assert!(rtt.is_some(), "no RTT measured while actively sending");
+}
+
+/// A zero interval opts out, leaving RTT unreported.
+#[tokio::test]
+async fn zero_interval_disables_probing() {
+    let mut cfg = Config::new(Version::QMux02);
+    cfg.rtt_interval = Duration::ZERO;
+    let (client, _server) = pair(cfg.clone(), cfg).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(client.stats().rtt(), None);
+}

--- a/rs/qmux/tests/rtt.rs
+++ b/rs/qmux/tests/rtt.rs
@@ -100,3 +100,62 @@ async fn zero_interval_disables_probing() {
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(client.stats().rtt(), None);
 }
+
+/// A TCP session reports the kernel's RTT immediately, before any QX_PING could
+/// have completed a round trip.
+///
+/// This is what lets a peer decide at handshake time whether it can report
+/// latency at all: an estimate that only appears one probe interval later is
+/// indistinguishable, at SETUP, from a transport that never reports one.
+#[cfg(unix)]
+#[tokio::test]
+async fn tcp_reports_rtt_immediately() {
+    let mut cfg = Config::new(Version::QMux02);
+    // No QX_PING probing at all, so the only possible source is the socket.
+    cfg.rtt_interval = Duration::ZERO;
+
+    let (client, server) = pair_with_socket_stats(cfg.clone(), cfg).await;
+
+    for (side, session) in [("client", &client), ("server", &server)] {
+        let rtt = session
+            .stats()
+            .rtt()
+            .unwrap_or_else(|| panic!("{side} reported no RTT at handshake"));
+        // Loopback. A wildly wrong figure would mean the mirrored `tcp_info` layout
+        // has drifted and we are reading some other field.
+        assert!(
+            rtt < Duration::from_secs(1),
+            "{side} implausible RTT: {rtt:?}"
+        );
+    }
+}
+
+/// Like [`pair`], but attaches the kernel's view of each socket the way the
+/// `qmux::tcp` builder does.
+#[cfg(unix)]
+async fn pair_with_socket_stats(client_cfg: Config, server_cfg: Config) -> (Session, Session) {
+    use std::sync::Arc;
+
+    fn stats(sock: &TcpStream) -> qmux::SharedSocketStats {
+        Arc::new(qmux::TcpStats::new(sock).unwrap())
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let stats = stats(&sock);
+        let transport = Stream::new(sock, server_cfg.version, server_cfg.max_record_size)
+            .with_socket_stats(stats);
+        Session::accept(transport, server_cfg).await.unwrap()
+    });
+
+    let sock = TcpStream::connect(addr).await.unwrap();
+    let stats = stats(&sock);
+    let transport =
+        Stream::new(sock, client_cfg.version, client_cfg.max_record_size).with_socket_stats(stats);
+    let client = Session::connect(transport, client_cfg).await.unwrap();
+
+    (client, server.await.unwrap())
+}


### PR DESCRIPTION
`qmux::Session` never implemented `stats()`, so it fell through to `web_transport_trait`'s `StatsUnavailable` default and every qmux transport (WebSocket, TCP, UDS) reported `rtt: None` **and** `estimated_send_rate: None`.

That is the bottom of a chain with a measurable cost downstream. moq-relay reads `rtt()` to fill the moq-lite PROBE message, and a browser that receives no PROBE pins its jitter buffer to a hardcoded fallback. `@moq/net` disables WebTransport for Firefox and Safari by user-agent check, so qmux is the normal path for two of the three browser engines, not an edge-case fallback — the measured cost was ~80ms of avoidable glass-to-glass latency for every non-Chromium viewer.

Two commits, because there are two independent sources and they answer different questions.

## 1. RTT from `QX_PING`

`QX_PING` is already a request/response pair whose Sequence Number the responder MUST echo, and the draft does not reserve it for keep-alive use, so the round trip is measurable with no wire change. The reader was discarding exactly the frames that close the loop (`// QX_PING: respond to requests, ignore responses`).

Two details the draft forces:

- **Keep-alive pings are activity-gated** (`ping_every = idle_ms / 3`, and only once silent on send), so they never fire while an application is actively sending — which is precisely when latency matters. RTT probing therefore runs on its own cadence off the last ping rather than off the last send. `Config::rtt_interval` (default 1s, zero disables) is additive: `Config` is already `#[non_exhaustive]`.
- **A responder MAY coalesce** several outstanding requests into one response carrying the largest Sequence Number. A response therefore retires every request up to and including its sequence, and is measured against the **newest** of them — the one the peer had to receive before it could answer. The older entries would each overstate the round trip.

The **writer** stamps each request as it reaches the wire, rather than the timer stamping it at enqueue: the control lane's queueing delay is ours, not the peer's, and counting it would inflate every jitter buffer downstream. Samples are smoothed with QUIC's SRTT recurrence (RFC 9002).

The timer now also runs when the idle timeout is disabled but probing is not.

## 2. RTT and delivery rate from the socket

`QX_PING` gives a round trip, but only *after* one has completed. That leaves a question it cannot answer: at handshake time, `rtt()` returning `None` is indistinguishable from a transport that will never report one. The distinction is real — moq-lite has the publisher advertise a Probe capability level in SETUP, at `accept()`, before any ping could possibly have been answered.

TCP already knows. The kernel measures a smoothed RTT during the three-way handshake, before any of our code runs, and on Linux tracks a delivery-rate estimate too. Both are readable with `getsockopt`, cost no traffic, and are available from the first moment. The delivery rate is also something `QX_PING` fundamentally cannot measure.

Adds:
- `SocketStats`, a trait for the transport's own view of the connection
- `Transport::socket_stats`, an optional hook (defaulted, so existing implementors are unaffected)
- `TcpStats`, reading `TCP_INFO` (Linux) / `TCP_CONNECTION_INFO` (macOS)

The `tcp` and `tls` builders attach it automatically. `Stream` and `ws::Upgraded` take it via `with_socket_stats`, for callers that build a transport by hand — notably an HTTP server that performed the upgrade itself and is the only one holding a descriptor. `uds` attaches nothing: a Unix socket has no `TCP_INFO`, and its round trip is negligible anyway.

`Session::stats()` prefers the socket's RTT and falls back to the `QX_PING` estimate, so a transport that exposes nothing — a type-erased HTTP upgrade with no descriptor to hand us — still reports what QMux can measure itself.

## Safety of the mirrored structs

The `tcp_info` structs are mirrored field-for-field so `repr(C)` computes the offsets, rather than hand-computing them. A typo in the middle would otherwise silently shift every later field and yield a plausible-looking wrong number instead of a failure, so a test pins the offsets actually read (`rtt` 68, `delivery_rate` 160 on Linux; `srtt` 44 on macOS). Reads are additionally bounded by the length the kernel reports, since older releases fill in less than the current struct.

macOS counts RTT in whole milliseconds, so a loopback round trip genuinely rounds to zero. A successful `getsockopt` on a connected socket is a measurement, so it is reported at zero rather than discarded as unknown; only the delivery rate treats zero as "no estimate yet", which is what it means before data has flowed.

## Compatibility

All additive — a defaulted trait method, a new field on an already-`#[non_exhaustive]` `Config`, and new types. Nothing existing changes shape, so this can ship as **0.5.1** and downstream `qmux = "0.5.0"` requirements pick it up with no manifest change.

`libc` is a new dependency, gated to `cfg(unix)`.

## Testing

`just check` clean; full suite green. New tests:

- `rtt.rs` unit tests: single sample, coalesced response measuring the newest, unmatched response ignored, SRTT smoothing, bounded outstanding list
- `tests/rtt.rs`: both ends measure RTT with no application traffic; RTT is measured **under load**, which is exactly when the keep-alive never fires; a zero interval opts out; and `tcp_reports_rtt_immediately` — with `QX_PING` probing disabled entirely, so the socket is the only possible source — which is the property that makes a handshake-time capability decision sound
- struct layout offset guards for both platforms

I could only exercise the macOS layout locally, which is why the Linux offsets are pinned in a test rather than trusted.

## Downstream

moq-dev/moq#2945 fixes the matching moq-lite conformance defects (PROBE discarding the whole message for want of a bitrate; SETUP advertising a capability independent of the transport). It needs this released before the latency actually improves.

(written by Opus 5)
