### PR TITLE
fix(wasm): report None when no subprotocol was negotiated

### DIFF
--- a/rs/web-transport-wasm/examples/harness.rs
+++ b/rs/web-transport-wasm/examples/harness.rs
@@ -62,6 +62,7 @@ pub async fn run(url: String, hash: String) -> Result<Array, JsValue> {
     }
 
     check!("echo round trip", echo_round_trip);
+    check!("no subprotocol reports None", no_subprotocol_is_none);
     check!(
         "dropped pending opens release stream credit",
         dropped_pending_opens_release_credit
@@ -130,6 +131,19 @@ async fn echo_round_trip(session: Session) -> Result<String, Error> {
     let got = read_all(&mut recv).await?;
 
     expect(got == "hello harness", format!("echoed {got:?}"))
+}
+
+/// `connect` above offers no subprotocols, so the browser negotiates none and
+/// reports `""`. The trait contract says an unnegotiated protocol is `None`, and a
+/// `Some("")` reaching a caller gets matched against their protocol table as if the
+/// peer had chosen something.
+async fn no_subprotocol_is_none(session: Session) -> Result<String, Error> {
+    let protocol = session.protocol();
+
+    expect(
+        protocol.is_none(),
+        format!("protocol() returned {protocol:?}"),
+    )
 }
 
 /// Dropping a handle cannot cancel the browser promise returned by open. Churn

--- a/rs/web-transport-wasm/src/session.rs
+++ b/rs/web-transport-wasm/src/session.rs
@@ -222,9 +222,15 @@ impl Session {
     pub fn new(inner: WebTransport, url: Url) -> Self {
         // TODO use the web_sys bindings when updated.
         // Until then, we try to access the protocol property on the inner object.
+        //
+        // The browser reports `""` when no subprotocol was negotiated, which is what
+        // `None` means here. Normalizing at the capture site keeps every reader —
+        // the inherent getter and both trait impls — from having to know that, and
+        // stops `Some("")` being matched against an application's protocol table.
         let protocol = Reflect::get(&inner, &"protocol".into())
             .ok()
-            .and_then(|p| p.as_string());
+            .and_then(|p| p.as_string())
+            .filter(|p| !p.is_empty());
 
         Self {
             shared: Rc::new(Shared {
@@ -556,7 +562,8 @@ impl Session {
         &self.shared.url
     }
 
-    /// Return the application protocol used to create the session.
+    /// Return the subprotocol the server selected, or `None` when none was
+    /// negotiated.
     pub fn protocol(&self) -> Option<&str> {
         self.shared.protocol.as_deref()
     }

--- a/rs/web-transport/src/wasm.rs
+++ b/rs/web-transport/src/wasm.rs
@@ -116,6 +116,8 @@ impl Session {
     }
 
     /// Return the application protocol used to create the session.
+    ///
+    /// This is the negotiated subprotocol, or `None` when none was negotiated.
     pub fn protocol(&self) -> Option<&str> {
         self.0.protocol()
     }


### PR DESCRIPTION
## What

`web_transport_wasm::Session::protocol()` returned `Some("")` when no subprotocol was negotiated. It now returns `None`.

## Why

The browser initializes `WebTransport.protocol` to `""` when the server selects no subprotocol — the same sentinel `WebSocket` uses. We passed that straight through, but `web_transport_trait::Session::protocol` documents `None` as the "nothing was negotiated" answer, so the wasm backend was out of conformance with the trait it implements.

The practical cost lands on callers: a caller matching the result against its own protocol table sees `Some("")` and reads it as a peer choice, instead of falling back to negotiating a version over its own handshake.

This was already known downstream. Both moq adapters (`rs/moq-wasm/src/transport.rs`, `rs/moq-ffi/src/transport.rs`) carry a `.filter(|p| !p.is_empty())` with a comment explaining the browser's sentinel. Those adapters exist to bridge to `web-transport-trait` and are slated for deletion now that this crate implements it natively (#369) — so the compensation has to move here or it gets deleted along with them.

Normalizing at the capture site in `Session::new` rather than in the getter keeps the inherent getter and both trait impls agreeing without each needing to know about `""`.

## Testing

Added a harness case. `connect` in the harness offers no subprotocols, so the browser negotiates none — exactly the path that produced the sentinel.

Ran `just harness` against Chromium and the `harness-server` QUIC peer, both ways:

- with the fix: **15 passed, 0 failed** — `protocol() returned None`
- with the fix reverted: **14 passed, 1 failed** — `protocol() returned Some("")`

`just check` and `just test` both pass.

## For reviewers

- The doc touch on `web-transport/src/wasm.rs` is comment-only; the router already delegates to the inherent getter, so it inherits the fix.
- No behavior change for a session that *did* negotiate a subprotocol.
- Not a semver break in practice, but it does change an observable return value, and `web-transport-wasm` is already queued for a breaking `0.6.0` in #363.

(written by Opus 5)
