### PR TITLE
chore: bump crate versions by hand

### DIFF
--- a/rs/qmux/CHANGELOG.md
+++ b/rs/qmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/moq-dev/web-transport/compare/qmux-v0.5.0...qmux-v0.5.1) - 2026-08-20
+
+### Added
+
+- *(qmux)* report RTT and delivery rate from Session::stats() ([#380](https://github.com/moq-dev/web-transport/pull/380))
+
 ## [0.5.0](https://github.com/moq-dev/web-transport/compare/qmux-v0.4.1...qmux-v0.5.0) - 2026-08-06
 
 ### Fixed

--- a/rs/qmux/Cargo.toml
+++ b/rs/qmux/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 keywords = ["quic", "qmux", "webtransport", "multiplexing"]

--- a/rs/qmux/README.md
+++ b/rs/qmux/README.md
@@ -10,7 +10,7 @@ The protocol reuses QUIC frame types and semantics while adapting them for strea
 
 ```toml
 [dependencies]
-qmux = "0.4"
+qmux = "0.5"
 ```
 
 ### Features

--- a/rs/web-transport-quiche/CHANGELOG.md
+++ b/rs/web-transport-quiche/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/moq-dev/web-transport/compare/web-transport-quiche-v0.6.0...web-transport-quiche-v0.7.0) - 2026-08-20
+
+### Fixed
+
+- *(quiche)* keep per-stream teardown out of the connection ([#379](https://github.com/moq-dev/web-transport/pull/379))
+- *(quiche)* [**breaking**] make set_priority higher-first across the crate ([#367](https://github.com/moq-dev/web-transport/pull/367))
+
+### Other
+
+- *(quiche)* [**breaking**] move the priority inversion into ez ([#372](https://github.com/moq-dev/web-transport/pull/372))
+
 ## [0.6.0](https://github.com/moq-dev/web-transport/compare/web-transport-quiche-v0.5.1...web-transport-quiche-v0.6.0) - 2026-08-06
 
 ### Fixed

--- a/rs/web-transport-quiche/Cargo.toml
+++ b/rs/web-transport-quiche/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport-quinn/CHANGELOG.md
+++ b/rs/web-transport-quinn/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/moq-dev/web-transport/compare/web-transport-quinn-v0.12.0...web-transport-quinn-v0.12.1) - 2026-08-20
+
+### Other
+
+- *(wasm)* implement the poll traits natively ([#369](https://github.com/moq-dev/web-transport/pull/369))
+
 ## [0.12.0](https://github.com/moq-dev/web-transport/compare/web-transport-quinn-v0.11.12...web-transport-quinn-v0.12.0) - 2026-08-06
 
 ### Fixed

--- a/rs/web-transport-quinn/Cargo.toml
+++ b/rs/web-transport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport-wasm/CHANGELOG.md
+++ b/rs/web-transport-wasm/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/moq-dev/web-transport/compare/web-transport-wasm-v0.5.10...web-transport-wasm-v0.6.0) - 2026-08-20
+
+### Added
+
+- *(wasm)* set waitUntilAvailable when opening streams ([#370](https://github.com/moq-dev/web-transport/pull/370))
+
+### Fixed
+
+- *(wasm)* report None when no subprotocol was negotiated ([#381](https://github.com/moq-dev/web-transport/pull/381))
+- *(wasm)* resubscribe to ready instead of waiting on closed ([#374](https://github.com/moq-dev/web-transport/pull/374))
+- *(wasm)* set rustdocflags so cargo doc and doctests compile ([#373](https://github.com/moq-dev/web-transport/pull/373))
+
+### Other
+
+- *(wasm)* [**breaking**] implement the poll traits natively ([#369](https://github.com/moq-dev/web-transport/pull/369))
+
 ## [0.5.10](https://github.com/moq-dev/web-transport/compare/web-transport-wasm-v0.5.9...web-transport-wasm-v0.5.10) - 2026-07-22
 
 ### Added

--- a/rs/web-transport-wasm/Cargo.toml
+++ b/rs/web-transport-wasm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.5.10"
+version = "0.6.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport/CHANGELOG.md
+++ b/rs/web-transport/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/moq-dev/web-transport/compare/web-transport-v0.11.0...web-transport-v0.12.0) - 2026-08-20
+
+### Fixed
+
+- *(wasm)* report None when no subprotocol was negotiated ([#381](https://github.com/moq-dev/web-transport/pull/381))
+
+### Other
+
+- *(wasm)* [**breaking**] implement the poll traits natively ([#369](https://github.com/moq-dev/web-transport/pull/369))
+
 ## [0.11.0](https://github.com/moq-dev/web-transport/compare/web-transport-v0.10.9...web-transport-v0.11.0) - 2026-08-06
 
 ### Other

--- a/rs/web-transport/Cargo.toml
+++ b/rs/web-transport/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -21,4 +21,4 @@ url = "2"
 web-transport-quinn = { version = "0.12.0", path = "../web-transport-quinn" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-transport-wasm = { version = "0.5.10", path = "../web-transport-wasm" }
+web-transport-wasm = { version = "0.6.0", path = "../web-transport-wasm" }


### PR DESCRIPTION
Replaces the release-plz proposal in #363, which has to be closed for this to release.

Two of its minor bumps were driven only by `auto_trait_impl_removed`. That is not a break worth a major-equivalent version here: no name, signature, or behavior changed, and a caller relying on `UnwindSafe` for one of these types was relying on an accident.

## Versions

| crate | #363 | here | why |
| --- | --- | --- | --- |
| `qmux` | 0.6.0 | **0.5.1** | unwind only |
| `web-transport-quinn` | 0.13.0 | **0.12.1** | library unchanged |
| `web-transport-quiche` | 0.7.0 | **0.7.0** | `set_priority` reverses meaning |
| `web-transport-wasm` | 0.6.0 | **0.6.0** | `Error` variants, `&mut self` receivers |
| `web-transport` | 0.12.0 | **0.12.0** | re-exports wasm on wasm32 |
| `web-transport-proto` | 0.6.1 | **0.6.1** | already in the manifest, unpublished |
| `web-transport-ffi` | 0.1.3 | *no bump* | `web-transport-quinn = "0.12"` still matches |
| `web-transport-node` | 0.0.7 | *no bump* | same |

### Patched instead of minor

`qmux` 0.5.1 — the only flagged break is `Session`, `Stream`, and `Upgraded` losing `UnwindSafe`/`RefUnwindSafe`. `Session::stats()` gaining RTT and delivery rate (#380) is additive.

`web-transport-quinn` 0.12.1 — #369 touched this crate only to add the `harness-server` example. The library is untouched, and cargo-semver-checks agreed it was compatible; release-plz proposed 0.13.0 because the commit carried a `!`.

Dropping the quinn requirement change is what removes `web-transport-ffi` and `web-transport-node` from the release entirely. Their `"0.12"` requirement is satisfied by 0.12.1, so #363's "updated the following local packages" bumps had nothing behind them.

### Kept minor

These are not unwind, so a patch would be a silent break for anyone who upgrades:

- **`web-transport-quiche`** — #367 and #372 reverse `SendStream::set_priority` and `ez::SendStream::set_priority` to higher-first. Same signature, opposite behavior; cargo-semver-checks cannot see it.
- **`web-transport-wasm`** — `Error::Streams` is gone, `Error::Session` is now a struct variant, `Error::Closed` is new, and `SendStream::closed`/`RecvStream::closed` take `&mut self`.
- **`web-transport`** — `pub use quic::*` re-exports the wasm module wholesale on wasm32, so the `Error` change lands in its surface too.

Each is a one-line revert to a patch if you'd rather ship them that way.

## Other

The `qmux` README install snippet still said `qmux = "0.4"`.

## Checks

Manifests and markdown only. `cargo metadata --no-deps` resolves the workspace, and every intra-workspace path requirement is satisfied by the new versions (checked by hand — the nix shell isn't available in this environment, so `just check` wasn't run; there is no tracked `Cargo.lock` to update).

---
_Generated by [Claude Code](https://claude.ai/code/session_015gokPRtDeLNb9vgWqdFqWh)_