### PR TITLE
fix(web-transport-quinn): prefer the controller's pacing rate for estimated_send_rate

### DIFF
--- a/rs/web-transport-quinn/src/session.rs
+++ b/rs/web-transport-quinn/src/session.rs
@@ -613,6 +613,7 @@ impl Session {
         SessionStats {
             stats: self.conn.stats(),
             rtt: self.conn.rtt(),
+            pacing_rate: self.conn.congestion_state().metrics().pacing_rate,
         }
     }
 }
@@ -959,6 +960,7 @@ impl SessionAccept {
 pub struct SessionStats {
     stats: quinn::ConnectionStats,
     rtt: std::time::Duration,
+    pacing_rate: Option<u64>,
 }
 
 impl web_transport_trait::Stats for SessionStats {
@@ -991,6 +993,10 @@ impl web_transport_trait::Stats for SessionStats {
     }
 
     fn estimated_send_rate(&self) -> Option<u64> {
+        // BBR reports 0 until its first rate sample.
+        if let Some(pacing_rate) = self.pacing_rate.filter(|rate| *rate > 0) {
+            return Some(pacing_rate);
+        }
         let rtt_secs = self.rtt.as_secs_f64();
         if self.stats.path.cwnd > 0 && rtt_secs > 0.0 {
             Some((self.stats.path.cwnd as f64 * 8.0 / rtt_secs) as u64)


### PR DESCRIPTION
## Summary

- `estimated_send_rate` derives the rate from cwnd/rtt, which overshoots under BBR: its cwnd sits a gain above the bandwidth-delay product, so a consumer pacing an encoder off this number asks for more than the path delivers.
- A controller that measures delivery rate (quinn's BBR) reports it as a pacing rate through `CongestionState::metrics`; prefer that when it is non-zero. BBR reports 0 until its first rate sample and CUBIC reports no pacing rate, so both keep the cwnd/rtt fallback.

## Public API changes

- None (`SessionStats` gains a private field).

## Test plan

- `cargo test -p web-transport-quinn`, `cargo clippy -p web-transport-quinn --all-targets`, `cargo fmt --check`: clean.

(Written by Claude Fable 5)
