### PR TITLE
Widen stream priority to i32, ranked onto quiche's urgency

### DIFF
--- a/rs/qmux/src/sched.rs
+++ b/rs/qmux/src/sched.rs
@@ -2,7 +2,7 @@
 //!
 //! Replaces the bounded `mpsc` data channel the session used to interleave
 //! STREAM frames purely by arrival order. Frames are bucketed by stream
-//! priority (a `u8`, higher = sent first, matching the W3C `sendOrder`
+//! priority (an `i32`, higher = sent first, matching the W3C `sendOrder`
 //! convention) so a high-priority stream can jump ahead of a low-priority
 //! backlog. Re-prioritization is retroactive and cheap: only the stream's
 //! scheduling pointer moves between bands, never its queued frames, so the
@@ -24,7 +24,7 @@ use crate::{Error, Frame, StreamId};
 
 /// Per-stream FIFO of pending frames plus the stream's current priority band.
 struct StreamSlot {
-    priority: u8,
+    priority: i32,
     frames: VecDeque<Frame>,
 }
 
@@ -32,7 +32,7 @@ struct Inner {
     /// Ready streams bucketed by priority. The MAX key is served first.
     /// A `StreamId` appears in at most one band at a time, and only while its
     /// slot has at least one queued frame.
-    bands: BTreeMap<u8, VecDeque<StreamId>>,
+    bands: BTreeMap<i32, VecDeque<StreamId>>,
     /// Per-stream queued frames + current priority.
     streams: HashMap<StreamId, StreamSlot>,
     /// Total queued frames across all streams (the capacity bound).
@@ -45,7 +45,7 @@ impl Inner {
     /// Schedule `id` in `band` if it isn't already scheduled somewhere.
     ///
     /// Caller guarantees the slot exists and has at least one frame.
-    fn arm(&mut self, id: StreamId, band: u8) {
+    fn arm(&mut self, id: StreamId, band: i32) {
         // A StreamId lives in at most one band. The slot's `priority` is the
         // single source of truth for which band it would be in, so checking the
         // band's queue for membership is unnecessary as long as callers only arm
@@ -126,7 +126,7 @@ impl PriorityQueue {
     /// otherwise have to either block (impossible from a sync caller) or be
     /// detached to a task (racing reset/teardown). The frame still lands in the
     /// stream's band, after its data. Fails only if the queue is closed.
-    pub fn push_now(&self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
+    pub fn push_now(&self, priority: i32, id: StreamId, frame: Frame) -> Result<(), Error> {
         let mut inner = self.inner.lock().unwrap();
         if inner.closed {
             return Err(Error::Closed);
@@ -135,7 +135,7 @@ impl PriorityQueue {
         Ok(())
     }
 
-    fn push_locked(&self, inner: &mut Inner, priority: u8, id: StreamId, frame: Frame) {
+    fn push_locked(&self, inner: &mut Inner, priority: i32, id: StreamId, frame: Frame) {
         self.enqueue_locked(inner, priority, id, frame);
         inner.len += 1;
     }
@@ -143,7 +143,7 @@ impl PriorityQueue {
     /// Append `frame` to `id`'s FIFO without touching `len`. Callers own the
     /// capacity accounting: `push_now` bumps it after the fact, while a
     /// [`Permit`] already reserved its slot in `reserve`.
-    fn enqueue_locked(&self, inner: &mut Inner, priority: u8, id: StreamId, frame: Frame) {
+    fn enqueue_locked(&self, inner: &mut Inner, priority: i32, id: StreamId, frame: Frame) {
         match inner.streams.get_mut(&id) {
             Some(slot) => {
                 // Already scheduled (its band points at `id`); just append.
@@ -214,7 +214,7 @@ impl PriorityQueue {
     /// Retroactively re-prioritize a stream. Frames don't move — only the
     /// scheduling pointer relocates from the old band to `new`. No-op if the
     /// stream has no queued frames.
-    pub fn set_priority(&self, id: StreamId, new: u8) {
+    pub fn set_priority(&self, id: StreamId, new: i32) {
         let mut inner = self.inner.lock().unwrap();
         let old = match inner.streams.get(&id) {
             Some(slot) => slot.priority,
@@ -312,7 +312,7 @@ impl Permit {
     /// Fails if the queue closed while the permit was outstanding: the consumer
     /// has already stopped popping, so enqueuing here would strand the frame and
     /// report success for data that will never be sent.
-    pub fn send(mut self, priority: u8, id: StreamId, frame: Frame) -> Result<(), Error> {
+    pub fn send(mut self, priority: i32, id: StreamId, frame: Frame) -> Result<(), Error> {
         let mut inner = self.queue.inner.lock().unwrap();
         if inner.closed {
             // Release the lock before returning: `self` still counts as armed, so
@@ -379,7 +379,7 @@ mod tests {
     /// capacity, not the cancellation split, so they read better without it.
     async fn push(
         q: &PriorityQueue,
-        priority: u8,
+        priority: i32,
         id: StreamId,
         frame: Frame,
     ) -> Result<(), Error> {

--- a/rs/qmux/src/session.rs
+++ b/rs/qmux/src/session.rs
@@ -2057,7 +2057,7 @@ pub struct SendStream {
     offset: u64,
     /// Scheduling priority (higher = sent first). Threaded into the queue on
     /// every `push` and relayed to the queue on `set_priority`.
-    priority: u8,
+    priority: i32,
     closed: Option<Error>,
     fin: bool,
 
@@ -2252,7 +2252,7 @@ impl generic::SendStream for SendStream {
     /// Re-prioritization is retroactive: already-queued frames for this stream
     /// move to the new band on the next scheduling decision (the bytes stay put,
     /// preserving per-stream order).
-    fn set_priority(&mut self, order: u8) {
+    fn set_priority(&mut self, order: i32) {
         self.priority = order;
         self.outbound.set_priority(self.id, order);
     }

--- a/rs/web-transport-iroh/src/send.rs
+++ b/rs/web-transport-iroh/src/send.rs
@@ -119,8 +119,8 @@ impl tokio::io::AsyncWrite for SendStream {
 impl web_transport_trait::SendStream for SendStream {
     type Error = WriteError;
 
-    fn set_priority(&mut self, order: u8) {
-        self.stream.set_priority(order.into()).ok();
+    fn set_priority(&mut self, order: i32) {
+        self.stream.set_priority(order).ok();
     }
 
     fn reset(&mut self, code: u32) {

--- a/rs/web-transport-noq/src/send.rs
+++ b/rs/web-transport-noq/src/send.rs
@@ -152,8 +152,8 @@ impl tokio::io::AsyncWrite for SendStream {
 impl web_transport_trait::SendStream for SendStream {
     type Error = WriteError;
 
-    fn set_priority(&mut self, order: u8) {
-        Self::set_priority(self, order.into()).ok();
+    fn set_priority(&mut self, order: i32) {
+        Self::set_priority(self, order).ok();
     }
 
     fn reset(&mut self, code: u32) {

--- a/rs/web-transport-proto/Cargo.toml
+++ b/rs/web-transport-proto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/web-transport"
 license = "MIT OR Apache-2.0"
 
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -20,7 +20,8 @@ use tokio_quiche::{
 use crate::ez::Lock;
 
 use super::{
-    ConnectionClosed, ConnectionError, ConnectionStats, Metrics, RecvState, SendState, StreamId,
+    ConnectionClosed, ConnectionError, ConnectionStats, Metrics, Priorities, RecvState, SendState,
+    StreamId,
 };
 
 // "drop" in ascii; if you see this then close(code)
@@ -44,6 +45,11 @@ pub(super) struct DriverState {
 
     bi: DriverOpen<(Lock<SendState>, Lock<RecvState>)>,
     uni: DriverOpen<Lock<SendState>>,
+
+    /// Ranks every open send stream, turning the application's `i32` send order
+    /// into the `u8` urgency quiche schedules by. Connection-wide because the
+    /// ranking is relative: one stream moving can shift the rest.
+    priority: Priorities,
 
     close_requested: ConnectionClosed,
     closed: ConnectionClosed,
@@ -113,6 +119,7 @@ impl DriverState {
             closed: ConnectionClosed::default(),
             bi: DriverOpen::new(next_bi),
             uni: DriverOpen::new(next_uni),
+            priority: Priorities::default(),
             established: false,
             alpn: None,
             server_name: None,
@@ -219,6 +226,15 @@ impl DriverState {
         self.waker.take()
     }
 
+    /// Change a stream's send order, where higher values are sent first.
+    ///
+    /// The new urgency reaches quiche via the driver, so wake it.
+    #[must_use = "wake the driver"]
+    pub fn set_priority(&mut self, stream_id: StreamId, order: i32) -> Option<Waker> {
+        self.priority.set(stream_id, order);
+        self.waker.take()
+    }
+
     #[must_use = "wake the driver"]
     pub fn recv(&mut self, stream_id: StreamId) -> Option<Waker> {
         if !self.recv.insert(stream_id) {
@@ -247,6 +263,7 @@ impl DriverState {
         let send = Lock::new(SendState::new(id));
         let recv = Lock::new(RecvState::new(id));
         self.bi.create.push((id, (send.clone(), recv.clone())));
+        self.priority.insert(id);
 
         let wakeup = self.waker.take();
         Poll::Ready(Ok((wakeup, id, send, recv)))
@@ -263,6 +280,7 @@ impl DriverState {
         send: Lock<SendState>,
         recv: Lock<RecvState>,
     ) -> WaiterList {
+        self.priority.insert(id);
         self.accept_bi.push_back((id, send, recv));
         self.accept_bi_waiters.take()
     }
@@ -346,6 +364,7 @@ impl DriverState {
 
         let send = Lock::new(SendState::new(id));
         self.uni.create.push((id, send.clone()));
+        self.priority.insert(id);
 
         let wakeup = self.waker.take();
         Poll::Ready(Ok((wakeup, id, send)))
@@ -580,6 +599,7 @@ impl Driver {
 
                     if closed {
                         entry.remove();
+                        self.state.lock().priority.remove(stream_id);
                     }
 
                     if let Some(waker) = waker {
@@ -698,6 +718,10 @@ impl Driver {
 
         uni_waiters.unwrap_or_default().wake();
 
+        // Before the flushes, so a stream created above sends its first bytes at
+        // the urgency it was opened with rather than quiche's default.
+        self.apply_priorities(qconn)?;
+
         for stream_id in recv {
             self.flush_recv(qconn, stream_id)?;
         }
@@ -705,6 +729,9 @@ impl Driver {
         for stream_id in send {
             self.flush_send(qconn, stream_id)?;
         }
+
+        // A flush can close a stream, which promotes whatever it was holding back.
+        self.apply_priorities(qconn)?;
 
         // Returning Ready hands control back to the io loop, which flushes the
         // scheduled PING to the socket.
@@ -757,6 +784,7 @@ impl Driver {
 
             if closed {
                 entry.remove();
+                self.state.lock().priority.remove(stream_id);
             }
 
             if let Some(waker) = waker {
@@ -764,6 +792,42 @@ impl Driver {
             }
         } else {
             tracing::warn!(?stream_id, "wakeup for closed stream");
+        }
+
+        Ok(())
+    }
+
+    /// Hand quiche the urgency changes the priority ranking has accumulated.
+    ///
+    /// Ranks are connection-wide, so a single `set_priority` (or a stream closing)
+    /// can move several streams. They're collected in `DriverState` and applied
+    /// here because this is the only place holding the quiche connection.
+    fn apply_priorities(&mut self, qconn: &mut QuicheConnection) -> Result<(), ConnectionError> {
+        let pending = self.state.lock().priority.take();
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        let mut deferred = Vec::new();
+
+        for (stream_id, urgency) in pending {
+            // The ranking knows about a stream from the moment it's opened, which is
+            // a pass earlier than quiche does. Hold the urgency until the stream is
+            // actually there rather than asking quiche to conjure it.
+            if !self.send.contains_key(&stream_id) {
+                deferred.push((stream_id, urgency));
+                continue;
+            }
+
+            tracing::trace!(?stream_id, urgency, "updating stream priority");
+
+            // `incremental` so streams sharing an urgency round-robin, matching how
+            // quinn and qmux treat equal priorities.
+            qconn.stream_priority(stream_id.into(), urgency, true)?;
+        }
+
+        if !deferred.is_empty() {
+            self.state.lock().priority.defer(deferred);
         }
 
         Ok(())
@@ -838,6 +902,13 @@ impl tokio_quiche::ApplicationOverQuic for Driver {
 
     fn process_writes(&mut self, qconn: &mut QuicheConnection) -> tokio_quiche::QuicResult<()> {
         if let Err(e) = self.write(qconn) {
+            self.abort(e);
+            return Ok(());
+        }
+
+        // `write` can close streams, and this runs on iterations where `poll` never
+        // does, so the ranking is settled here too before any packet leaves.
+        if let Err(e) = self.apply_priorities(qconn) {
             self.abort(e);
             return Ok(());
         }

--- a/rs/web-transport-quiche/src/ez/mod.rs
+++ b/rs/web-transport-quiche/src/ez/mod.rs
@@ -16,6 +16,7 @@ mod client;
 mod connection;
 mod driver;
 mod lock;
+mod priority;
 mod recv;
 mod send;
 mod server;
@@ -32,6 +33,7 @@ pub use stream::*;
 
 use driver::*;
 use lock::*;
+use priority::*;
 
 pub use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 pub use tls::{CertResolver, CertifiedKey, ClientAuth};

--- a/rs/web-transport-quiche/src/ez/priority.rs
+++ b/rs/web-transport-quiche/src/ez/priority.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
 
-use super::StreamId;
+use super::{StreamId, DEFAULT_PRIORITY};
 
 /// How many distinct priority levels quiche can express.
 const BANDS: usize = u8::MAX as usize + 1;
@@ -56,11 +56,27 @@ impl Priorities {
     /// prioritizes: an unranked stream would keep quiche's own default urgency and
     /// so could outrank a stream that explicitly asked to go last.
     pub fn insert(&mut self, id: StreamId) {
-        self.set(id, 0);
+        self.rank(id, DEFAULT_PRIORITY);
     }
 
     /// Change a stream's send order, where higher values are sent first.
+    ///
+    /// Ignored for a stream that isn't registered, which means the driver has
+    /// already retired it. The application can still be holding the handle then —
+    /// a peer `STOP_SENDING` retires a stream underneath a live `SendStream` — and
+    /// ranking it again would strand a level that nothing is left to remove,
+    /// pushing every live stream below it down a band, plus an urgency update that
+    /// can never be applied because the stream is gone from the driver's map.
     pub fn set(&mut self, id: StreamId, order: i32) {
+        if !self.streams.contains_key(&id) {
+            return;
+        }
+
+        self.rank(id, order);
+    }
+
+    /// Register or move `id` to `order`.
+    fn rank(&mut self, id: StreamId, order: i32) {
         if self.streams.get(&id) == Some(&order) {
             return;
         }
@@ -188,12 +204,20 @@ mod tests {
         StreamId::from(id)
     }
 
+    /// Open a stream and give it a send order, the same two steps `open_uni`
+    /// followed by `set_priority` takes. `set` alone is ignored for a stream the
+    /// driver hasn't registered.
+    fn open(p: &mut Priorities, id: StreamId, order: i32) {
+        p.insert(id);
+        p.set(id, order);
+    }
+
     #[test]
     fn ranks_by_descending_send_order() {
         let mut p = Priorities::default();
         p.insert(sid(0));
-        p.set(sid(4), 100);
-        p.set(sid(8), 50);
+        open(&mut p, sid(4), 100);
+        open(&mut p, sid(8), 50);
 
         let pending = p.take();
         assert_eq!(pending[&sid(4)], 0);
@@ -204,9 +228,9 @@ mod tests {
     #[test]
     fn equal_send_orders_share_a_band() {
         let mut p = Priorities::default();
-        p.set(sid(0), 7);
-        p.set(sid(4), 7);
-        p.set(sid(8), 3);
+        open(&mut p, sid(0), 7);
+        open(&mut p, sid(4), 7);
+        open(&mut p, sid(8), 3);
 
         let pending = p.take();
         assert_eq!(pending[&sid(0)], 0);
@@ -219,9 +243,9 @@ mod tests {
     #[test]
     fn promotion_shifts_the_streams_it_passed() {
         let mut p = Priorities::default();
-        p.set(sid(0), 30);
-        p.set(sid(4), 20);
-        p.set(sid(8), 10);
+        open(&mut p, sid(0), 30);
+        open(&mut p, sid(4), 20);
+        open(&mut p, sid(8), 10);
         let _ = p.take();
 
         p.set(sid(8), 40);
@@ -236,9 +260,9 @@ mod tests {
     #[test]
     fn removal_promotes_the_streams_below() {
         let mut p = Priorities::default();
-        p.set(sid(0), 30);
-        p.set(sid(4), 20);
-        p.set(sid(8), 10);
+        open(&mut p, sid(0), 30);
+        open(&mut p, sid(4), 20);
+        open(&mut p, sid(8), 10);
         let _ = p.take();
 
         p.remove(sid(0));
@@ -254,9 +278,9 @@ mod tests {
     #[test]
     fn removal_within_a_level_does_not_shift() {
         let mut p = Priorities::default();
-        p.set(sid(0), 30);
-        p.set(sid(4), 30);
-        p.set(sid(8), 10);
+        open(&mut p, sid(0), 30);
+        open(&mut p, sid(4), 30);
+        open(&mut p, sid(8), 10);
         let _ = p.take();
 
         p.remove(sid(0));
@@ -270,7 +294,7 @@ mod tests {
         let mut p = Priorities::default();
         // Descending send order, so stream N lands at rank N.
         for i in 0..(BANDS as u64 + 8) {
-            p.set(sid(i * 4), -(i as i32));
+            open(&mut p, sid(i * 4), -(i as i32));
         }
 
         let pending = p.take();
@@ -285,20 +309,59 @@ mod tests {
     fn overflow_streams_are_still_published() {
         let mut p = Priorities::default();
         for i in 0..BANDS as u64 {
-            p.set(sid(i * 4), -(i as i32));
+            open(&mut p, sid(i * 4), -(i as i32));
         }
         let _ = p.take();
 
         let late = sid((BANDS as u64 + 1) * 4);
-        p.set(late, i32::MIN);
+        open(&mut p, late, i32::MIN);
 
         assert_eq!(p.take()[&late], OVERFLOW);
+    }
+
+    /// A `SendStream` outlives the driver's record of it — a peer `STOP_SENDING`
+    /// retires the stream while the application still holds the handle. A
+    /// `set_priority` arriving then must not resurrect it: the level would never be
+    /// cleaned up (nothing is left to remove it), it would displace every live
+    /// stream below it, and its urgency update could never be applied.
+    #[test]
+    fn updates_to_a_retired_stream_are_ignored() {
+        let mut p = Priorities::default();
+        open(&mut p, sid(0), 30);
+        open(&mut p, sid(4), 20);
+        let _ = p.take();
+
+        p.remove(sid(0));
+        let _ = p.take();
+
+        p.set(sid(0), i32::MAX);
+
+        assert!(p.take().is_empty(), "a retired stream must not queue an update");
+        assert_eq!(p.order(sid(0)), None, "a retired stream must stay unregistered");
+        assert_eq!(
+            p.urgency(sid(4)),
+            Some(0),
+            "the live stream must keep the band the retirement promoted it to"
+        );
+    }
+
+    /// The same, for a stream that was never registered at all.
+    #[test]
+    fn updates_to_an_unknown_stream_are_ignored() {
+        let mut p = Priorities::default();
+        open(&mut p, sid(0), 30);
+        let _ = p.take();
+
+        p.set(sid(99), i32::MAX);
+
+        assert!(p.take().is_empty());
+        assert_eq!(p.urgency(sid(0)), Some(0));
     }
 
     #[test]
     fn setting_the_same_order_twice_is_a_noop() {
         let mut p = Priorities::default();
-        p.set(sid(0), 5);
+        open(&mut p, sid(0), 5);
         let _ = p.take();
 
         p.set(sid(0), 5);

--- a/rs/web-transport-quiche/src/ez/priority.rs
+++ b/rs/web-transport-quiche/src/ez/priority.rs
@@ -1,0 +1,294 @@
+//! Connection-wide mapping from the transport's `i32` send order onto quiche's
+//! 8-bit stream urgency.
+//!
+//! The application hands us an `i32` where *higher* is sent first, so callers can
+//! bit-pack a composite ordering into one value. quiche instead schedules by
+//! `urgency`, a `u8` where *lower* is sent first, so the range has to be
+//! compressed. Rather than rescale (which would collapse nearby values that the
+//! caller went out of its way to distinguish), the streams are ranked: the
+//! highest-priority level gets urgency 0, the next 1, and so on. Everything past
+//! [`BANDS`] shares the last urgency, so the top 256 levels are ordered exactly
+//! and the tail is left to round-robin among itself.
+//!
+//! Streams that share a send order share a level, and so share an urgency —
+//! quiche then round-robins between them (`incremental`), matching what quinn and
+//! qmux do with equal priorities.
+//!
+//! Ranks are relative, so one stream moving can shift every stream below it. The
+//! updates are collected here and applied by the driver, which is the only place
+//! holding a `quiche::Connection`.
+
+use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
+
+use super::StreamId;
+
+/// How many distinct priority levels quiche can express.
+const BANDS: usize = u8::MAX as usize + 1;
+
+/// The last urgency, shared by every level past the top [`BANDS`].
+const OVERFLOW: u8 = (BANDS - 1) as u8;
+
+/// The streams sharing one send order, plus the urgency last published for them.
+struct Level {
+    band: u8,
+    streams: HashSet<StreamId>,
+}
+
+/// Ranks every send stream on a connection, emitting the quiche urgency updates
+/// that ranking implies.
+#[derive(Default)]
+pub(super) struct Priorities {
+    /// Levels keyed by send order, so iterating in reverse walks them from the
+    /// highest priority down.
+    levels: BTreeMap<i32, Level>,
+
+    /// The send order each registered stream currently sits at.
+    streams: HashMap<StreamId, i32>,
+
+    /// Urgency changes the driver has yet to hand to quiche.
+    pending: HashMap<StreamId, u8>,
+}
+
+impl Priorities {
+    /// Register a new send stream at the default send order.
+    ///
+    /// Every send stream is registered, not just the ones the application
+    /// prioritizes: an unranked stream would keep quiche's own default urgency and
+    /// so could outrank a stream that explicitly asked to go last.
+    pub fn insert(&mut self, id: StreamId) {
+        self.set(id, 0);
+    }
+
+    /// Change a stream's send order, where higher values are sent first.
+    pub fn set(&mut self, id: StreamId, order: i32) {
+        if self.streams.get(&id) == Some(&order) {
+            return;
+        }
+
+        // A level appearing or disappearing shifts every level below it.
+        let mut shifted = match self.streams.insert(id, order) {
+            Some(previous) => self.detach(id, previous),
+            None => false,
+        };
+
+        match self.levels.entry(order) {
+            btree_map::Entry::Occupied(mut entry) => {
+                let level = entry.get_mut();
+                level.streams.insert(id);
+
+                // The level itself hasn't moved, so only this stream needs telling.
+                self.pending.insert(id, level.band);
+            }
+            btree_map::Entry::Vacant(entry) => {
+                // Seed at the tail band and publish it: `rebalance` corrects the
+                // level if it lands higher, but it is also allowed to stop before
+                // reaching a level that genuinely belongs down here.
+                entry.insert(Level {
+                    band: OVERFLOW,
+                    streams: HashSet::from([id]),
+                });
+                self.pending.insert(id, OVERFLOW);
+                shifted = true;
+            }
+        }
+
+        if shifted {
+            self.rebalance();
+        }
+    }
+
+    /// Drop a stream that has closed, promoting whatever it was holding back.
+    pub fn remove(&mut self, id: StreamId) {
+        let Some(order) = self.streams.remove(&id) else {
+            return;
+        };
+
+        // The stream is gone; an urgency update for it would only resurrect state.
+        self.pending.remove(&id);
+
+        if self.detach(id, order) {
+            self.rebalance();
+        }
+    }
+
+    /// Take the urgency updates accumulated so far, to be applied to quiche.
+    pub fn take(&mut self) -> HashMap<StreamId, u8> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// Requeue updates the driver couldn't apply yet, for the next attempt.
+    ///
+    /// A stream registers here as soon as it is opened, but quiche only learns of
+    /// it on the driver's next pass, so an urgency can be ready before there is
+    /// anything to apply it to. Anything queued since the [`take`](Self::take) is
+    /// newer and wins.
+    pub fn defer(&mut self, updates: impl IntoIterator<Item = (StreamId, u8)>) {
+        for (id, urgency) in updates {
+            self.pending.entry(id).or_insert(urgency);
+        }
+    }
+
+    /// Remove `id` from the level at `order`, reporting whether the level itself
+    /// went away.
+    fn detach(&mut self, id: StreamId, order: i32) -> bool {
+        let btree_map::Entry::Occupied(mut entry) = self.levels.entry(order) else {
+            return false;
+        };
+
+        entry.get_mut().streams.remove(&id);
+        if entry.get().streams.is_empty() {
+            entry.remove();
+            return true;
+        }
+
+        false
+    }
+
+    /// Re-rank the levels, queueing an update for every stream whose urgency moved.
+    fn rebalance(&mut self) {
+        for (index, level) in self.levels.values_mut().rev().enumerate() {
+            let band = index.min(OVERFLOW as usize) as u8;
+
+            if level.band == band {
+                // Every rebalance leaves each level's band correct, and bands only
+                // grow going down, so an unchanged level already in the overflow
+                // band means everything below it is there too.
+                if band == OVERFLOW {
+                    break;
+                }
+                continue;
+            }
+
+            level.band = band;
+            for &id in &level.streams {
+                self.pending.insert(id, band);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sid(id: u64) -> StreamId {
+        StreamId::from(id)
+    }
+
+    #[test]
+    fn ranks_by_descending_send_order() {
+        let mut p = Priorities::default();
+        p.insert(sid(0));
+        p.set(sid(4), 100);
+        p.set(sid(8), 50);
+
+        let pending = p.take();
+        assert_eq!(pending[&sid(4)], 0);
+        assert_eq!(pending[&sid(8)], 1);
+        assert_eq!(pending[&sid(0)], 2);
+    }
+
+    #[test]
+    fn equal_send_orders_share_a_band() {
+        let mut p = Priorities::default();
+        p.set(sid(0), 7);
+        p.set(sid(4), 7);
+        p.set(sid(8), 3);
+
+        let pending = p.take();
+        assert_eq!(pending[&sid(0)], 0);
+        assert_eq!(pending[&sid(4)], 0);
+        assert_eq!(pending[&sid(8)], 1);
+    }
+
+    /// A promotion has to push everything it jumped over down a band, or the
+    /// promoted stream would merely tie with them.
+    #[test]
+    fn promotion_shifts_the_streams_it_passed() {
+        let mut p = Priorities::default();
+        p.set(sid(0), 30);
+        p.set(sid(4), 20);
+        p.set(sid(8), 10);
+        let _ = p.take();
+
+        p.set(sid(8), 40);
+
+        let pending = p.take();
+        assert_eq!(pending[&sid(8)], 0);
+        assert_eq!(pending[&sid(0)], 1);
+        assert_eq!(pending[&sid(4)], 2);
+    }
+
+    /// Closing a stream frees its band, so the streams below it move up.
+    #[test]
+    fn removal_promotes_the_streams_below() {
+        let mut p = Priorities::default();
+        p.set(sid(0), 30);
+        p.set(sid(4), 20);
+        p.set(sid(8), 10);
+        let _ = p.take();
+
+        p.remove(sid(0));
+
+        let pending = p.take();
+        assert!(!pending.contains_key(&sid(0)));
+        assert_eq!(pending[&sid(4)], 0);
+        assert_eq!(pending[&sid(8)], 1);
+    }
+
+    /// Losing one of several streams at the same send order doesn't move anything:
+    /// the level is still occupied.
+    #[test]
+    fn removal_within_a_level_does_not_shift() {
+        let mut p = Priorities::default();
+        p.set(sid(0), 30);
+        p.set(sid(4), 30);
+        p.set(sid(8), 10);
+        let _ = p.take();
+
+        p.remove(sid(0));
+
+        assert!(p.take().is_empty());
+    }
+
+    /// Only the top [`BANDS`] levels are ordered; the rest tie at the last band.
+    #[test]
+    fn levels_past_the_last_band_share_it() {
+        let mut p = Priorities::default();
+        // Descending send order, so stream N lands at rank N.
+        for i in 0..(BANDS as u64 + 8) {
+            p.set(sid(i * 4), -(i as i32));
+        }
+
+        let pending = p.take();
+        assert_eq!(pending[&sid(0)], 0);
+        assert_eq!(pending[&sid((BANDS as u64 - 1) * 4)], OVERFLOW);
+        assert_eq!(pending[&sid((BANDS as u64 + 7) * 4)], OVERFLOW);
+    }
+
+    /// A stream that arrives already in the overflow band still needs an update:
+    /// quiche's own default urgency sits in the middle of the range, not at the end.
+    #[test]
+    fn overflow_streams_are_still_published() {
+        let mut p = Priorities::default();
+        for i in 0..BANDS as u64 {
+            p.set(sid(i * 4), -(i as i32));
+        }
+        let _ = p.take();
+
+        let late = sid((BANDS as u64 + 1) * 4);
+        p.set(late, i32::MIN);
+
+        assert_eq!(p.take()[&late], OVERFLOW);
+    }
+
+    #[test]
+    fn setting_the_same_order_twice_is_a_noop() {
+        let mut p = Priorities::default();
+        p.set(sid(0), 5);
+        let _ = p.take();
+
+        p.set(sid(0), 5);
+        assert!(p.take().is_empty());
+    }
+}

--- a/rs/web-transport-quiche/src/ez/priority.rs
+++ b/rs/web-transport-quiche/src/ez/priority.rs
@@ -336,8 +336,15 @@ mod tests {
 
         p.set(sid(0), i32::MAX);
 
-        assert!(p.take().is_empty(), "a retired stream must not queue an update");
-        assert_eq!(p.order(sid(0)), None, "a retired stream must stay unregistered");
+        assert!(
+            p.take().is_empty(),
+            "a retired stream must not queue an update"
+        );
+        assert_eq!(
+            p.order(sid(0)),
+            None,
+            "a retired stream must stay unregistered"
+        );
         assert_eq!(
             p.urgency(sid(4)),
             Some(0),

--- a/rs/web-transport-quiche/src/ez/send.rs
+++ b/rs/web-transport-quiche/src/ez/send.rs
@@ -41,9 +41,6 @@ pub(super) struct SendState {
     // received
     stop: Option<u64>,
 
-    // received SET_PRIORITY
-    priority: Option<u8>,
-
     // No more progress can be made on the stream.
     closed: bool,
 }
@@ -58,7 +55,6 @@ impl SendState {
             fin: false,
             reset: None,
             stop: None,
-            priority: None,
             closed: false,
         }
     }
@@ -143,11 +139,6 @@ impl SendState {
 
         if self.stop.take().is_some() {
             return Ok(self.blocked.take());
-        }
-
-        if let Some(priority) = self.priority.take() {
-            tracing::trace!(stream_id = ?self.id, priority, "updating STREAM");
-            qconn.stream_priority(self.id.into(), priority, true)?;
         }
 
         while let Some(mut chunk) = self.queued.pop_front() {
@@ -408,11 +399,15 @@ impl SendStream {
 
     /// Set the priority of this stream.
     ///
-    /// Lower priority values are sent first. Defaults to 0.
-    pub fn set_priority(&mut self, priority: u8) {
-        self.state.lock().priority = Some(priority);
-
-        let waker = self.driver.lock().send(self.id);
+    /// Streams with **higher** values are sent first, but are not guaranteed to
+    /// arrive first. Defaults to 0.
+    ///
+    /// quiche schedules by an 8-bit urgency, so the `i32` is a *relative* order
+    /// rather than a value quiche sees: the connection ranks its send streams and
+    /// gives the 256 highest-priority levels an urgency each. Streams past that
+    /// share the last one, as do streams with equal priority (which round-robin).
+    pub fn set_priority(&mut self, order: i32) {
+        let waker = self.driver.lock().set_priority(self.id, order);
         if let Some(waker) = waker {
             waker.wake();
         }

--- a/rs/web-transport-quiche/src/send.rs
+++ b/rs/web-transport-quiche/src/send.rs
@@ -63,8 +63,10 @@ impl SendStream {
 
     /// Set the priority of this stream.
     ///
-    /// Lower priority values are sent first. Defaults to 0.
-    pub fn set_priority(&mut self, order: u8) {
+    /// Streams with **higher** values are sent first, but are not guaranteed to
+    /// arrive first. Defaults to 0. See [`ez::SendStream::set_priority`] for how the
+    /// `i32` is mapped onto quiche's 8-bit stream urgency.
+    pub fn set_priority(&mut self, order: i32) {
         self.inner.set_priority(order)
     }
 
@@ -123,7 +125,7 @@ impl web_transport_trait::SendStream for SendStream {
         self.write(buf).await
     }
 
-    fn set_priority(&mut self, order: u8) {
+    fn set_priority(&mut self, order: i32) {
         self.set_priority(order)
     }
 
@@ -161,7 +163,7 @@ impl web_transport_trait::poll::SendStream for SendStream {
             .map_err(Into::into)
     }
 
-    fn set_priority(&mut self, order: u8) {
+    fn set_priority(&mut self, order: i32) {
         self.set_priority(order)
     }
 

--- a/rs/web-transport-quiche/tests/priority.rs
+++ b/rs/web-transport-quiche/tests/priority.rs
@@ -1,0 +1,167 @@
+//! Per-stream send prioritization.
+//!
+//! The application sets an `i32` send order where higher is sent first, but quiche
+//! schedules by an 8-bit urgency where *lower* is sent first. The connection
+//! bridges the two by ranking its send streams, so this drives that ranking over a
+//! real connection rather than the unit tests' in-memory bookkeeping: the streams
+//! that finish first must be the ones that asked to.
+
+use std::net::{Ipv4Addr, SocketAddr};
+
+use anyhow::{Context, Result};
+use rcgen::{CertifiedKey, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::sync::mpsc;
+use url::Url;
+use web_transport_quiche::{ClientBuilder, ServerBuilder, Settings};
+
+/// Enough streams that the scheduler has real choices to make, few enough that
+/// the whole payload fits inside the default connection flow-control window.
+const STREAMS: usize = 32;
+
+/// Big enough that a stream can't be drained in a single congestion window, so
+/// the scheduler has to keep choosing between them.
+const PAYLOAD: usize = 256 * 1024;
+
+/// How many completions to inspect, and the band they must fall in. Strict
+/// urgency ordering makes these exactly the top four; the slack absorbs
+/// scheduling noise while staying far out of reach of an unprioritized run.
+const CHECKED: usize = 4;
+const TOP: usize = 8;
+
+fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+    let CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()])
+            .context("rcgen self-signed")?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_bytes = KeyPair::serialize_der(&signing_key);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert_der], key_der))
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+}
+
+/// Each stream carries one repeated byte so the reader can name it without
+/// depending on the order the streams arrive in.
+fn tag(stream: usize) -> u8 {
+    stream as u8
+}
+
+/// Accept `STREAMS` unidirectional streams, reading each to EOF and reporting its
+/// tag in *completion* order.
+async fn spawn_server() -> Result<(SocketAddr, mpsc::UnboundedReceiver<u8>)> {
+    let (chain, key) = make_self_signed()?;
+
+    let bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let mut server = ServerBuilder::default()
+        .with_bind(bind)?
+        .with_single_cert(chain, key)?;
+
+    let addr = *server
+        .local_addrs()
+        .first()
+        .context("server has no local address")?;
+
+    let (done, finished) = mpsc::unbounded_channel();
+
+    tokio::spawn(async move {
+        let request = server.accept().await.context("server accept")?;
+        let session = request.ok().await.context("server session")?;
+
+        for _ in 0..STREAMS {
+            let mut recv = session.accept_uni().await.context("accept uni")?;
+            let done = done.clone();
+
+            tokio::spawn(async move {
+                let mut tag = None;
+                let mut read = 0;
+                let mut buf = [0u8; 8 * 1024];
+
+                while let Some(n) = recv.read(&mut buf).await? {
+                    if n == 0 {
+                        break;
+                    }
+                    tag.get_or_insert(buf[0]);
+                    read += n;
+                }
+
+                assert_eq!(read, PAYLOAD, "stream {tag:?} truncated");
+                let _ = done.send(tag.context("stream carried no data")?);
+
+                anyhow::Ok(())
+            });
+        }
+
+        anyhow::Ok(())
+    });
+
+    Ok((addr, finished))
+}
+
+/// Streams that asked to go first do, even though quiche only has 256 urgencies
+/// to spend and the send order is an `i32`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn higher_priority_finishes_first() -> Result<()> {
+    init_tracing();
+
+    let (addr, mut finished) = spawn_server().await?;
+
+    let mut settings = Settings::default();
+    settings.verify_peer = false;
+
+    let session = ClientBuilder::default()
+        .with_settings(settings)
+        .with_bind((Ipv4Addr::LOCALHOST, 0))?
+        .connect(Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))?)
+        .await?
+        .established()
+        .await
+        .context("client handshake")?;
+
+    // Open every stream and queue its payload before any of them can drain, so the
+    // scheduler is choosing between all of them rather than servicing whichever
+    // happened to be ready. The send orders are spread far apart to make the point
+    // that they are ranked, not truncated to a `u8`.
+    let mut writers = Vec::with_capacity(STREAMS);
+    for stream in 0..STREAMS {
+        let mut send = session.open_uni().await.context("open uni")?;
+        send.set_priority((STREAMS - stream) as i32 * 1_000_000);
+
+        writers.push(tokio::spawn(async move {
+            send.write_all(&vec![tag(stream); PAYLOAD]).await?;
+            send.finish()?;
+            send.closed().await?;
+            anyhow::Ok(())
+        }));
+    }
+
+    let mut order = Vec::with_capacity(CHECKED);
+    for _ in 0..CHECKED {
+        order.push(finished.recv().await.context("stream never completed")?);
+    }
+
+    for writer in writers {
+        writer.await??;
+    }
+
+    for tag in &order {
+        assert!(
+            (*tag as usize) < TOP,
+            "stream {tag} finished in the first {CHECKED} despite ranking below the top {TOP}: {order:?}"
+        );
+    }
+
+    session.close(0, "bye");
+    session.closed().await;
+    Ok(())
+}

--- a/rs/web-transport-quiche/tests/priority.rs
+++ b/rs/web-transport-quiche/tests/priority.rs
@@ -19,13 +19,12 @@ use web_transport_quiche::{ClientBuilder, ServerBuilder, Settings};
 /// Enough streams that the scheduler has real choices to make.
 const STREAMS: usize = 32;
 
-/// Payload per stream. The total dwarfs [`WINDOW`], so the sender is choosing
-/// between backlogged streams for essentially the whole test.
-const PAYLOAD: usize = 256 * 1024;
-
-/// Payload total stays under the default connection flow-control window (10MB) on
+/// Payload per stream.
+///
+/// The total stays under the default connection flow-control window (10MB) on
 /// purpose: every stream can then buffer in full, so transmission order is quiche's
 /// scheduling decision rather than a race for scarce send credit.
+const PAYLOAD: usize = 256 * 1024;
 
 /// The streams are split into two tiers of equal size, and the first [`CHECKED`]
 /// completions must all come from the urgent one.

--- a/rs/web-transport-quinn/src/send.rs
+++ b/rs/web-transport-quinn/src/send.rs
@@ -157,8 +157,8 @@ impl tokio::io::AsyncWrite for SendStream {
 impl web_transport_trait::SendStream for SendStream {
     type Error = WriteError;
 
-    fn set_priority(&mut self, order: u8) {
-        Self::set_priority(self, order.into()).ok();
+    fn set_priority(&mut self, order: i32) {
+        Self::set_priority(self, order).ok();
     }
 
     fn reset(&mut self, code: u32) {
@@ -214,8 +214,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
     // faster but loses data: the chunk would be gone from `buf` before Quinn
     // accepted it, a silent hole in the stream if the write does not complete.
 
-    fn set_priority(&mut self, order: u8) {
-        Self::set_priority(self, order.into()).ok();
+    fn set_priority(&mut self, order: i32) {
+        Self::set_priority(self, order).ok();
     }
 
     fn reset(&mut self, code: u32) {

--- a/rs/web-transport-trait/src/lib.rs
+++ b/rs/web-transport-trait/src/lib.rs
@@ -222,7 +222,12 @@ pub trait SendStream: MaybeSend {
     ///
     /// Streams with higher values will be sent first, but are not guaranteed to arrive first.
     /// This matches the W3C WebTransport `sendOrder` convention (and quinn's scheduler).
-    fn set_priority(&mut self, order: u8);
+    ///
+    /// The full `i32` range is available so callers can bit-pack a composite ordering
+    /// (for example a track priority in the high bits and a sequence number in the low
+    /// bits) into a single value. Backends that cannot express that many distinct
+    /// levels approximate it, so treat the ordering as best-effort.
+    fn set_priority(&mut self, order: i32);
 
     /// Mark the stream as finished, erroring on any future writes.
     ///

--- a/rs/web-transport-trait/src/poll.rs
+++ b/rs/web-transport-trait/src/poll.rs
@@ -199,7 +199,12 @@ pub trait SendStream {
     /// Streams with higher values will be sent first, but are not guaranteed to
     /// arrive first. This matches the W3C WebTransport `sendOrder` convention (and
     /// quinn's scheduler).
-    fn set_priority(&mut self, order: u8);
+    ///
+    /// The full `i32` range is available so callers can bit-pack a composite ordering
+    /// (for example a track priority in the high bits and a sequence number in the low
+    /// bits) into a single value. Backends that cannot express that many distinct
+    /// levels approximate it, so treat the ordering as best-effort.
+    fn set_priority(&mut self, order: i32);
 
     /// Mark the stream as finished, erroring on any future writes.
     ///

--- a/rs/web-transport-trait/tests/defaults.rs
+++ b/rs/web-transport-trait/tests/defaults.rs
@@ -70,7 +70,7 @@ impl SendStream for DripSend {
         }
     }
 
-    fn set_priority(&mut self, _order: u8) {}
+    fn set_priority(&mut self, _order: i32) {}
 
     fn finish(&mut self) -> Result<(), TestError> {
         Ok(())

--- a/rs/web-transport-trait/tests/sans_io.rs
+++ b/rs/web-transport-trait/tests/sans_io.rs
@@ -103,7 +103,7 @@ impl Inbox {
 /// `!Send`: holds an [`Rc`].
 struct LocalSend {
     buf: Shared,
-    priority: u8,
+    priority: i32,
 }
 
 impl SendStream for LocalSend {
@@ -119,7 +119,7 @@ impl SendStream for LocalSend {
         Poll::Ready(Ok(buf.len()))
     }
 
-    fn set_priority(&mut self, order: u8) {
+    fn set_priority(&mut self, order: i32) {
         self.priority = order;
     }
 

--- a/rs/web-transport-wasm/src/traits.rs
+++ b/rs/web-transport-wasm/src/traits.rs
@@ -160,8 +160,8 @@ impl web_transport_trait::poll::SendStream for SendStream {
         SendStream::poll_write(self, cx, buf)
     }
 
-    fn set_priority(&mut self, order: u8) {
-        SendStream::set_priority(self, order.into())
+    fn set_priority(&mut self, order: i32) {
+        SendStream::set_priority(self, order)
     }
 
     fn finish(&mut self) -> Result<(), Error> {
@@ -184,8 +184,8 @@ impl web_transport_trait::SendStream for SendStream {
         poll_fn(|cx| SendStream::poll_write(self, cx, buf)).await
     }
 
-    fn set_priority(&mut self, order: u8) {
-        SendStream::set_priority(self, order.into())
+    fn set_priority(&mut self, order: i32) {
+        SendStream::set_priority(self, order)
     }
 
     fn finish(&mut self) -> Result<(), Error> {

--- a/rs/web-transport/src/quinn.rs
+++ b/rs/web-transport/src/quinn.rs
@@ -225,7 +225,7 @@ impl SendStream {
 
     /// Set the stream's priority.
     ///
-    /// Streams with lower values will be sent first, but are not guaranteed to arrive first.
+    /// Streams with higher values will be sent first, but are not guaranteed to arrive first.
     pub fn set_priority(&mut self, order: i32) {
         self.inner.set_priority(order).ok();
     }


### PR DESCRIPTION
## What

`web_transport_trait::SendStream::set_priority` (and the `poll` variant) now take an `i32` instead of a `u8`, matching quinn's own API and the W3C `sendOrder` convention (higher is sent first).

- **quinn / noq / iroh** drop the `order.into()` widening and pass the value straight through.
- **qmux**'s scheduler bands are keyed by `i32` rather than `u8`; nothing else about the scheduler changes.
- **quiche** gets a new connection-wide ranking, `ez::Priorities`, that maps the `i32` onto quiche's 8-bit stream urgency.

## Why

A `u8` forced callers with a composite ordering — a track priority in the high bits and a group sequence in the low bits, say — to either rescale or throw away resolution before handing it over. Quinn already takes an `i32`, so the trait was strictly narrower than the backend underneath it and the lossy conversion was happening in the wrong place. Widening it lets moq bit-pack its ordering into a single value.

## How quiche handles it

quiche schedules by `urgency`, a `u8` where *lower* is sent first, so it can't take the value directly. Modeled on `moq-net`'s `PriorityQueue`:

- Send streams are grouped into *levels* keyed by send order (`BTreeMap<i32, Level>`). Levels are ranked descending: the top 256 get an urgency each, and every level past that shares the last one.
- **Deviation from moq's design, worth a look:** moq ranks per *item*, which would give two equal-priority streams different urgencies and so a strict order between them. Here levels are per *distinct value*, so equal priorities share a band and quiche round-robins them (`incremental: true`) — matching what quinn and qmux do. For moq's bit-packed orders, which are effectively unique per stream, the two schemes are identical.
- `rebalance` walks levels from the top and stops at the first unchanged overflow band, so a priority change costs ~256 level visits rather than O(streams).
- The ranking lives in `DriverState` and the driver drains the urgency updates it produces, since the driver is the only holder of the quiche connection. Updates for streams quiche hasn't created yet are deferred rather than dropped.
- Every send stream registers at priority 0 when opened. Without that, a stream that never called `set_priority` would keep quiche's default urgency (127) and could outrank a stream that explicitly asked to go last.

## Incidental fix

`web-transport-quiche`'s trait impl previously passed the priority to quiche's urgency verbatim. Since quiche sends *lower* urgency first, a higher priority meant the stream was sent **later** — the opposite of what the trait documents. That is now correct.

## Breaking change

`set_priority(u8)` → `set_priority(i32)` on both `SendStream` traits, and on `web-transport-quiche`'s inherent `SendStream::set_priority` / `ez::SendStream::set_priority`. Existing `u8` call sites still compile if the literal fits; ones passing a `u8` *variable* need a cast. The `ez` method also flips meaning: it used to be raw quiche urgency (lower first), and is now send order (higher first).

## Testing

- Unit tests in `ez/priority.rs` cover descending ranking, equal-priority banding, promotion and removal shifts, the overflow band, and re-publishing a stream that lands in overflow.
- New `tests/priority.rs` drives 32 streams with spread-out send orders over a real connection and asserts the first completions come from the top-priority streams.

`cargo test -p web-transport-quiche -p web-transport-trait -p qmux` passes locally: 8 `ez::priority` unit tests and `higher_priority_finishes_first` both green, alongside the existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)

