### PR TITLE
Don't rank a quiche send half the peer already stopped

### DIFF
--- a/rs/web-transport-quiche/src/ez/driver.rs
+++ b/rs/web-transport-quiche/src/ez/driver.rs
@@ -299,7 +299,6 @@ impl DriverState {
         send: Lock<SendState>,
         recv: Lock<RecvState>,
     ) -> WaiterList {
-        self.priority.insert(id);
         self.accept_bi.push_back((id, send, recv));
         self.accept_bi_waiters.take()
     }
@@ -570,13 +569,24 @@ impl Driver {
         let mut state = SendState::new(stream_id);
         state.flush(qconn)?;
 
-        let state = Lock::new(state);
-        self.send.insert(stream_id, state.clone());
+        // The peer can stop the send half before we ever accept it, in which case
+        // that first flush already retired it. Tracking a stream nothing will flush
+        // again would strand it here for the life of the connection: `notify` skips
+        // a closed state and quiche won't report a collected stream writable. The
+        // application still gets the handle, which reports the stop on first use.
+        let live = !state.is_closed();
 
-        let mut waiters = self
-            .state
-            .lock()
-            .push_accept_bi(stream_id, state.clone(), recv_state);
+        let state = Lock::new(state);
+        if live {
+            self.send.insert(stream_id, state.clone());
+        }
+
+        let mut driver = self.state.lock();
+        if live {
+            driver.priority.insert(stream_id);
+        }
+        let mut waiters = driver.push_accept_bi(stream_id, state.clone(), recv_state);
+        drop(driver);
 
         waiters.wake();
 

--- a/rs/web-transport-quiche/src/ez/priority.rs
+++ b/rs/web-transport-quiche/src/ez/priority.rs
@@ -179,9 +179,11 @@ impl Priorities {
             let band = index.min(OVERFLOW as usize) as u8;
 
             if level.band == band {
-                // Every rebalance leaves each level's band correct, and bands only
-                // grow going down, so an unchanged level already in the overflow
-                // band means everything below it is there too.
+                // Every rebalance leaves each level's band correct and one call
+                // adds or drops at most one level, so a level can only shift by a
+                // single rank before the next rebalance. Reaching an unchanged
+                // overflow level therefore means every level below it was already
+                // at or past [`OVERFLOW`] beforehand, and is still there now.
                 if band == OVERFLOW {
                     break;
                 }
@@ -363,6 +365,90 @@ mod tests {
 
         assert!(p.take().is_empty());
         assert_eq!(p.urgency(sid(0)), Some(0));
+    }
+
+    /// The early exit in [`Priorities::rebalance`] is the one piece of the ranking
+    /// that isn't obviously safe: it stops at the first unchanged overflow level,
+    /// betting that everything below it is already there. Drive a long pseudorandom
+    /// sequence of opens, re-rankings and closes and check every level against a
+    /// from-scratch ranking after each step.
+    ///
+    /// The run has to spend most of its time *past* [`BANDS`] levels or the early
+    /// exit is never reached and this proves nothing, so it grows the live set well
+    /// beyond that and churns there. The `saw_overflow` assertion keeps it honest.
+    #[test]
+    fn rebalance_matches_a_full_ranking() {
+        // xorshift, so the sequence is fixed without pulling in a rng crate.
+        let mut seed = 0x2545_F491_4F6C_DD1Du64;
+        let mut rand = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+
+        // Enough distinct send orders that the live streams spread across more than
+        // [`BANDS`] levels rather than piling into a few.
+        let spread = 4 * BANDS as u64;
+        let target = 2 * BANDS;
+
+        let mut p = Priorities::default();
+        let mut live: Vec<StreamId> = Vec::new();
+        let mut saw_overflow = false;
+
+        for step in 0..10_000u64 {
+            let roll = rand() % 100;
+
+            // Open-heavy until the live set is past `target`, then balanced, so the
+            // run climbs over the overflow boundary and keeps crossing back and forth.
+            let open_odds = if live.len() < target { 70 } else { 34 };
+
+            if roll < open_odds || live.is_empty() {
+                let id = sid(step * 4);
+                p.insert(id);
+                if rand() % 2 == 0 {
+                    p.set(id, (rand() % spread) as i32 - spread as i32 / 2);
+                }
+                live.push(id);
+            } else if roll < open_odds + 15 {
+                let id = live[(rand() % live.len() as u64) as usize];
+                p.set(id, (rand() % spread) as i32 - spread as i32 / 2);
+            } else {
+                let id = live.swap_remove((rand() % live.len() as u64) as usize);
+                p.remove(id);
+            }
+
+            saw_overflow |= p.levels.len() > BANDS;
+
+            let expected: Vec<u8> = (0..p.levels.len())
+                .map(|i| i.min(OVERFLOW as usize) as u8)
+                .collect();
+            let actual: Vec<u8> = p.levels.values().rev().map(|l| l.band).collect();
+            assert_eq!(actual, expected, "bands diverged at step {step}");
+
+            // Nothing is left behind: every level is occupied and every stream is
+            // in the level its send order names.
+            for (order, level) in &p.levels {
+                assert!(!level.streams.is_empty(), "empty level at step {step}");
+                for id in &level.streams {
+                    assert_eq!(
+                        p.streams.get(id),
+                        Some(order),
+                        "stray stream at step {step}"
+                    );
+                }
+            }
+            assert_eq!(
+                p.streams.len(),
+                p.levels.values().map(|l| l.streams.len()).sum::<usize>(),
+                "stream count diverged at step {step}"
+            );
+        }
+
+        assert!(
+            saw_overflow,
+            "the run never exceeded {BANDS} levels, so the overflow early exit went untested"
+        );
     }
 
     #[test]

--- a/rs/web-transport-quiche/tests/priority.rs
+++ b/rs/web-transport-quiche/tests/priority.rs
@@ -8,6 +8,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rcgen::{CertifiedKey, KeyPair};
@@ -41,6 +42,14 @@ const CHECKED: usize = 8;
 /// Send order for the urgent tier — the upper half of the tags. Far from the other
 /// tier's 0 to show the value is ranked, not truncated to a `u8`.
 const URGENT: i32 = 1_000_000;
+
+/// Ceiling on the whole exchange.
+///
+/// Every await below is otherwise unbounded, so a stream that stalls would park
+/// `finished.recv()` or a writer join forever and the failure would surface as
+/// CI's job timeout rather than as this test. Generous enough that a loaded
+/// runner won't trip it: 8MB over loopback is well under a second.
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 fn make_self_signed() -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
     let CertifiedKey { cert, signing_key } =
@@ -130,6 +139,12 @@ async fn spawn_server() -> Result<(SocketAddr, mpsc::UnboundedReceiver<u8>)> {
 /// spend and the send order is an `i32`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn higher_priority_finishes_first() -> Result<()> {
+    tokio::time::timeout(TIMEOUT, run())
+        .await
+        .context("timed out waiting for the streams to complete")?
+}
+
+async fn run() -> Result<()> {
     init_tracing();
 
     let (addr, mut finished) = spawn_server().await?;


### PR DESCRIPTION
Follow-up to #390, narrowed. That PR's review turned up three lifecycle defects; this lands the one whose fix is unambiguous, plus test hardening. The ranking math in `ez::Priorities` is unchanged — it was correct.

## The fix

`accept_bi` registered the accepted send half unconditionally. If the peer sends STOP_SENDING before we accept, the first `SendState::flush` already comes back closed — and nothing will ever flush it again, since `notify` skips a closed state and quiche won't report a collected stream writable.

The stale entry in the driver's send map predates the ranking. What #390 added is that the stream also holds an **urgency band** for the life of the connection, so a peer repeating this can push live streams toward the overflow band and flatten their relative order.

Only live send halves are tracked now. The application still receives the handle and sees `Stop(code)` on first use (or `Closed` if quiche already discarded the code). `priority.insert` moves out of `push_accept_bi` into the driver, which is the half that knows whether the flush survived.

## Test hardening

- `tests/priority.rs` had no bounded await anywhere, so a stalled stream parked `finished.recv()` or a writer join until CI's job timeout instead of failing. Now bounded at 30s.
- `rebalance_matches_a_full_ranking` — 10k pseudorandom ranking operations checked against a from-scratch ranking after every step. The early exit in `rebalance` is the one part of the mapping that isn't locally obvious, and it only executes once the overflow band is occupied, so the run is weighted to climb past `BANDS` levels and `saw_overflow` asserts it actually got there.

## Deliberately not included

Two findings from the #390 review are **left open**, because the obvious fix for them turned out to be wrong:

1. **A stream loses its rank while quiche is still sending it.** `SendState` reports closed the moment its FIN reaches quiche, so the band is freed while quiche still has buffered bytes; the promotion that follows can lift a lower-priority stream level with data that outranks it.
2. **A `set_priority` immediately before `finish` is dropped**, since `Priorities::remove` clears the pending update.

The natural fix — hold the rank until `qconn.stream_capacity(id)` errors — is sound but **not complete**: quiche only drops a stream once `is_complete()`, which for a *bidirectional* stream requires both directions. A bidi stream whose send half is finished and acked keeps returning `Ok` while the peer's half stays open, so the rank would never be reaped. That is worse than the bug it fixes, and "finish your send, keep reading the response" is the normal bidi pattern. quiche 0.29 exposes no send-side drain predicate (`stream_closed` reports FIN *written*, `is_flushable` isn't on `Connection`), so this needs a different mechanism and belongs in its own change.

`cargo test -p web-transport-quiche` green; `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)